### PR TITLE
Make IndicatorInvoker a supported public breadth-harvest API

### DIFF
--- a/src/Builder/Evaluation/IndicatorInvoker.cs
+++ b/src/Builder/Evaluation/IndicatorInvoker.cs
@@ -5,16 +5,19 @@ using OoplesFinance.StockIndicators.Models;
 namespace OoplesFinance.StockIndicators.Builder;
 
 /// <summary>
-/// Invokes indicator calculations dynamically using reflection.
-/// Provides access to all 750+ indicators via IndicatorName.
+/// Invokes indicator calculations dynamically by <see cref="IndicatorName"/> and returns the FULL per-indicator
+/// breadth — every named intermediate series (<see cref="StockData.OutputValues"/>) plus the primary
+/// (<see cref="StockData.CustomValuesList"/>). This is the SUPPORTED breadth-harvest surface for ML feature
+/// engineering (thousands of candidate series across an Input × MovingAvgType × length grid).
 /// </summary>
 /// <remarks>
-/// V1 API - DEPRECATED. Use the V2 StatefulIndicatorFactory and source-generated factory methods instead.
-/// This reflection-based approach is slower and will be removed in the next major version.
-/// V2 provides compile-time type safety and better performance through source generation.
+/// NOT deprecated. For typed, single-output use of one indicator, prefer the source-generated V2
+/// <c>StatefulIndicatorFactory</c> (compile-time safety, faster). This reflection-based invoker is the
+/// intentional path when you need the full multi-series breadth that the single-output V2 factory collapses
+/// away — e.g. the feature-universe harvester. It is the one supported reason the full-output Calculate
+/// surface is retained, so callers never need to touch the deprecated direct <c>Calculate*</c> extension methods.
 /// </remarks>
-[Obsolete("V1 API - use StatefulIndicatorFactory.Create() instead. Will be removed in next major version.", error: false)]
-internal static class IndicatorInvoker
+public static class IndicatorInvoker
 {
     private static readonly Dictionary<IndicatorName, MethodInfo> MethodCache = new();
     private static readonly object CacheLock = new();


### PR DESCRIPTION
Exposes the full per-indicator breadth (OutputValues + CustomValuesList) the v2 single-output factory collapses away — the surface ML feature-universe harvesting needs. `IndicatorInvoker` becomes public + non-obsolete (reflection-based, so it never compile-time-calls the deprecated `Calculate*` extensions — no CS0618). Lets consumers drop all `#pragma warning disable CS0618` workarounds. Typed single-indicator use still prefers the v2 `StatefulIndicatorFactory`.