### PR TITLE
fix: unblock ci, restore net461, add net8.0, and fix signal pattern and volume index defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup .NET 10
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 10.x
+          dotnet-version: |
+            8.x
+            10.x
 
       - name: Restore dependencies
         run: dotnet restore src/OoplesFinance.StockIndicators.csproj
 
       - name: Build for .NET 10
         run: dotnet build src/OoplesFinance.StockIndicators.csproj --no-restore --configuration Release --framework net10.0
+
+      - name: Build for .NET 8
+        run: dotnet build src/OoplesFinance.StockIndicators.csproj --no-restore --configuration Release --framework net8.0
 
       - name: Build for .NET Framework 4.6.1
         run: dotnet build src/OoplesFinance.StockIndicators.csproj --no-restore --configuration Release --framework net461

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # dotnet build/test below run repository-controlled MSBuild inputs; the checkout token
+          # has no reader after this step, so it should not be left in .git/config.
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        # The build below compiles repository-controlled MSBuild inputs. Leaving the checkout
+        # token in .git/config makes it reachable from any of that, and nothing after this step
+        # performs a git operation, so there is nothing to persist it for.
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.x
+          10.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,22 +62,20 @@ jobs:
         # queries: security-extended,security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+    # Autobuild is not usable here. It walks the whole repository, which includes
+    # benchmarks/OoplesFinance.StockIndicators.Benchmarks. That project pulls in
+    # OoplesFinance.StockIndicators.Original.dll through an "Original" extern alias, via a
+    # HintPath into benchmarks/.baseline - a gitignored local worktree that does not exist
+    # on a runner. Autobuild therefore fails with
+    #   CS0430: The extern alias 'Original' was not specified in a /reference option
+    # then gives up with "Could not auto-detect a suitable build method", and the analysis
+    # step is skipped - so no code scanning has actually been running on this repository.
+    #
+    # Building the library explicitly analyses the code we ship and skips the benchmarks.
+    - name: Build for analysis
+      run: dotnet build src/OoplesFinance.StockIndicators.csproj --configuration Release --framework net10.0
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,11 @@ FodyWeavers.xsd
 
 #Ignore vscode AI rules
 .github\instructions\codacy.instructions.md
+
+# Local settings with real credentials - never commit these
+appsettings.local.json
+appsettings.*.local.json
+secrets.json
+.env
+.env.local
+.env.*.local

--- a/src/Builder/Notifications/NotificationTypes.cs
+++ b/src/Builder/Notifications/NotificationTypes.cs
@@ -1,4 +1,4 @@
-namespace OoplesFinance.StockIndicators.Builder.Notifications;
+﻿namespace OoplesFinance.StockIndicators.Builder.Notifications;
 
 /// <summary>
 /// Interface for notification channels.
@@ -747,33 +747,7 @@ public sealed class NotificationRoute
         }
 
         // Match by pattern
-        if (SignalPattern is string patternToMatch && patternToMatch.Length > 0)
-        {
-            if (patternToMatch == "*")
-            {
-                return true;
-            }
-
-            // Simple wildcard matching
-            if (patternToMatch.Contains("*"))
-            {
-                if (string.IsNullOrEmpty(notification.Name))
-                {
-                    return false;
-                }
-
-                var regexPattern = patternToMatch.Replace("*", ".*");
-                return System.Text.RegularExpressions.Regex.IsMatch(
-                    notification.Name,
-                    $"^{regexPattern}$",
-                    System.Text.RegularExpressions.RegexOptions.IgnoreCase,
-                    TimeSpan.FromSeconds(1));
-            }
-
-            return string.Equals(notification.Name, patternToMatch, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return false;
+        return SignalPatternMatcher.IsMatch(SignalPattern, notification.Name);
     }
 }
 

--- a/src/Builder/Trading/TradingTypes.cs
+++ b/src/Builder/Trading/TradingTypes.cs
@@ -1,4 +1,4 @@
-using OoplesFinance.StockIndicators.Builder.Catalogs;
+﻿using OoplesFinance.StockIndicators.Builder.Catalogs;
 
 namespace OoplesFinance.StockIndicators.Builder.Trading;
 
@@ -975,26 +975,8 @@ public sealed class ExtendedAutoTradeRule
     /// <summary>
     /// Checks if this rule matches a notification by name.
     /// </summary>
-    public bool Matches(string signalName)
-    {
-        if (string.IsNullOrEmpty(SignalPattern))
-        {
-            return false;
-        }
-
-        if (SignalPattern == "*")
-        {
-            return true;
-        }
-
-        if (SignalPattern.EndsWith("*"))
-        {
-            var prefix = SignalPattern.Substring(0, SignalPattern.Length - 1);
-            return signalName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return string.Equals(SignalPattern, signalName, StringComparison.OrdinalIgnoreCase);
-    }
+    public bool Matches(string signalName) =>
+        SignalPatternMatcher.IsMatch(SignalPattern, signalName);
 }
 
 /// <summary>

--- a/src/Calculations/PriceChannel/PriceChannelEtoK.cs
+++ b/src/Calculations/PriceChannel/PriceChannelEtoK.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace OoplesFinance.StockIndicators;
 
 public static partial class Calculations
@@ -747,7 +747,8 @@ public static partial class Calculations
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateKeltnerChannels(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 20, int length2 = 10, double multFactor = 2)
+        int length1 = 20, int length2 = 10, double multFactor = 2,
+        MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
     {
         List<double> upperChannelList = new(stockData.Count);
         List<double> lowerChannelList = new(stockData.Count);
@@ -755,8 +756,16 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
+        // ORDER MATTERS. GetMovingAverageList writes its result into stockData.CustomValuesList, and the
+        // true-range helper treats a non-empty CustomValuesList as the close series. Computing the average
+        // first therefore made the ATR measure the distance from each bar's high and low to the PREVIOUS
+        // MOVING AVERAGE rather than to the previous close - on AAPL that inflated ATR(10) from 3.9553 to
+        // 9.7261 and pushed the upper band from 143.74 to 155.28. The ATR is computed here, before any
+        // moving average touches stockData.
+        var atrList = CalculateAverageTrueRange(stockData, atrMaType, length2).CustomValuesList;
+        stockData.SetCustomValues(new List<double>());
+
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length2).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/TrailingStop/TrailingStopLtoR.cs
+++ b/src/Calculations/TrailingStop/TrailingStopLtoR.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace OoplesFinance.StockIndicators;
 
 public static partial class Calculations
@@ -347,6 +347,110 @@ public static partial class Calculations
         stockData.SetSignals(signalsList);
         stockData.SetCustomValues(tsList);
         stockData.IndicatorName = IndicatorName.MotionToAttractionTrailingStop;
