### PR TITLE
ci: stop dependabot re-proposing the roslyn floor bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,27 @@ updates:
     # Deliberately no `ignore` rule for major updates. The test-tooling majors that came through
     # recently - coverlet 6 to 10, Microsoft.NET.Test.Sdk 17 to 18, FluentAssertions 6 to 8 - are
     # exactly the updates this repository has been taking, so suppressing majors would hide them.
+    #
+    # The two exceptions below are not ordinary dependencies. The source generator's Roslyn
+    # reference is a COMPATIBILITY FLOOR: csc refuses to load an analyzer built against a Roslyn
+    # newer than itself (CS9057), so this reference decides the minimum .NET SDK anyone building
+    # this repository from source is forced onto.
+    #
+    # This has already happened once. PR #155 took the 4.8.0 -> 5.9.0 bump as routine, CI stayed
+    # green because it resolves 10.x to the newest SDK, and the repository silently stopped
+    # building on SDK 10.0.1xx - breaking a downstream production deployment. PR #179 was the bot
+    # proposing exactly the same change again, caught only by SourceGeneratorRoslynFloorTests.
+    #
+    # Ignored at every version rather than pinned to a range, because a bump above the floor breaks
+    # source consumers and a bump below it buys nothing. Both carry PrivateAssets="all" and the
+    # published package ships no analyzer, so nothing here reaches a package consumer at runtime.
+    #
+    # To raise the floor deliberately, remove these entries, change the constants in
+    # SourceGeneratorRoslynFloorTests, and say in the commit message which SDK becomes the new
+    # minimum - it is a breaking change for source consumers and should read like one.
+    ignore:
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      - dependency-name: "Microsoft.CodeAnalysis.Analyzers"
 
   # GitHub Actions updates. The workflows pin actions to a commit SHA, which is the safe way to use
   # a third-party action but also freezes it - nothing tells you an update exists. Dependabot is

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -20,8 +20,13 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+# Keyed on the pull request, not github.ref. Under pull_request_target github.ref is the BASE branch,
+# so every open PR shared one group and cancel-in-progress cancelled each other's runs: updating
+# four branches from master at once left three of them with a cancelled title check, which reads
+# as a failure. Superseding a run for the SAME PR - a second push, an edited title - is still the
+# intent, and the PR number gives exactly that.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## What

Adds a dependabot `ignore` rule for `Microsoft.CodeAnalysis.CSharp` and
`Microsoft.CodeAnalysis.Analyzers` in the NuGet ecosystem.

## Why

The source generator's Roslyn reference is a **compatibility floor**, not an ordinary dependency.
`csc` refuses to load an analyzer built against a Roslyn newer than itself:

```
CSC : error CS9057: Analyzer assembly '...SourceGeneration.dll' cannot be used because it
      references version '5.9.0.0' of the compiler, which is newer than the currently running
      version '5.0.0.0'
```

So that one reference decides the minimum .NET SDK anyone building this repository from source is
forced onto.

**This has already cost a production deployment.** PR #155 took the 4.8.0 -> 5.9.0 bump as routine.
CI stayed green - it resolves `10.x` to the newest SDK - and the repository silently stopped building
on SDK 10.0.1xx, whose compiler is 5.0.

PR #179 is the bot proposing the identical change again, and the only thing that stopped it was
`SourceGeneratorRoslynFloorTests` failing. That test is doing its job, but a guard that fires every
release is not the same as the change not being proposed: it leaves a standing queue of PRs that look
like routine dependency hygiene and are not.

## Choices

**Ignored at every version, not pinned to a range.** A bump above the floor breaks source consumers;
one below it buys nothing. There is no useful window.

**Security exposure is nil.** Both references carry `PrivateAssets="all"`, and the published NuGet
package ships no analyzer - the generator's output is compiled into `lib/*.dll`. Nothing here reaches
a package consumer at runtime.

**Raising the floor stays possible, just deliberate.** Remove these entries, change the constants in
`SourceGeneratorRoslynFloorTests`, and say in the commit message which SDK becomes the new minimum.
It is a breaking change for source consumers and should read like one.

## Consequence for #179

#179 cannot be made green without lowering the floor, which is the thing that must not happen. It
should be closed rather than fixed - flagged there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to exclude selected Roslyn packages from automated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->