### PR TITLE
fix: match the batch lookback in ultimatetraderoscillator

### DIFF
--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -2175,6 +2175,18 @@ public sealed class UltimateOscillatorState : IStreamingIndicatorState, IDisposa
 
 public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, IDisposable
 {
+    /// <summary>GetMaxAndMinValuesList clamps its window to a minimum of two.</summary>
+    private const int EnvelopeLength = 2;
+
+    // The batch side feeds each of these series through GetInputValuesList, which has no high or low
+    // for a synthetic series and substitutes a two-bar envelope of the series itself. The stochastic's
+    // own lookback is then applied on top of that, so its effective window is one bar longer than the
+    // lookback asked for. These pairs reproduce that envelope; without them this state used a plain
+    // lookback window and drifted from the batch from bar 15 onward. See issue #167.
+    private readonly RollingWindowMax _trEnvelopeMax;
+    private readonly RollingWindowMin _trEnvelopeMin;
+    private readonly RollingWindowMax _volEnvelopeMax;
+    private readonly RollingWindowMin _volEnvelopeMin;
     private readonly RollingWindowMax _trMax;
     private readonly RollingWindowMin _trMin;
     private readonly RollingWindowMax _volMax;
@@ -2194,6 +2206,10 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
         var resolvedLb = Math.Max(1, lbLength);
         var resolvedRange = Math.Max(1, rangeLength);
         _ = length;
+        _trEnvelopeMax = new RollingWindowMax(EnvelopeLength);
+        _trEnvelopeMin = new RollingWindowMin(EnvelopeLength);
+        _volEnvelopeMax = new RollingWindowMax(EnvelopeLength);
+        _volEnvelopeMin = new RollingWindowMin(EnvelopeLength);
         _trMax = new RollingWindowMax(resolvedLb);
         _trMin = new RollingWindowMin(resolvedLb);
         _volMax = new RollingWindowMax(resolvedLb);
@@ -2217,6 +2233,10 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
         var resolvedLb = Math.Max(1, lbLength);
         var resolvedRange = Math.Max(1, rangeLength);
         _ = length;
+        _trEnvelopeMax = new RollingWindowMax(EnvelopeLength);
+        _trEnvelopeMin = new RollingWindowMin(EnvelopeLength);
+        _volEnvelopeMax = new RollingWindowMax(EnvelopeLength);
+        _volEnvelopeMin = new RollingWindowMin(EnvelopeLength);
         _trMax = new RollingWindowMax(resolvedLb);
         _trMin = new RollingWindowMin(resolvedLb);
         _volMax = new RollingWindowMax(resolvedLb);
@@ -2233,6 +2253,10 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
 
     public void Reset()
     {
+        _trEnvelopeMax.Reset();
+        _trEnvelopeMin.Reset();
+        _volEnvelopeMax.Reset();
+        _volEnvelopeMin.Reset();
         _trMax.Reset();
         _trMin.Reset();
         _volMax.Reset();
@@ -2254,14 +2278,18 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
         var open = bar.Open;
         var prevClose = _hasPrev ? _prevClose : 0;
         var tr = CalculationsHelper.CalculateTrueRange(high, low, prevClose);
-        var trHigh = isFinal ? _trMax.Add(tr, out _) : _trMax.Preview(tr, out _);
-        var trLow = isFinal ? _trMin.Add(tr, out _) : _trMin.Preview(tr, out _);
+        var trEnvelopeHigh = isFinal ? _trEnvelopeMax.Add(tr, out _) : _trEnvelopeMax.Preview(tr, out _);
+        var trEnvelopeLow = isFinal ? _trEnvelopeMin.Add(tr, out _) : _trEnvelopeMin.Preview(tr, out _);
+        var trHigh = isFinal ? _trMax.Add(trEnvelopeHigh, out _) : _trMax.Preview(trEnvelopeHigh, out _);
+        var trLow = isFinal ? _trMin.Add(trEnvelopeLow, out _) : _trMin.Preview(trEnvelopeLow, out _);
         var trRange = trHigh - trLow;
         var trSto = trRange != 0 ? MathHelper.MinOrMax((tr - trLow) / trRange * 100, 100, 0) : 0;
 
         var volume = bar.Volume;
-        var volHigh = isFinal ? _volMax.Add(volume, out _) : _volMax.Preview(volume, out _);
-        var volLow = isFinal ? _volMin.Add(volume, out _) : _volMin.Preview(volume, out _);
+        var volEnvelopeHigh = isFinal ? _volEnvelopeMax.Add(volume, out _) : _volEnvelopeMax.Preview(volume, out _);
+        var volEnvelopeLow = isFinal ? _volEnvelopeMin.Add(volume, out _) : _volEnvelopeMin.Preview(volume, out _);
+        var volHigh = isFinal ? _volMax.Add(volEnvelopeHigh, out _) : _volMax.Preview(volEnvelopeHigh, out _);
+        var volLow = isFinal ? _volMin.Add(volEnvelopeLow, out _) : _volMin.Preview(volEnvelopeLow, out _);
         var volRange = volHigh - volLow;
         var vSto = volRange != 0 ? MathHelper.MinOrMax((volume - volLow) / volRange * 100, 100, 0) : 0;
 
@@ -2306,6 +2334,10 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
 
     public void Dispose()
     {
+        _trEnvelopeMax.Dispose();
+        _trEnvelopeMin.Dispose();
+        _volEnvelopeMax.Dispose();
+        _volEnvelopeMin.Dispose();
         _trMax.Dispose();
         _trMin.Dispose();
         _volMax.Dispose();

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -2202,34 +2202,30 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
 
     public UltimateTraderOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 10,
         int lbLength = 5, int smoothLength = 4, int rangeLength = 2, InputName inputName = InputName.Close)
+        : this(maType, length, lbLength, smoothLength, rangeLength, inputName, null)
     {
-        var resolvedLb = Math.Max(1, lbLength);
-        var resolvedRange = Math.Max(1, rangeLength);
-        _ = length;
-        _trEnvelopeMax = new RollingWindowMax(EnvelopeLength);
-        _trEnvelopeMin = new RollingWindowMin(EnvelopeLength);
-        _volEnvelopeMax = new RollingWindowMax(EnvelopeLength);
-        _volEnvelopeMin = new RollingWindowMin(EnvelopeLength);
-        _trMax = new RollingWindowMax(resolvedLb);
-        _trMin = new RollingWindowMin(resolvedLb);
-        _volMax = new RollingWindowMax(resolvedLb);
-        _volMin = new RollingWindowMin(resolvedLb);
-        _rangeHigh = new RollingWindowMax(resolvedRange);
-        _rangeLow = new RollingWindowMin(resolvedRange);
-        _dxiAvgSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLb);
-        _dxisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _dxissSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
     }
 
     public UltimateTraderOscillatorState(MovingAvgType maType, int length, int lbLength, int smoothLength, int rangeLength,
         Func<OhlcvBar, double> selector)
+        : this(maType, length, lbLength, smoothLength, rangeLength, InputName.Close,
+            selector ?? throw new ArgumentNullException(nameof(selector)))
     {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
+    }
 
+    /// <summary>
+    /// The one place the windows and smoothers are built.
+    /// </summary>
+    /// <remarks>
+    /// The two public constructors differ only in how the input is selected - by name, or by a
+    /// caller-supplied delegate - so everything else was written out twice. Adding the envelope
+    /// windows for issue #167 made that second copy large enough for SonarCloud to fail the
+    /// duplication gate, which is a fair reading: two copies of a construction sequence are two
+    /// places to forget a field the next time one is added.
+    /// </remarks>
+    private UltimateTraderOscillatorState(MovingAvgType maType, int length, int lbLength, int smoothLength,
+        int rangeLength, InputName inputName, Func<OhlcvBar, double>? selector)
+    {
         var resolvedLb = Math.Max(1, lbLength);
         var resolvedRange = Math.Max(1, rangeLength);
         _ = length;
@@ -2246,7 +2242,7 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
         _dxiAvgSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLb);
         _dxisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _dxissSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
+        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.UltimateTraderOscillator;

--- a/tests/StreamingTests/StreamingStatefulParityTests.cs
+++ b/tests/StreamingTests/StreamingStatefulParityTests.cs
@@ -11,6 +11,20 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
     {
         get
         {
+            // Withheld from #166: this diverged from bar 15 because the batch stochastic sees a two-bar
+            // envelope of the true range as its high and low, which widens its lookback by one bar.
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("UltimateTraderOscillator.Uto",
+                    () => new UltimateTraderOscillatorState(),
+                    data => data.CalculateUltimateTraderOscillator().OutputValues["Uto"], "Uto")
+            };
+            yield return new object[]
+            {
+                new StatefulIndicatorSpec("UltimateTraderOscillator.Signal",
+                    () => new UltimateTraderOscillatorState(),
+                    data => data.CalculateUltimateTraderOscillator().OutputValues["Signal"], "Signal")
+            };
             yield return new object[]
             {
                 new StatefulIndicatorSpec("UlcerIndex",


### PR DESCRIPTION
Closes the remaining half of #167 (the HurstCycleChannel half is in #173). **2154 passed, 0 failed.**

## The divergence

The two sides agreed to 1e-14 through bar 14 and then parted:

```
 14   -78.17681247   -78.17681247    -1.42E-014
 15   -73.12893954   -72.88845383    -2.40E-001
```

## The cause is one line

```csharp
var windowLength = Math.Max(length, 2);   // GetMaxAndMinValuesList
```

The batch feeds the true range and the volume through the stochastic by putting each on `CustomValuesList`. `GetInputValuesList` then has no high or low for a synthetic series, so it substitutes a pair derived from the series itself via `GetMaxAndMinValuesList(inputList, 0)` — and that zero is clamped to **two**.

So the high and low the stochastic receives are a **two-bar envelope** of the series rather than the series, and the stochastic's own five-bar lookback is applied on top of it.

Verified rather than reasoned:

```
high/low substituted for a chained series equals the series itself?  False
  i=1  tr=3.8200  high=5.1700  max(tr[i-1],tr[i])=5.1700

5-bar max of the 2-bar max == 6-bar max of raw?  True
...                       == plain 5-bar max?    False
```

The batch's effective window is **six** bars where five were asked for; the streaming state used a plain five. Bars 0–14 matched because the extreme happened to fall inside both windows — bar 15 is where the sixth bar back first became the extreme.

## The fix

The state applies the same two-bar envelope before its lookback, to both the true range and the volume. Measured against the batch over 200 bars:

```
max |batch - stream|   Uto 4.7e-12   Signal 8.1e-12
```

The parity specs withheld from #166 are added and pass.

## Deliberately not addressed

Whether a two-bar envelope is the right stand-in for a synthetic series' high and low is a separate and **wider** question: every indicator that chains a series into something using highs and lows inherits it, and each gets a lookback one bar longer than it asked for. Changing that would move published values across many indicators, so it needs its own decision. This makes the two sides agree on what the library currently computes.

Also ruled out along the way, and worth recording so nobody re-checks them: `CustomValuesList` contamination (this method sets the series it wants, correctly), the first-bar true range, the smoothing chain's shape, the `length` parameter (unused on both sides), and the weighted moving average itself — `MovingAverageCore.WeightedMovingAverage` and `WmaState` look different but produce identical numerators and sums at every index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5