+
+        return stockData;
+    }
+
+
+    /// <summary>
+    /// Calculates the UT Bot Alerts indicator, the ATR trailing stop published as the
+    /// "UT Bot Alerts" TradingView script.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The stop trails price by <paramref name="keyValue"/> multiples of ATR. While price stays on the
+    /// same side of the stop the level only ever moves in the favourable direction - it ratchets up in an
+    /// uptrend and down in a downtrend, and never gives ground - which is what makes it a stop rather than
+    /// a band. When price closes through it, the stop flips to the other side and the position marker
+    /// reverses.
+    /// </para>
+    /// <para>
+    /// Buy and Sell mark the bars where that flip happens; Position holds 1 while long and -1 while short,
+    /// so it can be read directly as a regime filter between flips.
+    /// </para>
+    /// </remarks>
+    /// <param name="stockData">The stock data.</param>
+    /// <param name="maType">Moving average used to smooth the true range. Wilder's is the ATR standard.</param>
+    /// <param name="length">ATR period.</param>
+    /// <param name="keyValue">ATR multiple the stop trails by.</param>
+    /// <returns></returns>
+    [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
+    public static StockData CalculateUtBotAlerts(this StockData stockData,
+        MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 10, double keyValue = 1)
+    {
+        List<double> trailingStopList = new(stockData.Count);
+        List<double> positionList = new(stockData.Count);
+        List<double> buyList = new(stockData.Count);
+        List<double> sellList = new(stockData.Count);
+        List<Signal>? signalsList = CreateSignalsList(stockData);
+        var (inputList, _, _, _, _) = GetInputValuesList(stockData);
+
+        // Taken before any moving average runs against stockData: GetMovingAverageList writes into
+        // CustomValuesList, which the true-range helper would then read as the close series.
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        stockData.SetCustomValues(new List<double>());
+
+        for (var i = 0; i < stockData.Count; i++)
+        {
+            var currentValue = inputList[i];
+            var prevValue = i >= 1 ? inputList[i - 1] : currentValue;
+            var nLoss = keyValue * atrList[i];
+            var prevStop = i >= 1 ? trailingStopList[i - 1] : 0;
+
+            double trailingStop;
+            if (currentValue > prevStop && prevValue > prevStop)
+            {
+                // Still above the stop: raise it, never lower it.
+                trailingStop = Math.Max(prevStop, currentValue - nLoss);
+            }
+            else if (currentValue < prevStop && prevValue < prevStop)
+            {
+                // Still below the stop: lower it, never raise it.
+                trailingStop = Math.Min(prevStop, currentValue + nLoss);
+            }
+            else
+            {
+                // Price crossed the stop, so it flips to the other side of price.
+                trailingStop = currentValue > prevStop ? currentValue - nLoss : currentValue + nLoss;
+            }
+
+            trailingStopList.Add(trailingStop);
+
+            var prevPosition = i >= 1 ? positionList[i - 1] : 0;
+            double position;
+            if (prevValue < prevStop && currentValue > prevStop)
+            {
+                position = 1;
+            }
+            else if (prevValue > prevStop && currentValue < prevStop)
+            {
+                position = -1;
+            }
+            else
+            {
+                position = prevPosition;
+            }
+
+            positionList.Add(position);
+
+            var crossedAbove = prevValue <= prevStop && currentValue > trailingStop;
+            var crossedBelow = prevValue >= prevStop && currentValue < trailingStop;
+            buyList.Add(i >= 1 && crossedAbove ? 1 : 0);
+            sellList.Add(i >= 1 && crossedBelow ? 1 : 0);
+
+            var signal = GetCompareSignal(currentValue - trailingStop, prevValue - prevStop);
+            signalsList?.Add(signal);
+        }
+
+        stockData.SetOutputValues(() => new Dictionary<string, List<double>>{
+            { "TrailingStop", trailingStopList },
+            { "Position", positionList },
+            { "Buy", buyList },
+            { "Sell", sellList }
+        });
+        stockData.SetSignals(signalsList);
+        stockData.SetCustomValues(trailingStopList);
+        stockData.IndicatorName = IndicatorName.UtBotAlerts;
 
         return stockData;
     }

--- a/src/Calculations/Trend/TrendStoZ.cs
+++ b/src/Calculations/Trend/TrendStoZ.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace OoplesFinance.StockIndicators;
 
 public static partial class Calculations
@@ -892,6 +892,97 @@ public static partial class Calculations
         stockData.SetSignals(signalsList);
         stockData.SetCustomValues(stcList);
         stockData.IndicatorName = IndicatorName.SchaffTrendCycle;
+
+        return stockData;
+    }
+
+    /// <summary>
+    /// Calculates the Schaff Trend Cycle as published in the "STC Indicator - A Better MACD [SHK]"
+    /// TradingView script.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the full Schaff construction: a MACD line is put through a stochastic, the result is
+    /// smoothed, that is put through a second stochastic, and the result is smoothed again. The existing
+    /// <see cref="CalculateSchaffTrendCycle"/> applies only the first of those two passes, which is why
+    /// the two do not agree - this one is the double-smoothed form the script implements.
+    /// </para>
+    /// <para>
+    /// Where a stochastic window is completely flat its denominator is zero; in that case the previous
+    /// value is carried forward rather than treated as zero, which is what the Pine <c>nz</c> chain does
+    /// and what keeps the series from collapsing during quiet stretches.
+    /// </para>
+    /// </remarks>
+    /// <param name="stockData">The stock data.</param>
+    /// <param name="maType">Moving average used for the MACD legs.</param>
+    /// <param name="fastLength">Fast MACD length.</param>
+    /// <param name="slowLength">Slow MACD length.</param>
+    /// <param name="cycleLength">Lookback of both stochastic passes.</param>
+    /// <param name="d1Length">Smoothing applied after the first stochastic pass.</param>
+    /// <param name="d2Length">Smoothing applied after the second stochastic pass.</param>
+    /// <returns></returns>
+    [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
+    public static StockData CalculateSchaffTrendCycleShk(this StockData stockData,
+        MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 23, int slowLength = 50,
+        int cycleLength = 10, int d1Length = 3, int d2Length = 3)
+    {
+        List<double> macdList = new(stockData.Count);
+        List<double> fastKList = new(stockData.Count);
+        List<double> fastDList = new(stockData.Count);
+        List<double> slowKList = new(stockData.Count);
+        List<double> stcList = new(stockData.Count);
+        List<Signal>? signalsList = CreateSignalsList(stockData);
+        var (inputList, _, _, _, _) = GetInputValuesList(stockData);
+
+        var fastEmaList = GetMovingAverageList(stockData, maType, fastLength, inputList);
+        var slowEmaList = GetMovingAverageList(stockData, maType, slowLength, inputList);
+
+        for (var i = 0; i < stockData.Count; i++)
+        {
+            macdList.Add(fastEmaList[i] - slowEmaList[i]);
+        }
+
+        // First stochastic pass, over the MACD line.
+        var (macdHighestList, macdLowestList) = GetMaxAndMinValuesList(macdList, cycleLength);
+        var d1Alpha = (double)2 / (d1Length + 1);
+        for (var i = 0; i < stockData.Count; i++)
+        {
+            var range = macdHighestList[i] - macdLowestList[i];
+            var prevFastK = i >= 1 ? fastKList[i - 1] : 0;
+            var fastK = range > 0 ? MinOrMax((macdList[i] - macdLowestList[i]) / range * 100, 100, 0) : prevFastK;
+            fastKList.Add(fastK);
+
+            var prevFastD = i >= 1 ? fastDList[i - 1] : fastK;
+            fastDList.Add(prevFastD + (d1Alpha * (fastK - prevFastD)));
+        }
+
+        // Second stochastic pass, over the smoothed result of the first.
+        var (fastDHighestList, fastDLowestList) = GetMaxAndMinValuesList(fastDList, cycleLength);
+        var d2Alpha = (double)2 / (d2Length + 1);
+        for (var i = 0; i < stockData.Count; i++)
+        {
+            var range = fastDHighestList[i] - fastDLowestList[i];
+            var prevSlowK = i >= 1 ? slowKList[i - 1] : 0;
+            var slowK = range > 0 ? MinOrMax((fastDList[i] - fastDLowestList[i]) / range * 100, 100, 0) : prevSlowK;
+            slowKList.Add(slowK);
+
+            var prevStc = i >= 1 ? stcList[i - 1] : slowK;
+            var stc = MinOrMax(prevStc + (d2Alpha * (slowK - prevStc)), 100, 0);
+            stcList.Add(stc);
+
+            var prevStc1 = i >= 1 ? stcList[i - 1] : 0;
+            var prevStc2 = i >= 2 ? stcList[i - 2] : 0;
+            var signal = GetRsiSignal(stc - prevStc1, prevStc1 - prevStc2, stc, prevStc1, 75, 25);
+            signalsList?.Add(signal);
+        }
+
+        stockData.SetOutputValues(() => new Dictionary<string, List<double>>{
+            { "Stc", stcList },
+            { "Macd", macdList }
+        });
+        stockData.SetSignals(signalsList);
+        stockData.SetCustomValues(stcList);
+        stockData.IndicatorName = IndicatorName.SchaffTrendCycleShk;
 
         return stockData;
     }

--- a/src/Calculations/Volume/VolumeLtoR.cs
+++ b/src/Calculations/Volume/VolumeLtoR.cs
@@ -1,4 +1,4 @@
-
+﻿
 namespace OoplesFinance.StockIndicators;
 
 public static partial class Calculations
@@ -135,7 +135,13 @@ public static partial class Calculations
             var prevNvi = i >= 1 ? nviList[i - 1] : initialValue;
             var pctChg = CalculatePercentChange(currentClose, prevClose);
 
-            var nvi = currentVolume >= prevVolume ? prevNvi : prevNvi + pctChg;
+            // Fosback's NVI compounds the period's rate of change onto the running index:
+            //     NVI = prevNVI + (prevNVI * ROC).
+            // CalculatePercentChange returns that ROC already scaled to a percentage, so it has to be
+            // divided back out. Adding pctChg straight onto the index instead moved a 1% day by 1 point
+            // rather than by 1% of the index, making every move smaller than it should be by a factor of
+            // prevNVI / 100.
+            var nvi = currentVolume >= prevVolume ? prevNvi : prevNvi + (prevNvi * pctChg / 100);
             nviList.Add(nvi);
         }
 
@@ -188,7 +194,9 @@ public static partial class Calculations
             var prevPvi = i >= 1 ? pviList[i - 1] : initialValue;
             var pctChg = CalculatePercentChange(currentClose, prevClose);
 
-            var pvi = currentVolume <= prevVolume ? prevPvi : prevPvi + pctChg;
+            // PVI is the same construction as NVI, applied on rising volume instead of falling:
+            //     PVI = prevPVI + (prevPVI * ROC).
+            var pvi = currentVolume <= prevVolume ? prevPvi : prevPvi + (prevPvi * pctChg / 100);
             pviList.Add(pvi);
         }
 

--- a/src/Enums/IndicatorName.cs
+++ b/src/Enums/IndicatorName.cs
@@ -1208,6 +1208,8 @@ public enum IndicatorName
     [Category(IndicatorType.Momentum)]
     SchaffTrendCycle,
     [Category(IndicatorType.Momentum)]
+    SchaffTrendCycleShk,
+    [Category(IndicatorType.Momentum)]
     SectorRotationModel,
     [Category(IndicatorType.Momentum)]
     SelfAdjustingRelativeStrengthIndex,
@@ -1443,6 +1445,8 @@ public enum IndicatorName
     UpsideDownsideVolume,
     [Category(IndicatorType.Volatility)]
     UpsidePotentialRatio,
+    [Category(IndicatorType.Trend)]
+    UtBotAlerts,
     [Category(IndicatorType.Momentum)]
     ValueChartIndicator,
     [Category(IndicatorType.Trend)]

--- a/src/Helpers/SignalPatternMatcher.cs
+++ b/src/Helpers/SignalPatternMatcher.cs
@@ -1,4 +1,4 @@
-//     Ooples Finance Stock Indicator Library
+﻿//     Ooples Finance Stock Indicator Library
 //     https://ooples.github.io/OoplesFinance.StockIndicators/
 //
 //     Copyright © Franklin Moormann, 2020-2022
@@ -39,7 +39,10 @@ internal static class SignalPatternMatcher
     /// <returns><c>true</c> when the value matches the pattern; otherwise <c>false</c>.</returns>
     public static bool IsMatch(string? pattern, string? value)
     {
-        if (string.IsNullOrEmpty(pattern) || value is null)
+        // Written as an explicit null/length test rather than string.IsNullOrEmpty
+        // because the net461 reference assemblies lack the NotNullWhen annotation,
+        // so the compiler cannot narrow the nullable pattern through that call.
+        if (pattern is null || pattern.Length == 0 || value is null)
         {
             return false;
         }

--- a/src/Helpers/SignalPatternMatcher.cs
+++ b/src/Helpers/SignalPatternMatcher.cs
@@ -1,0 +1,118 @@
+//     Ooples Finance Stock Indicator Library
+//     https://ooples.github.io/OoplesFinance.StockIndicators/
+//
+//     Copyright © Franklin Moormann, 2020-2022
+//     cheatcountry@gmail.com
+//
+//     This library is free software and it uses the Apache 2.0 license
+//     so if you are going to re-use or modify my code then I just ask
+//     that you include my copyright info and my contact info in a comment
+
+namespace OoplesFinance.StockIndicators.Helpers;
+
+/// <summary>
+/// Matches signal names against simple wildcard patterns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The single supported metacharacter is <c>*</c>, which matches any run of
+/// characters including an empty one. It may appear anywhere in the pattern and
+/// any number of times, so <c>RSI*</c>, <c>*Oversold</c>, <c>*Oversold*</c> and
+/// <c>RSI*Cross*</c> all behave as expected. Every other character is matched
+/// literally, case-insensitively.
+/// </para>
+/// <para>
+/// This is deliberately not implemented by translating the pattern into a regular
+/// expression. Doing so requires escaping the literal portion, and forgetting that
+/// step silently turns ordinary signal names such as <c>RSI (14)</c> or
+/// <c>Price &gt; $5.00</c> into regex metacharacters. The linear scan below also
+/// removes any possibility of catastrophic backtracking.
+/// </para>
+/// </remarks>
+internal static class SignalPatternMatcher
+{
+    /// <summary>
+    /// Determines whether <paramref name="value"/> matches <paramref name="pattern"/>.
+    /// </summary>
+    /// <param name="pattern">The wildcard pattern. An empty or null pattern never matches.</param>
+    /// <param name="value">The signal name to test.</param>
+    /// <returns><c>true</c> when the value matches the pattern; otherwise <c>false</c>.</returns>
+    public static bool IsMatch(string? pattern, string? value)
+    {
+        if (string.IsNullOrEmpty(pattern) || value is null)
+        {
+            return false;
+        }
+
+        // A pattern of only wildcards matches anything, including the empty string.
+        if (IsAllWildcards(pattern))
+        {
+            return true;
+        }
+
+        return MatchCore(pattern, value);
+    }
+
+    private static bool IsAllWildcards(string pattern)
+    {
+        foreach (var c in pattern)
+        {
+            if (c != '*')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Greedy wildcard match with backtracking limited to the most recent <c>*</c>.
+    /// Runs in linear time for the patterns this library uses and never recurses.
+    /// </summary>
+    private static bool MatchCore(string pattern, string value)
+    {
+        var patternIndex = 0;
+        var valueIndex = 0;
+        var lastStarIndex = -1;
+        var resumeIndex = 0;
+
+        while (valueIndex < value.Length)
+        {
+            if (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+            {
+                // Remember where to resume if the rest of the pattern fails to match.
+                lastStarIndex = patternIndex;
+                resumeIndex = valueIndex;
+                patternIndex++;
+            }
+            else if (patternIndex < pattern.Length && CharsEqual(pattern[patternIndex], value[valueIndex]))
+            {
+                patternIndex++;
+                valueIndex++;
+            }
+            else if (lastStarIndex >= 0)
+            {
+                // Let the last '*' absorb one more character and try again.
+                patternIndex = lastStarIndex + 1;
+                resumeIndex++;
+                valueIndex = resumeIndex;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        // Any wildcards left over match the empty remainder.
+        while (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+        {
+            patternIndex++;
+        }
+
+        return patternIndex == pattern.Length;
+    }
+
+    private static bool CharsEqual(char left, char right) =>
+        left == right || char.ToUpperInvariant(left) == char.ToUpperInvariant(right);
+}

--- a/src/OoplesFinance.StockIndicators.csproj
+++ b/src/OoplesFinance.StockIndicators.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- Fork note: net461 dropped — the platform consuming this is net10-only,
-         and the net461 shim chain conflicts with the Alpaca SDK transitive deps. -->
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;net461</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -107,7 +105,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.6.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>

--- a/src/Streaming/StatefulIndicators.Batch18.cs
+++ b/src/Streaming/StatefulIndicators.Batch18.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
+﻿#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
 using System.Collections.Generic;
 using OoplesFinance.StockIndicators.Enums;
 using OoplesFinance.StockIndicators.Helpers;
@@ -1409,7 +1409,10 @@ public sealed class NegativeVolumeDisparityIndicatorState : IStreamingIndicatorS
         var prevVolume = _hasPrev ? _prevVolume : 0;
         var prevNvi = _hasPrev ? _prevNvi : 1000;
         var pctChg = CalculationsHelper.CalculatePercentChange(value, prevClose);
-        var nvi = volume >= prevVolume ? prevNvi : prevNvi + pctChg;
+        // Matches the batch CalculateNegativeVolumeIndex: Fosback compounds the rate of change onto the
+        // running index (NVI = prevNVI + prevNVI * ROC), and CalculatePercentChange returns that ROC
+        // already scaled to a percentage, so the 100 has to come back out.
+        var nvi = volume >= prevVolume ? prevNvi : prevNvi + (prevNvi * pctChg / 100);
 
         var inputSma = _inputSma.Next(value, isFinal);
         var nviSma = _nviSma.Next(nvi, isFinal);
@@ -1516,7 +1519,10 @@ public sealed class NegativeVolumeIndexState : IStreamingIndicatorState, IDispos
         var prevVolume = _hasPrev ? _prevVolume : 0;
         var prevNvi = _hasPrev ? _prevNvi : _initialValue;
         var pctChg = CalculationsHelper.CalculatePercentChange(value, prevClose);
-        var nvi = volume >= prevVolume ? prevNvi : prevNvi + pctChg;
+        // Matches the batch CalculateNegativeVolumeIndex: Fosback compounds the rate of change onto the
+        // running index (NVI = prevNVI + prevNVI * ROC), and CalculatePercentChange returns that ROC
+        // already scaled to a percentage, so the 100 has to come back out.
+        var nvi = volume >= prevVolume ? prevNvi : prevNvi + (prevNvi * pctChg / 100);
         var signal = _signalSmoother.Next(nvi, isFinal);
 
         if (isFinal)

--- a/src/Streaming/StatefulIndicators.Batch19.cs
+++ b/src/Streaming/StatefulIndicators.Batch19.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
+﻿#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
 using System.Collections.Generic;
 using OoplesFinance.StockIndicators.Enums;
 using OoplesFinance.StockIndicators.Helpers;
@@ -2126,7 +2126,8 @@ public sealed class PositiveVolumeIndexState : IStreamingIndicatorState, IDispos
         var prevVolume = _hasPrev ? _prevVolume : 0;
         var prevPvi = _hasPrev ? _prevPvi : _initialValue;
         var pctChg = CalculationsHelper.CalculatePercentChange(value, prevClose);
-        var pvi = volume <= prevVolume ? prevPvi : prevPvi + pctChg;
+        // Matches the batch CalculatePositiveVolumeIndex: PVI = prevPVI + prevPVI * ROC, on rising volume.
+        var pvi = volume <= prevVolume ? prevPvi : prevPvi + (prevPvi * pctChg / 100);
         var signal = _signalSmoother.Next(pvi, isFinal);
 
         if (isFinal)

--- a/src/Streaming/StatefulIndicators.Batch29.cs
+++ b/src/Streaming/StatefulIndicators.Batch29.cs
@@ -1,0 +1,260 @@
+#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
+using System.Collections.Generic;
+using OoplesFinance.StockIndicators.Enums;
+using OoplesFinance.StockIndicators.Helpers;
+
+namespace OoplesFinance.StockIndicators.Streaming;
+
+/// <summary>
+/// Streaming form of <c>CalculateSchaffTrendCycleShk</c>: the double-smoothed Schaff Trend Cycle from
+/// the "STC Indicator - A Better MACD [SHK]" script.
+/// </summary>
+public sealed class SchaffTrendCycleShkState : IStreamingIndicatorState, IDisposable
+{
+    private readonly IMovingAverageSmoother _fastEma;
+    private readonly IMovingAverageSmoother _slowEma;
+    private readonly RollingWindowMax _macdMax;
+    private readonly RollingWindowMin _macdMin;
+    private readonly RollingWindowMax _fastDMax;
+    private readonly RollingWindowMin _fastDMin;
+    private readonly StreamingInputResolver _input;
+    private readonly double _d1Alpha;
+    private readonly double _d2Alpha;
+    private double _prevFastK;
+    private double _prevFastD;
+    private double _prevSlowK;
+    private double _prevStc;
+    private bool _hasPrev;
+
+    public SchaffTrendCycleShkState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
+        int fastLength = 23, int slowLength = 50, int cycleLength = 10, int d1Length = 3, int d2Length = 3,
+        InputName inputName = InputName.Close)
+        : this(maType, fastLength, slowLength, cycleLength, d1Length, d2Length,
+            new StreamingInputResolver(inputName, null))
+    {
+    }
+
+    public SchaffTrendCycleShkState(MovingAvgType maType, int fastLength, int slowLength, int cycleLength,
+        int d1Length, int d2Length, Func<OhlcvBar, double> selector)
+        : this(maType, fastLength, slowLength, cycleLength, d1Length, d2Length,
+            new StreamingInputResolver(InputName.Close,
+                selector ?? throw new ArgumentNullException(nameof(selector))))
+    {
+    }
+
+    private SchaffTrendCycleShkState(MovingAvgType maType, int fastLength, int slowLength, int cycleLength,
+        int d1Length, int d2Length, StreamingInputResolver input)
+    {
+        var cycle = Math.Max(1, cycleLength);
+        _fastEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
+        _slowEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
+        _macdMax = new RollingWindowMax(cycle);
+        _macdMin = new RollingWindowMin(cycle);
+        _fastDMax = new RollingWindowMax(cycle);
+        _fastDMin = new RollingWindowMin(cycle);
+        _d1Alpha = (double)2 / (Math.Max(1, d1Length) + 1);
+        _d2Alpha = (double)2 / (Math.Max(1, d2Length) + 1);
+        _input = input;
+    }
+
+    public IndicatorName Name => IndicatorName.SchaffTrendCycleShk;
+
+    public void Reset()
+    {
+        _fastEma.Reset();
+        _slowEma.Reset();
+        _macdMax.Reset();
+        _macdMin.Reset();
+        _fastDMax.Reset();
+        _fastDMin.Reset();
+        _prevFastK = 0;
+        _prevFastD = 0;
+        _prevSlowK = 0;
+        _prevStc = 0;
+        _hasPrev = false;
+    }
+
+    public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
+    {
+        var value = _input.GetValue(bar);
+        var macd = _fastEma.Next(value, isFinal) - _slowEma.Next(value, isFinal);
+
+        // First stochastic pass, over the MACD line.
+        var macdHigh = isFinal ? _macdMax.Add(macd, out _) : _macdMax.Preview(macd, out _);
+        var macdLow = isFinal ? _macdMin.Add(macd, out _) : _macdMin.Preview(macd, out _);
+        var macdRange = macdHigh - macdLow;
+
+        // A flat window has no range to normalise against. Carry the previous reading forward rather
+        // than snapping to zero, which is what the Pine nz() chain and the batch calculation both do.
+        var fastK = macdRange > 0
+            ? MathHelper.MinOrMax((macd - macdLow) / macdRange * 100, 100, 0)
+            : _prevFastK;
+        var fastD = _hasPrev ? _prevFastD + (_d1Alpha * (fastK - _prevFastD)) : fastK;
+
+        // Second stochastic pass, over the smoothed result of the first. This pass is what separates
+        // the SHK indicator from the single-pass SchaffTrendCycle already in the library.
+        var fastDHigh = isFinal ? _fastDMax.Add(fastD, out _) : _fastDMax.Preview(fastD, out _);
+        var fastDLow = isFinal ? _fastDMin.Add(fastD, out _) : _fastDMin.Preview(fastD, out _);
+        var fastDRange = fastDHigh - fastDLow;
+
+        var slowK = fastDRange > 0
+            ? MathHelper.MinOrMax((fastD - fastDLow) / fastDRange * 100, 100, 0)
+            : _prevSlowK;
+        var stc = _hasPrev
+            ? MathHelper.MinOrMax(_prevStc + (_d2Alpha * (slowK - _prevStc)), 100, 0)
+            : MathHelper.MinOrMax(slowK, 100, 0);
+
+        if (isFinal)
+        {
+            _prevFastK = fastK;
+            _prevFastD = fastD;
+            _prevSlowK = slowK;
+            _prevStc = stc;
+            _hasPrev = true;
+        }
+
+        IReadOnlyDictionary<string, double>? outputs = null;
+        if (includeOutputs)
+        {
+            outputs = new Dictionary<string, double>(2)
+            {
+                { "Stc", stc },
+                { "Macd", macd }
+            };
+        }
+
+        return new StreamingIndicatorStateResult(stc, outputs);
+    }
+
+    public void Dispose()
+    {
+        _fastEma.Dispose();
+        _slowEma.Dispose();
+        _macdMax.Dispose();
+        _macdMin.Dispose();
+        _fastDMax.Dispose();
+        _fastDMin.Dispose();
+    }
+}
+
+/// <summary>
+/// Streaming form of <c>CalculateUtBotAlerts</c>: an ATR trailing stop that ratchets in the direction
+/// of the trend and flips when price closes through it.
+/// </summary>
+public sealed class UtBotAlertsState : IStreamingIndicatorState, IDisposable
+{
+    private readonly IMovingAverageSmoother _atrSmoother;
+    private readonly StreamingInputResolver _input;
+    private readonly double _keyValue;
+    private double _prevValue;
+    private double _prevStop;
+    private double _prevPosition;
+    private bool _hasPrev;
+
+    public UtBotAlertsState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 10,
+        double keyValue = 1, InputName inputName = InputName.Close)
+        : this(maType, length, keyValue, new StreamingInputResolver(inputName, null))
+    {
+    }
+
+    public UtBotAlertsState(MovingAvgType maType, int length, double keyValue,
+        Func<OhlcvBar, double> selector)
+        : this(maType, length, keyValue,
+            new StreamingInputResolver(InputName.Close,
+                selector ?? throw new ArgumentNullException(nameof(selector))))
+    {
+    }
+
+    private UtBotAlertsState(MovingAvgType maType, int length, double keyValue, StreamingInputResolver input)
+    {
+        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
+        _keyValue = keyValue;
+        _input = input;
+    }
+
+    public IndicatorName Name => IndicatorName.UtBotAlerts;
+
+    public void Reset()
+    {
+        _atrSmoother.Reset();
+        _prevValue = 0;
+        _prevStop = 0;
+        _prevPosition = 0;
+        _hasPrev = false;
+    }
+
+    public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
+    {
+        var value = _input.GetValue(bar);
+
+        // The first bar has no previous close. Seeding it with 0 would make the true range the bar's
+        // price rather than its range, which is exactly what the batch true-range helper avoids by
+        // reusing the bar's own close.
+        var prevValue = _hasPrev ? _prevValue : value;
+        var tr = CalculationsHelper.CalculateTrueRange(bar.High, bar.Low, prevValue);
+        var atr = _atrSmoother.Next(tr, isFinal);
+        var nLoss = _keyValue * atr;
+        var prevStop = _hasPrev ? _prevStop : 0;
+
+        double trailingStop;
+        if (value > prevStop && prevValue > prevStop)
+        {
+            // Still above the stop: raise it, never lower it.
+            trailingStop = Math.Max(prevStop, value - nLoss);
+        }
+        else if (value < prevStop && prevValue < prevStop)
+        {
+            // Still below the stop: lower it, never raise it.
+            trailingStop = Math.Min(prevStop, value + nLoss);
+        }
+        else
+        {
+            // Price crossed the stop, so it flips to the other side of price.
+            trailingStop = value > prevStop ? value - nLoss : value + nLoss;
+        }
+
+        double position;
+        if (prevValue < prevStop && value > prevStop)
+        {
+            position = 1;
+        }
+        else if (prevValue > prevStop && value < prevStop)
+        {
+            position = -1;
+        }
+        else
+        {
+            position = _hasPrev ? _prevPosition : 0;
+        }
+
+        var buy = _hasPrev && prevValue <= prevStop && value > trailingStop ? 1d : 0d;
+        var sell = _hasPrev && prevValue >= prevStop && value < trailingStop ? 1d : 0d;
+
+        if (isFinal)
+        {
+            _prevValue = value;
+            _prevStop = trailingStop;
+            _prevPosition = position;
+            _hasPrev = true;
+        }
+
+        IReadOnlyDictionary<string, double>? outputs = null;
+        if (includeOutputs)
+        {
+            outputs = new Dictionary<string, double>(4)
+            {
+                { "TrailingStop", trailingStop },
+                { "Position", position },
+                { "Buy", buy },
+                { "Sell", sell }
+            };
+        }
+
+        return new StreamingIndicatorStateResult(trailingStop, outputs);
+    }
+
+    public void Dispose()
+    {
+        _atrSmoother.Dispose();
+    }
+}

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
+﻿#pragma warning disable CS0618 // Suppress obsolete warnings for internal Calculate* method calls
 using System;
 using System.Collections.Generic;
 using OoplesFinance.StockIndicators.Attributes;
@@ -4212,23 +4212,27 @@ public sealed class KeltnerChannelsState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public KeltnerChannelsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 20,
-        int length2 = 10, double multFactor = 2, InputName inputName = InputName.Close)
+        int length2 = 10, double multFactor = 2, InputName inputName = InputName.Close,
+        MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
     {
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
+        // The ATR is smoothed with Wilder's method, matching the batch CalculateKeltnerChannels and the
+        // standard definition; maType stays the basis average. Passing maType to both would silently make
+        // the bands disagree with the batch calculation.
+        _atrSmoother = MovingAverageSmootherFactory.Create(atrMaType, Math.Max(1, length2));
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _mult = multFactor;
         _input = new StreamingInputResolver(inputName, null);
     }
 
     public KeltnerChannelsState(MovingAvgType maType, int length1, int length2, double multFactor,
-        Func<OhlcvBar, double> selector)
+        Func<OhlcvBar, double> selector, MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
     {
         if (selector == null)
         {
             throw new ArgumentNullException(nameof(selector));
         }
 
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
+        _atrSmoother = MovingAverageSmootherFactory.Create(atrMaType, Math.Max(1, length2));
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _mult = multFactor;
         _input = new StreamingInputResolver(InputName.Close, selector);
@@ -4247,7 +4251,11 @@ public sealed class KeltnerChannelsState : IStreamingIndicatorState, IDisposable
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
         var value = _input.GetValue(bar);
-        var prevValue = _hasPrev ? _prevValue : 0;
+        // On the very first bar there is no previous close. Seeding it with 0 made the true range
+        // max(high-low, |high-0|, |low-0|) - the bar's PRICE rather than its range - which on AAPL made
+        // the opening ATR 18.2880 instead of 0.5170 and put the first upper band at 218.59 instead of
+        // 183.04. The batch true-range helper uses the bar's own close for that first bar; match it.
+        var prevValue = _hasPrev ? _prevValue : value;
         var tr = CalculationsHelper.CalculateTrueRange(bar.High, bar.Low, prevValue);
         var atr = _atrSmoother.Next(tr, isFinal);
         var middle = _middleSmoother.Next(value, isFinal);

--- a/tests/IntegrationTests/AlpacaTestCredentials.cs
+++ b/tests/IntegrationTests/AlpacaTestCredentials.cs
@@ -1,0 +1,51 @@
+namespace OoplesFinance.StockIndicators.Tests.IntegrationTests;
+
+using OoplesFinance.StockIndicators.Builder.Trading;
+
+/// <summary>
+/// Resolves the Alpaca paper-trading credentials used by the integration tests.
+/// </summary>
+/// <remarks>
+/// These tests talk to the live Alpaca paper-trading API. A clean checkout has no
+/// credentials, so without this gate every one of them fails with
+/// <c>RestClientErrorException : Unauthorized</c> and turns CI red for a reason that
+/// has nothing to do with the code under test. Tests consult <see cref="Available"/>
+/// and skip themselves when the credentials are absent; supplying
+/// <c>ALPACA_API_KEY</c> and <c>ALPACA_API_SECRET</c> makes them run for real.
+/// </remarks>
+internal static class AlpacaTestCredentials
+{
+    /// <summary>The environment variable holding the Alpaca API key id.</summary>
+    public const string ApiKeyVariable = "ALPACA_API_KEY";
+
+    /// <summary>The environment variable holding the Alpaca API secret key.</summary>
+    public const string ApiSecretVariable = "ALPACA_API_SECRET";
+
+    /// <summary>The message shown on the skipped tests when credentials are missing.</summary>
+    public const string SkipReason =
+        "Alpaca paper-trading credentials are not configured. Set the " +
+        ApiKeyVariable + " and " + ApiSecretVariable + " environment variables to run these tests.";
+
+    /// <summary>Gets the configured Alpaca API key, or an empty string when unset.</summary>
+    public static string ApiKey => Environment.GetEnvironmentVariable(ApiKeyVariable) ?? string.Empty;
+
+    /// <summary>Gets the configured Alpaca API secret, or an empty string when unset.</summary>
+    public static string ApiSecret => Environment.GetEnvironmentVariable(ApiSecretVariable) ?? string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether both credentials are present, so the
+    /// integration tests can reach the Alpaca API.
+    /// </summary>
+    public static bool Available =>
+        !string.IsNullOrWhiteSpace(ApiKey) && !string.IsNullOrWhiteSpace(ApiSecret);
+
+    /// <summary>
+    /// Builds the Alpaca options used by the integration tests. Always paper trading.
+    /// </summary>
+    public static AlpacaOptions CreateOptions() => new()
+    {
+        ApiKey = ApiKey,
+        ApiSecret = ApiSecret,
+        UsePaper = true
+    };
+}

--- a/tests/IntegrationTests/BrokerIntegrationTests.cs
+++ b/tests/IntegrationTests/BrokerIntegrationTests.cs
@@ -15,9 +15,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests basic broker account info retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldRetrieveAccountInfo()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange - Using Alpaca paper trading as the test broker
         var broker = CreateTestBroker();
 
@@ -33,9 +35,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests position retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldRetrievePositions()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -50,9 +54,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests market order submission (paper trading).
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldSubmitMarketOrder_PaperTrading()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -76,9 +82,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests limit order submission (paper trading).
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldSubmitLimitOrder_PaperTrading()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -108,9 +116,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests stop order submission (paper trading).
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldSubmitStopOrder_PaperTrading()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -140,9 +150,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests order cancellation.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldCancelOrder()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -169,9 +181,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests order status retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldRetrieveOrderStatus()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -202,9 +216,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests position closing.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldClosePosition()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -232,9 +248,11 @@ public class BrokerIntegrationTests
     /// <summary>
     /// Tests concurrent order submission.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Broker_ShouldHandleConcurrentOrders()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var broker = CreateTestBroker();
 
@@ -267,13 +285,7 @@ public class BrokerIntegrationTests
     private static IBroker CreateTestBroker()
     {
         // Use environment variables or test configuration for credentials
-        var options = new AlpacaOptions
-        {
-            ApiKey = Environment.GetEnvironmentVariable("ALPACA_API_KEY") ?? "test-key",
-            ApiSecret = Environment.GetEnvironmentVariable("ALPACA_API_SECRET") ?? "test-secret",
-            UsePaper = true // Always use paper trading for tests
-        };
-
+        var options = AlpacaTestCredentials.CreateOptions();
         return new AlpacaBroker(options);
     }
 

--- a/tests/IntegrationTests/MarketDataIntegrationTests.cs
+++ b/tests/IntegrationTests/MarketDataIntegrationTests.cs
@@ -14,9 +14,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests quote retrieval from Alpaca.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveQuote()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -34,9 +36,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests historical bar retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveHistoricalBars()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var endDate = DateTime.UtcNow.Date;
@@ -65,9 +69,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests intraday bar retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveIntradayBars()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var endDate = DateTime.UtcNow;
@@ -95,9 +101,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests multiple symbol quotes.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveMultipleQuotes()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var symbols = new[] { "AAPL", "MSFT", "GOOGL", "AMZN" };
@@ -115,9 +123,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests market data caching.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task MarketDataCache_ShouldCacheQuotes()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var cacheTtl = TimeSpan.FromSeconds(30);
         var cache = new MarketDataCache(cacheTtl, cacheTtl, cacheTtl, cacheTtl);
@@ -140,9 +150,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests order book retrieval (Level 2 data).
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveOrderBook()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -165,9 +177,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests quote streaming.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldStreamQuotes()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var symbols = new[] { "AAPL", "MSFT" };
@@ -195,9 +209,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests trade streaming.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldStreamTrades()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var symbols = new[] { "AAPL" };
@@ -225,9 +241,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests market data provider resilience to invalid symbols.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task MarketData_ShouldHandleInvalidSymbol()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -246,9 +264,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests concurrent market data requests.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task MarketData_ShouldHandleConcurrentRequests()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var symbols = Enumerable.Range(0, 20).Select(_ => "AAPL").ToList();
@@ -265,9 +285,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests market snapshot retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveSnapshot()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -282,9 +304,11 @@ public class MarketDataIntegrationTests
     /// <summary>
     /// Tests latest trade retrieval.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task AlpacaMarketData_ShouldRetrieveLatestTrade()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -302,25 +326,13 @@ public class MarketDataIntegrationTests
 
     private static IMarketDataProvider CreateAlpacaProvider()
     {
-        var options = new AlpacaOptions
-        {
-            ApiKey = Environment.GetEnvironmentVariable("ALPACA_API_KEY") ?? "test-key",
-            ApiSecret = Environment.GetEnvironmentVariable("ALPACA_API_SECRET") ?? "test-secret",
-            UsePaper = true
-        };
-
+        var options = AlpacaTestCredentials.CreateOptions();
         return new AlpacaMarketDataProvider(options);
     }
 
     private static IMarketDataProvider CreateAlpacaProviderWithCache(MarketDataCache cache)
     {
-        var options = new AlpacaOptions
-        {
-            ApiKey = Environment.GetEnvironmentVariable("ALPACA_API_KEY") ?? "test-key",
-            ApiSecret = Environment.GetEnvironmentVariable("ALPACA_API_SECRET") ?? "test-secret",
-            UsePaper = true
-        };
-
+        var options = AlpacaTestCredentials.CreateOptions();
         return new AlpacaMarketDataProvider(options, enableStreaming: false, cache: cache);
     }
 
@@ -336,9 +348,11 @@ public class MarketDataQualityTests
     /// <summary>
     /// Tests that bar data has correct OHLC relationships.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Bars_ShouldHaveValidOHLCRelationships()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var endDate = DateTime.UtcNow.Date;
@@ -369,9 +383,11 @@ public class MarketDataQualityTests
     /// <summary>
     /// Tests that quote spreads are reasonable.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Quotes_ShouldHaveReasonableSpreads()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
 
@@ -393,9 +409,11 @@ public class MarketDataQualityTests
     /// <summary>
     /// Tests that bars are in chronological order.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Bars_ShouldBeInChronologicalOrder()
     {
+        Skip.IfNot(AlpacaTestCredentials.Available, AlpacaTestCredentials.SkipReason);
+
         // Arrange
         var provider = CreateAlpacaProvider();
         var endDate = DateTime.UtcNow.Date;
@@ -443,13 +461,7 @@ public class MarketDataQualityTests
 
     private static IMarketDataProvider CreateAlpacaProvider()
     {
-        var options = new AlpacaOptions
-        {
-            ApiKey = Environment.GetEnvironmentVariable("ALPACA_API_KEY") ?? "test-key",
-            ApiSecret = Environment.GetEnvironmentVariable("ALPACA_API_SECRET") ?? "test-secret",
-            UsePaper = true
-        };
-
+        var options = AlpacaTestCredentials.CreateOptions();
         return new AlpacaMarketDataProvider(options);
     }
 }

--- a/tests/OoplesFinance.StockIndicators.Tests.Unit.csproj
+++ b/tests/OoplesFinance.StockIndicators.Tests.Unit.csproj
@@ -26,6 +26,7 @@
     </PackageReference>
     <ProjectReference Include="..\src\OoplesFinance.StockIndicators.csproj" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/StreamingTests/StreamingStatefulParityTests.cs
+++ b/tests/StreamingTests/StreamingStatefulParityTests.cs
@@ -661,6 +661,27 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
             };
             yield return new object[]
             {
+                new StatefulIndicatorSpec("SchaffTrendCycleShk.Stc",
+                    () => new SchaffTrendCycleShkState(MovingAvgType.ExponentialMovingAverage, 23, 50, 10, 3, 3),
+                    data => data.CalculateSchaffTrendCycleShk(MovingAvgType.ExponentialMovingAverage, 23, 50, 10, 3, 3)
+                        .OutputValues["Stc"], "Stc")
+            };
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("UtBotAlerts.TrailingStop",
+                    () => new UtBotAlertsState(MovingAvgType.WildersSmoothingMethod, 10, 1),
+                    data => data.CalculateUtBotAlerts(MovingAvgType.WildersSmoothingMethod, 10, 1)
+                        .OutputValues["TrailingStop"], "TrailingStop")
+            };
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("UtBotAlerts.Position",
+                    () => new UtBotAlertsState(MovingAvgType.WildersSmoothingMethod, 10, 1),
+                    data => data.CalculateUtBotAlerts(MovingAvgType.WildersSmoothingMethod, 10, 1)
+                        .OutputValues["Position"], "Position")
+            };
+            yield return new object[]
+            {
                 new StatefulIndicatorSpec("KeltnerChannels.MiddleBand",
                     () => new KeltnerChannelsState(MovingAvgType.ExponentialMovingAverage, 20, 10, 2),
                     data => data.CalculateKeltnerChannels(MovingAvgType.ExponentialMovingAverage, 20, 10, 2)

--- a/tests/StreamingTests/StreamingStatefulParityTests.cs
+++ b/tests/StreamingTests/StreamingStatefulParityTests.cs
@@ -1,4 +1,4 @@
-using OoplesFinance.StockIndicators.Streaming;
+﻿using OoplesFinance.StockIndicators.Streaming;
 using OoplesFinance.StockIndicators.Helpers;
 
 namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
@@ -665,6 +665,22 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
                     () => new KeltnerChannelsState(MovingAvgType.ExponentialMovingAverage, 20, 10, 2),
                     data => data.CalculateKeltnerChannels(MovingAvgType.ExponentialMovingAverage, 20, 10, 2)
                         .OutputValues["MiddleBand"])
+            };
+            // MiddleBand is only the basis average, so it stayed in agreement while the ATR-derived bands
+            // silently diverged between batch and streaming. Cover those too.
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("KeltnerChannels.UpperBand",
+                    () => new KeltnerChannelsState(MovingAvgType.ExponentialMovingAverage, 20, 10, 2),
+                    data => data.CalculateKeltnerChannels(MovingAvgType.ExponentialMovingAverage, 20, 10, 2)
+                        .OutputValues["UpperBand"], "UpperBand")
+            };
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("KeltnerChannels.LowerBand",
+                    () => new KeltnerChannelsState(MovingAvgType.ExponentialMovingAverage, 20, 10, 2),
+                    data => data.CalculateKeltnerChannels(MovingAvgType.ExponentialMovingAverage, 20, 10, 2)
+                        .OutputValues["LowerBand"], "LowerBand")
             };
             yield return new object[]
             {
@@ -4381,8 +4397,18 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
             var ticker = data[i];
             var bar = new OhlcvBar("AAPL", BarTimeframe.Tick, ticker.Date, ticker.Date,
                 ticker.Open, ticker.High, ticker.Low, ticker.Close, ticker.Volume, isFinal: true);
-            var result = state.Update(bar, isFinal: true, includeOutputs: false);
-            streamingValues.Add(result.Value);
+            var result = state.Update(bar, isFinal: true, includeOutputs: spec.OutputKey is not null);
+            if (spec.OutputKey is null)
+            {
+                streamingValues.Add(result.Value);
+            }
+            else
+            {
+                result.Outputs.Should().NotBeNull($"{spec.Name} should publish named outputs");
+                result.Outputs!.ContainsKey(spec.OutputKey).Should()
+                    .BeTrue($"{spec.Name} should publish an output named {spec.OutputKey}");
+                streamingValues.Add(result.Outputs[spec.OutputKey]);
+            }
         }
 
         for (var i = 0; i < maxCount; i++)
@@ -4436,7 +4462,16 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
         actual.Should().BeApproximately(expected, 5e-10, $"{name} mismatch at index {index}");
     }
 
+    /// <summary>
+    /// A batch calculation paired with its streaming state.
+    /// </summary>
+    /// <param name="OutputKey">
+    /// Named output to compare. When null the state's primary <c>Result.Value</c> is used, which is all
+    /// this harness could read before - so an indicator publishing several series was only ever checked
+    /// on its primary one, and the rest could drift between batch and streaming unnoticed.
+    /// </param>
     public sealed record StatefulIndicatorSpec(string Name,
         Func<IStreamingIndicatorState> CreateState,
-        Func<StockData, List<double>> Calculate);
+        Func<StockData, List<double>> Calculate,
+        string? OutputKey = null);
 }

--- a/tests/ValidationTests/KeltnerChannelReferenceTests.cs
+++ b/tests/ValidationTests/KeltnerChannelReferenceTests.cs
@@ -1,0 +1,92 @@
+using System.Globalization;
+using OoplesFinance.StockIndicators.Models;
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.ValidationTests;
+
+/// <summary>
+/// Pins Keltner Channels to the standard definition, as charting platforms compute it:
+/// an EMA basis with bands at a multiple of Wilder-smoothed ATR.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #30 reported the upper band sitting roughly eight points above TradingView's for the same
+/// input. Two things were wrong. The ATR was smoothed with the caller's <c>maType</c> (an EMA) rather
+/// than Wilder's method, and - far larger - the moving average was computed <em>before</em> the ATR.
+/// <c>GetMovingAverageList</c> stores its result in <c>StockData.CustomValuesList</c>, which the
+/// true-range helper treats as the close series, so the ATR ended up measuring each bar's high and low
+/// against the previous MOVING AVERAGE instead of the previous close.
+/// </para>
+/// <para>
+/// The expected values below are computed independently from the definition
+/// (<c>basis = EMA(close, 20)</c>, <c>atr = RMA(TrueRange, 10)</c>, <c>upper = basis + 2*atr</c>)
+/// over the checked-in AAPL series, so a regression in either the ordering or the smoothing fails here.
+/// </para>
+/// </remarks>
+public class KeltnerChannelReferenceTests
+{
+    private const double Tolerance = 1e-4;
+
+    private static List<TickerData> Aapl()
+    {
+        var list = new List<TickerData>();
+        foreach (var line in File.ReadAllLines("TestData/AAPL.csv").Skip(1))
+        {
+            var p = line.Split(',');
+            list.Add(new TickerData
+            {
+                Date = DateTime.ParseExact(p[0], "yyyyMMdd", CultureInfo.InvariantCulture),
+                Open = double.Parse(p[1], CultureInfo.InvariantCulture),
+                High = double.Parse(p[2], CultureInfo.InvariantCulture),
+                Low = double.Parse(p[3], CultureInfo.InvariantCulture),
+                Close = double.Parse(p[4], CultureInfo.InvariantCulture),
+                Volume = double.Parse(p[5], CultureInfo.InvariantCulture)
+            });
+        }
+        return list;
+    }
+
+    [Fact]
+    public void KeltnerChannels_MatchTheStandardDefinitionOnTheLastBar()
+    {
+        var result = new StockData(Aapl()).CalculateKeltnerChannels();
+        var last = result.OutputValues["MiddleBand"].Count - 1;
+
+        // Independently computed: EMA(close,20) = 135.8312, RMA(TrueRange,10) = 4.1662.
+        Assert.Equal(135.8312, result.OutputValues["MiddleBand"][last], Tolerance);
+        Assert.Equal(144.1636, result.OutputValues["UpperBand"][last], Tolerance);
+        Assert.Equal(127.4988, result.OutputValues["LowerBand"][last], Tolerance);
+    }
+
+    [Fact]
+    public void KeltnerChannels_AtrIsMeasuredAgainstCloseNotTheMovingAverage()
+    {
+        var keltner = new StockData(Aapl()).CalculateKeltnerChannels();
+        var atr = new StockData(Aapl())
+            .CalculateAverageTrueRange(MovingAvgType.WildersSmoothingMethod, 10).CustomValuesList;
+        var last = atr.Count - 1;
+
+        // Recovering the ATR from the band width must give back a genuine ATR of the price series.
+        // Before the fix this implied 9.7261 against a true ATR(10) of 4.1662, because the true range
+        // was being measured against the 20-period average instead of the close.
+        var impliedAtr =
+            (keltner.OutputValues["UpperBand"][last] - keltner.OutputValues["MiddleBand"][last]) / 2.0;
+
+        Assert.Equal(atr[last], impliedAtr, Tolerance);
+    }
+
+    [Fact]
+    public void KeltnerChannels_AtrSmoothingIsCallerOverridable()
+    {
+        // The Wilder default is the standard, but the ATR smoothing stays selectable.
+        var wilder = new StockData(Aapl()).CalculateKeltnerChannels();
+        var ema = new StockData(Aapl()).CalculateKeltnerChannels(
+            MovingAvgType.ExponentialMovingAverage, 20, 10, 2, MovingAvgType.ExponentialMovingAverage);
+        var last = wilder.OutputValues["UpperBand"].Count - 1;
+
+        // Same basis, different band width: EMA-smoothed ATR(10) is 3.9553 rather than 4.1662.
+        Assert.Equal(
+            wilder.OutputValues["MiddleBand"][last], ema.OutputValues["MiddleBand"][last], Tolerance);
+        Assert.Equal(143.7419, ema.OutputValues["UpperBand"][last], Tolerance);
+    }
+}

--- a/tests/ValidationTests/NewIndicatorTests.cs
+++ b/tests/ValidationTests/NewIndicatorTests.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+using OoplesFinance.StockIndicators.Models;
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.ValidationTests;
+
+/// <summary>
+/// Behavioural tests for the two indicators requested in issues #45 and #46.
+/// </summary>
+public class NewIndicatorTests
+{
+    private const double Tolerance = 1e-9;
+
+    private static List<TickerData> Aapl()
+    {
+        var list = new List<TickerData>();
+        foreach (var line in File.ReadAllLines("TestData/AAPL.csv").Skip(1))
+        {
+            var p = line.Split(',');
+            list.Add(new TickerData
+            {
+                Date = DateTime.ParseExact(p[0], "yyyyMMdd", CultureInfo.InvariantCulture),
+                Open = double.Parse(p[1], CultureInfo.InvariantCulture),
+                High = double.Parse(p[2], CultureInfo.InvariantCulture),
+                Low = double.Parse(p[3], CultureInfo.InvariantCulture),
+                Close = double.Parse(p[4], CultureInfo.InvariantCulture),
+                Volume = double.Parse(p[5], CultureInfo.InvariantCulture)
+            });
+        }
+        return list;
+    }
+
+    // ---------------------------------------------------------------- issue #46
+
+    [Fact]
+    public void SchaffTrendCycleShk_IsBoundedToZeroHundredAndOnePerBar()
+    {
+        var bars = Aapl();
+        var stc = new StockData(bars).CalculateSchaffTrendCycleShk().OutputValues["Stc"];
+
+        Assert.Equal(bars.Count, stc.Count);
+        Assert.All(stc, v =>
+        {
+            Assert.True(double.IsFinite(v), "STC must be finite");
+            Assert.InRange(v, 0.0, 100.0);
+        });
+    }
+
+    [Fact]
+    public void SchaffTrendCycleShk_AppliesASecondStochasticPassUnlikeTheSinglePassVersion()
+    {
+        var bars = Aapl();
+        var single = new StockData(bars).CalculateSchaffTrendCycle().OutputValues["Stc"];
+        var shk = new StockData(bars).CalculateSchaffTrendCycleShk().OutputValues["Stc"];
+
+        // The whole point of the SHK script is the second stochastic + smoothing pass, so the two
+        // series must not be the same. If this ever passes, the extra pass has been lost.
+        Assert.Equal(single.Count, shk.Count);
+        Assert.Contains(Enumerable.Range(0, shk.Count), i => Math.Abs(single[i] - shk[i]) > 1e-6);
+    }
+
+    [Fact]
+    public void SchaffTrendCycleShk_PublishesTheUnderlyingMacd()
+    {
+        var bars = Aapl();
+        var result = new StockData(bars).CalculateSchaffTrendCycleShk(
+            MovingAvgType.ExponentialMovingAverage, 23, 50, 10, 3, 3);
+
+        var macd = result.OutputValues["Macd"];
+        var fast = new StockData(bars).CalculateExponentialMovingAverage(23).CustomValuesList;
+        var slow = new StockData(bars).CalculateExponentialMovingAverage(50).CustomValuesList;
+
+        Assert.Equal(bars.Count, macd.Count);
+        for (var i = 0; i < macd.Count; i++)
+        {
+            Assert.Equal(fast[i] - slow[i], macd[i], Tolerance);
+        }
+    }
+
+    // ---------------------------------------------------------------- issue #45
+
+    [Fact]
+    public void UtBotAlerts_ReturnsOneValuePerBarForEveryOutput()
+    {
+        var bars = Aapl();
+        var result = new StockData(bars).CalculateUtBotAlerts();
+
+        foreach (var output in result.OutputValues)
+        {
+            Assert.Equal(bars.Count, output.Value.Count);
+        }
+    }
+
+    [Fact]
+    public void UtBotAlerts_StopRatchetsAndNeverGivesGroundWhilePriceHoldsItsSide()
+    {
+        var bars = Aapl();
+        var result = new StockData(bars).CalculateUtBotAlerts();
+        var stop = result.OutputValues["TrailingStop"];
+        var closes = bars.Select(b => b.Close).ToList();
+
+        for (var i = 1; i < stop.Count; i++)
+        {
+            var prevStop = stop[i - 1];
+            if (closes[i] > prevStop && closes[i - 1] > prevStop)
+            {
+                // Held above: the stop may rise but must never fall.
+                Assert.True(stop[i] >= prevStop,
+                    $"stop fell from {prevStop} to {stop[i]} at index {i} while price stayed above it");
+            }
+            else if (closes[i] < prevStop && closes[i - 1] < prevStop)
+            {
+                // Held below: the stop may fall but must never rise.
+                Assert.True(stop[i] <= prevStop,
+                    $"stop rose from {prevStop} to {stop[i]} at index {i} while price stayed below it");
+            }
+        }
+    }
+
+    [Fact]
+    public void UtBotAlerts_PositionIsAlwaysFlatLongOrShortAndFlipsOnlyWithASignal()
+    {
+        var bars = Aapl();
+        var result = new StockData(bars).CalculateUtBotAlerts();
+        var position = result.OutputValues["Position"];
+        var buy = result.OutputValues["Buy"];
+        var sell = result.OutputValues["Sell"];
+
+        Assert.All(position, p => Assert.Contains(p, new[] { -1.0, 0.0, 1.0 }));
+        Assert.All(buy, b => Assert.Contains(b, new[] { 0.0, 1.0 }));
+        Assert.All(sell, sl => Assert.Contains(sl, new[] { 0.0, 1.0 }));
+
+        // A bar cannot be both a buy and a sell.
+        for (var i = 0; i < buy.Count; i++)
+        {
+            Assert.False(buy[i] == 1 && sell[i] == 1, $"bar {i} is flagged as both buy and sell");
+        }
+
+        // Both directions must actually occur on a year of real data, or the crossing logic is dead.
+        Assert.Contains(1.0, buy);
+        Assert.Contains(1.0, sell);
+        Assert.Contains(1.0, position);
+        Assert.Contains(-1.0, position);
+    }
+
+    [Fact]
+    public void UtBotAlerts_StopSitsOneAtrMultipleFromPriceOnAFlip()
+    {
+        var bars = Aapl();
+        const double keyValue = 2.0;
+        var result = new StockData(bars).CalculateUtBotAlerts(
+            MovingAvgType.WildersSmoothingMethod, 10, keyValue);
+        var stop = result.OutputValues["TrailingStop"];
+        var atr = new StockData(bars)
+            .CalculateAverageTrueRange(MovingAvgType.WildersSmoothingMethod, 10).CustomValuesList;
+        var closes = bars.Select(b => b.Close).ToList();
+
+        var flips = 0;
+        for (var i = 1; i < stop.Count; i++)
+        {
+            var prevStop = stop[i - 1];
+            var heldAbove = closes[i] > prevStop && closes[i - 1] > prevStop;
+            var heldBelow = closes[i] < prevStop && closes[i - 1] < prevStop;
+            if (heldAbove || heldBelow)
+            {
+                continue;
+            }
+
+            // On a flip the stop is placed exactly keyValue * ATR away from price.
+            var expected = closes[i] > prevStop
+                ? closes[i] - (keyValue * atr[i])
+                : closes[i] + (keyValue * atr[i]);
+            Assert.Equal(expected, stop[i], 1e-9);
+            flips++;
+        }
+
+        Assert.True(flips > 0, "the AAPL series should produce at least one stop flip");
+    }
+}

--- a/tests/ValidationTests/SignalPatternMatchingTests.cs
+++ b/tests/ValidationTests/SignalPatternMatchingTests.cs
@@ -1,0 +1,91 @@
+using OoplesFinance.StockIndicators.Builder;
+using OoplesFinance.StockIndicators.Builder.Notifications;
+using OoplesFinance.StockIndicators.Builder.Trading;
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.ValidationTests;
+
+/// <summary>
+/// Tests for signal-name wildcard matching, exercised through the two public
+/// surfaces that rely on it: auto-trade rules and notification routes.
+/// </summary>
+public class SignalPatternMatchingTests
+{
+    private static bool RuleMatches(string pattern, string signalName) =>
+        new ExtendedAutoTradeRule { SignalPattern = pattern }.Matches(signalName);
+
+    private static bool RouteMatches(string pattern, string signalName) =>
+        new NotificationRoute { SignalPattern = pattern }
+            .Matches(new NotificationEvent(new SignalHandle(0), signalName, 0, DateTime.UtcNow));
+
+    [Theory]
+    // Exact matches, case-insensitive.
+    [InlineData("MACD Bullish Cross", "MACD Bullish Cross", true)]
+    [InlineData("macd bullish cross", "MACD Bullish Cross", true)]
+    [InlineData("MACD Bullish Cross", "MACD Bearish Cross", false)]
+    // Match-everything.
+    [InlineData("*", "anything at all", true)]
+    [InlineData("*", "", true)]
+    // Trailing wildcard (prefix match).
+    [InlineData("RSI*", "RSI Oversold", true)]
+    [InlineData("RSI*", "MACD Cross", false)]
+    [InlineData("RSI*", "RSI", true)]
+    // Leading wildcard (suffix match) - was unsupported and never matched.
+    [InlineData("*Oversold", "RSI Oversold", true)]
+    [InlineData("*Oversold", "RSI Overbought", false)]
+    // Surrounding wildcards (contains) - was unsupported and never matched.
+    [InlineData("*Oversold*", "RSI Oversold", true)]
+    [InlineData("*Oversold*", "RSI Oversold Cross", true)]
+    [InlineData("*oversold*", "RSI OVERSOLD Cross", true)]
+    [InlineData("*Oversold*", "RSI Overbought", false)]
+    // Interior wildcards.
+    [InlineData("RSI*Cross", "RSI Oversold Cross", true)]
+    [InlineData("RSI*Cross*", "RSI Oversold Crossover", true)]
+    [InlineData("RSI*Cross", "MACD Oversold Cross", false)]
+    // A wildcard matches an empty run.
+    [InlineData("RSI*Cross", "RSICross", true)]
+    // Empty patterns never match.
+    [InlineData("", "RSI Oversold", false)]
+    public void Patterns_MatchTheSameWayForRulesAndRoutes(string pattern, string signalName, bool expected)
+    {
+        Assert.Equal(expected, RuleMatches(pattern, signalName));
+        Assert.Equal(expected, RouteMatches(pattern, signalName));
+    }
+
+    [Theory]
+    // Regex metacharacters must be treated as literal text. A pattern-to-regex
+    // translation that forgets to escape turns these into wildcards or, for the
+    // unbalanced bracket, throws.
+    [InlineData("RSI (14)*", "RSI (14) Oversold", true)]
+    [InlineData("RSI (14)*", "RSI 914 Oversold", false)]
+    [InlineData("Price > $5.00*", "Price > $5.00 Breakout", true)]
+    [InlineData("Price > $5.00*", "Price > $5X00 Breakout", false)]
+    [InlineData("Signal [A]*", "Signal [A] Fired", true)]
+    [InlineData("Signal [*", "Signal [A] Fired", true)]
+    [InlineData("A+B*", "A+B Cross", true)]
+    [InlineData("A+B*", "AAB Cross", false)]
+    public void RegexMetacharactersAreMatchedLiterally(string pattern, string signalName, bool expected)
+    {
+        Assert.Equal(expected, RuleMatches(pattern, signalName));
+        Assert.Equal(expected, RouteMatches(pattern, signalName));
+    }
+
+    [Fact]
+    public void ConsecutiveWildcardsBehaveAsOne()
+    {
+        Assert.True(RuleMatches("**", "anything"));
+        Assert.True(RuleMatches("RSI**Cross", "RSI Oversold Cross"));
+        Assert.True(RouteMatches("**", "anything"));
+        Assert.True(RouteMatches("RSI**Cross", "RSI Oversold Cross"));
+    }
+
+    [Fact]
+    public void BacktrackingPatternCompletesPromptly()
+    {
+        // A pattern of this shape is the classic catastrophic-backtracking trigger
+        // for a regex-based implementation. The linear matcher must stay fast.
+        var signalName = new string('a', 2000) + "b";
+        Assert.True(RuleMatches("*a*a*a*a*a*b", signalName));
+        Assert.False(RuleMatches("*a*a*a*a*a*c", signalName));
+    }
+}

--- a/tests/ValidationTests/VolumeIndexFormulaTests.cs
+++ b/tests/ValidationTests/VolumeIndexFormulaTests.cs
@@ -1,0 +1,87 @@
+using OoplesFinance.StockIndicators.Models;
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.ValidationTests;
+
+/// <summary>
+/// Pins the Negative and Positive Volume Index formulas to Fosback's definition.
+/// </summary>
+/// <remarks>
+/// Both indices start at a fixed level (1000 by convention) and, on qualifying days, compound that
+/// period's rate of change onto the running index:
+/// <code>
+///     NVI = prevNVI + (prevNVI * (close - prevClose) / prevClose)      // when volume FALLS
+///     PVI = prevPVI + (prevPVI * (close - prevClose) / prevClose)      // when volume RISES
+/// </code>
+/// On non-qualifying days the index carries forward unchanged. The expected values below are computed
+/// by hand from that definition, so a regression in the formula fails here rather than silently
+/// producing a plausible-looking but wrongly scaled series.
+/// </remarks>
+public class VolumeIndexFormulaTests
+{
+    private const double Tolerance = 1e-6;
+
+    /// <summary>Close/volume pairs chosen so each branch of both indicators is exercised.</summary>
+    private static List<TickerData> Series() =>
+    [
+        //                     close, volume
+        Bar("2024-01-01", 100.0, 1_000),
+        Bar("2024-01-02", 110.0,   500),   // volume FELL, +10%  -> NVI moves, PVI holds
+        Bar("2024-01-03", 121.0, 2_000),   // volume ROSE, +10%  -> PVI moves, NVI holds
+        Bar("2024-01-04", 108.9, 1_000),   // volume FELL, -10%  -> NVI moves, PVI holds
+    ];
+
+    private static TickerData Bar(string date, double close, double volume) => new()
+    {
+        Date = DateTime.Parse(date, System.Globalization.CultureInfo.InvariantCulture),
+        Open = close,
+        High = close,
+        Low = close,
+        Close = close,
+        Volume = volume
+    };
+
+    [Fact]
+    public void NegativeVolumeIndex_CompoundsRateOfChangeOnFallingVolume()
+    {
+        var actual = new StockData(Series()).CalculateNegativeVolumeIndex().CustomValuesList;
+
+        // Day 1: seed.                                            1000
+        // Day 2: volume fell, +10%  -> 1000 + 1000*0.10          = 1100
+        // Day 3: volume rose        -> unchanged                 = 1100
+        // Day 4: volume fell, -10%  -> 1100 + 1100*(-0.10)       =  990
+        Assert.Equal(4, actual.Count);
+        Assert.Equal(1000.0, actual[0], Tolerance);
+        Assert.Equal(1100.0, actual[1], Tolerance);
+        Assert.Equal(1100.0, actual[2], Tolerance);
+        Assert.Equal(990.0, actual[3], Tolerance);
+    }
+
+    [Fact]
+    public void PositiveVolumeIndex_CompoundsRateOfChangeOnRisingVolume()
+    {
+        var actual = new StockData(Series()).CalculatePositiveVolumeIndex().CustomValuesList;
+
+        // Day 1: seed.                                            1000
+        // Day 2: volume fell        -> unchanged                 = 1000
+        // Day 3: volume rose, +10%  -> 1000 + 1000*0.10          = 1100
+        // Day 4: volume fell        -> unchanged                 = 1100
+        Assert.Equal(4, actual.Count);
+        Assert.Equal(1000.0, actual[0], Tolerance);
+        Assert.Equal(1000.0, actual[1], Tolerance);
+        Assert.Equal(1100.0, actual[2], Tolerance);
+        Assert.Equal(1100.0, actual[3], Tolerance);
+    }
+
+    [Fact]
+    public void VolumeIndexes_RespectACustomInitialValue()
+    {
+        var nvi = new StockData(Series()).CalculateNegativeVolumeIndex(initialValue: 100).CustomValuesList;
+
+        // Same 10% moves, seeded at 100 instead of 1000.
+        Assert.Equal(100.0, nvi[0], Tolerance);
+        Assert.Equal(110.0, nvi[1], Tolerance);
+        Assert.Equal(110.0, nvi[2], Tolerance);
+        Assert.Equal(99.0, nvi[3], Tolerance);
+    }
+}


### PR DESCRIPTION
Repo-health pass: gets CI building and green again, restores the dropped framework targets, and fixes two real indicator defects found along the way.

## Why CI has been red since June

The workflow still had a **Build for .NET Framework 4.6.1** step, but `306b286` removed `net461` from `TargetFrameworks`. That step cannot succeed once the target is gone, and it sits *ahead* of the test steps — so **the test suite has not run on `master` at all since then**.

```
5. Build for .NET 10                success
6. Build for .NET Framework 4.6.1   failure   ← every run
7. Restore test dependencies        skipped
8. Build and run tests              skipped   ← 2000+ tests, never executed
```

## 1. `net461` restored, `net8.0` added

The stated reason for dropping net461 was that "the net461 shim chain conflicts with the Alpaca SDK". The real conflict was narrower: that same commit bumped `System.Memory` to 4.6.0 for Alpaca but left `System.Buffers` at 4.5.1, and the resulting `NU1605` downgrade is fatal because warnings are errors on this target. **Aligning `System.Buffers` to 4.6.0 is the entire fix.**

`TargetFrameworks` is now `net10.0;net8.0;net461`. net8.0 needed no source changes. The one net461 compile error was in the new `SignalPatternMatcher`, where the net461 reference assemblies lack the `NotNullWhen` annotation on `string.IsNullOrEmpty`.

**Verified by running, not just compiling** — a net461 and a net8.0 console app built against the produced package:

```
Runtime: .NET Framework 4.8.9337.0      Runtime: .NET 8.0.31
RSI last       : 63.0382                RSI last       : 63.0382
SMA last       : 80.9929                SMA last       : 80.9929
```

Identical series on both. The package now ships `lib/net10.0`, `lib/net8.0`, `lib/net461`.

> One caveat: `Microsoft.Extensions.Http` 9.0.0, pulled in transitively by Alpaca, declares **net462** as its minimum and warns on net461. It works, but raising the floor to net462 would remove that warning.

## 2. Wildcard signal patterns matched almost nothing

`ExtendedAutoTradeRule.Matches` only understood a trailing `*`. Given `"*Oversold*"` it took the `EndsWith("*")` branch, stripped the last character, and asked whether the signal started with the literal `"*Oversold"` — never true. **Any rule written with a leading or interior wildcard silently never fired**, so the trade it was meant to place was never submitted.

`NotificationRoute.Matches` had the opposite bug: it did handle wildcards, but by building a regex with `Replace("*", ".*")` and **no escaping**. Real signal names are full of regex metacharacters — `"RSI (14)*"` became a capture group, `"Price > $5.00*"` treated `.` as any-character and `$` as an anchor, and `"Signal [*"` threw on an invalid expression.

Both now share `SignalPatternMatcher`, which scans the pattern directly — no expression to backtrack, so the ReDoS-shaped inputs the regex version was exposed to are linear. **29 new tests; 15 fail against the previous implementations.**

This also fixes `ExecutionEngine_MultipleMatchingRules_ExecutesAll`, which submitted one order instead of two.

## 3. Negative / Positive Volume Index were wrongly scaled — closes #40

The all-zeros symptom in #40 is long fixed, but the formula it pointed at was not. Fosback compounds the rate of change onto the running index; the code added it as **points**:

| seeded at 1000, +10% day | value |
|---|---|
| before | `1000 + 10` = **1010** |
| after | `1000 + 1000×0.10` = **1100** |

`CalculatePercentChange` returns a percentage rather than a fraction, so the missing piece was `/ 100`. Every move was understated by `prevNVI/100`, compounding across the series — worse than zeros, because the output looks plausible. Fixed in the batch calculations and in all three streaming states that inline the expression, keeping streaming/batch parity. The existing golden tests only asserted `IsFinite`, which a wrongly-scaled series satisfies; **3 new tests fail against the old formula**.

## 4. Alpaca integration tests no longer fail a clean checkout

21 tests hit the live Alpaca API and their helpers fell back to the literals `"test-key"`/`"test-secret"`, so every one failed with `RestClientErrorException : Unauthorized`. They now skip with an actionable message, and still run for real when `ALPACA_API_KEY`/`ALPACA_API_SECRET` are set.

## 5. `appsettings.local.json` was not ignored

It holds real Alpaca and Supabase credentials for local runs and was not covered by `.gitignore`, so routine staging picks it up. Added, along with the other local-secret and `.env` patterns.

## Verification

| | |
|---|---|
| `Release` net10.0 / net8.0 / net461 | `0 Error(s)` each |
| Test suite | **2125 total / 2101 passed / 0 failed / 24 skipped** |

Before this branch: 2093 collected, 22 failing, and none of it running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Schaff Trend Cycle (SHK) and UT Bot Alerts indicators, including streaming support.
  * Added configurable ATR smoothing for Keltner Channels.
  * Added broader framework support for .NET 8, .NET 10, and .NET Framework 4.6.1.

* **Bug Fixes**
  * Corrected Keltner Channel ATR calculations and initialization.
  * Corrected Positive and Negative Volume Index compounding formulas.
  * Improved wildcard signal matching for notifications and automated trading rules.

* **Testing**
  * Added validation coverage for new indicators, volume indexes, Keltner Channels, signal matching, and broker integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->