### PR TITLE
feat!: let every indicator take custom values in both engines

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -150,6 +150,45 @@ var handle = indicators.Calculate(
 
 ## Breaking Changes
 
+### Custom input: one mechanism for every streaming indicator
+
+Every streaming state used to take custom input through its own selector constructor -
+`new RsiState(14, bar => ...)` - and 82 of them had none, so some indicators could not take custom
+values at all. Those per-state selector constructors are removed. `CustomInputState` wraps any state
+instead, and ready-made `InputSeries` presets are named after the input names they replace.
+
+```csharp
+// Before
+var rsi = new RelativeStrengthIndexState(14, 3, bar => (bar.High + bar.Low) / 2);
+
+// After - a preset
+var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.MedianPrice);
+
+// After - any function of the bar
+var rsi = new CustomInputState(new RelativeStrengthIndexState(14), bar => (bar.High + bar.Low) / 2);
+
+// After - another indicator's output (streaming chaining)
+var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.Of(new MidpointState(14)));
+```
+
+The same presets work in batch, where `UseInput` chains a series:
+
+```csharp
+var rsi = stockData.UseInput(InputSeries.MedianPrice).CalculateRelativeStrengthIndex(length: 14);
+```
+
+| Input | Preset |
+|---|---|
+| close, adjusted close, open, high, low, volume | `InputSeries.Close`, `.AdjustedClose`, `.Open`, `.High`, `.Low`, `.Volume` |
+| median, typical, full typical, weighted close, average price | `InputSeries.MedianPrice`, `.TypicalPrice`, `.FullTypicalPrice`, `.WeightedClose`, `.AveragePrice` |
+| midpoint, midprice over *n* bars | `InputSeries.Midpoint(n)`, `InputSeries.Midprice(n)` |
+| any function of the bar | `InputSeries.Of(bar => ...)` |
+| another indicator's output | `InputSeries.Of(state)` |
+
+A custom series changes more than the close: when its value lies outside the bar's range, the
+indicator's high and low come from the series itself (the max and min of its previous and current
+value). Batch applies the same rule to a chained series, so the two engines give the same numbers.
+
 ### Removed
 
 - None - all v1.x methods are still available (will be deprecated in v3.0)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -281,6 +281,19 @@ the indicator's published definition, so **some batch values change**:
   with it on, and only `CustomValuesList` is empty. `Clear()` gives the data a new, empty series rather
   than emptying the list in place, so a list you kept from an earlier result survives it; setting
   `CustomValuesList` to null now reads back as an empty list.
+- **`IncludeOutputValues = false` and `RoundingDigits` change only what is published**, the same way
+  (`IncludeOutputValuesTests`, `RoundingDigitsTests`). With output values off, 56 indicators threw reading a
+  component's named series from the emptied dictionary; it is now replaced rather than cleared in place.
+  With rounding on, 187 indicators computed on rounded values - a component's result, or an intermediate
+  series handed on as input - so their final digits were the rounding of a different computation. Every
+  indicator now computes on unrounded values and rounds only what it publishes.
+- **Four indicators take each component of the price, as they are defined.** Each component call publishes
+  its result for the next one, and these called the next component without handing back the caller's series;
+  their streaming states copied the chain. CCT StochRSI took every RSI after the first of the RSI before it,
+  the Fast and Slow RSI Oscillator took its kurtosis term of the RSI, and the Sector Rotation Model took its
+  second rate of change of the first. Connors RSI ranked a 100-bar rate of change of the RSI; it ranks the
+  one-bar rate of change of the price over 100 bars, as Connors defines it, and the Stochastic Connors RSI and
+  Quasi White Noise built on it follow.
 - **Adaptive Ehlers windows take a cycle within float noise of an integer as that integer** before
   rounding up to whole bars. A dominant cycle of exactly 29 in exact arithmetic could arrive as
   29.000000000000004 and average over 30 bars, and which side it fell depended on summation order. Values

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -274,12 +274,32 @@ the indicator's published definition, so **some batch values change**:
   origin; Chande Forecast, the standard deviation channel, Inertia and Projection Bands follow. Correlation is taken from each value's distance to the window mean, so a
   window with one side constant correlates at 0 rather than a rounding residue of either sign; the
   Periodic Channel sums that sign. Otherwise values change only in their last digits.
+- **`IncludeCustomValues = false` hides a result without changing any.** It used to empty the one list
+  that both the caller and the next calculation read, so a chain ran on the close, 176 indicators threw
+  and the Accelerator, Derivative and McClellan oscillators computed other values
+  (`IncludeCustomValuesTests`). Every indicator now computes with the option off exactly what it computes
+  with it on, and only `CustomValuesList` is empty. `Clear()` gives the data a new, empty series rather
+  than emptying the list in place, so a list you kept from an earlier result survives it; setting
+  `CustomValuesList` to null now reads back as an empty list.
+- **Adaptive Ehlers windows take a cycle within float noise of an integer as that integer** before
+  rounding up to whole bars. A dominant cycle of exactly 29 in exact arithmetic could arrive as
+  29.000000000000004 and average over 30 bars, and which side it fell depended on summation order. Values
+  move only on bars where the cycle sat within a relative 1e-9 of an integer.
 
 Streaming-only corrections (batch unchanged): the first bar's true range in the ATR channels, Stoller
 channels, dynamic support/resistance, Bollinger Fibonacci ratios, Hurst cycle channel, trend trader bands,
 VMA bands, Trender and the volume positive/negative indicator; the Time Price Indicator's band offset; the
 defaults of the Ergodic Mean Deviation Indicator (signal length 5) and Quadratic Least Squares MA (length
-50); VIDYA's seed; and the Trend Analysis Index, Trender and Vervoort Smoothed Oscillator deviations.
+50); VIDYA's seed; and the Trend Analysis Index, Trender and Vervoort Smoothed Oscillator deviations. The
+first bar's true range in the Grover Llorens Cycle Oscillator and the Ultimate Trader Oscillator is also
+High - Low now, not the whole high.
+
+A preview (`isFinal: false`) of a bar now publishes what that bar publishes once final
+(`StreamingPreviewTests`, every state). Nine did not: ALMA, Interquartile Range Bands and Trimean left the
+forming bar out of their window; Alligator, Gator and the Ehlers Fractal Adaptive Moving Average read their
+displaced value a bar late; and Connors RSI, with the Stochastic Connors RSI and Quasi White Noise built on
+it, ranked the forming value against a value the commit evicts. The autocorrelation periodogram behind the
+adaptive Ehlers indicators divided the previous bar's powers by the forming bar's maximum.
 
 `BollingerBandsState` takes an optional `maType`, and `CalculateVolatilityIndexDynamicAverageIndicator` is
 the batch twin of the streaming state of the same name.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -189,6 +189,43 @@ A custom series changes more than the close: when its value lies outside the bar
 indicator's high and low come from the series itself (the max and min of its previous and current
 value). Batch applies the same rule to a chained series, so the two engines give the same numbers.
 
+### InputName is removed
+
+Callers pass values, not a name for them. `InputName` is gone from every indicator constructor, every
+`Calculate*` method, `StockData`, and the streaming options. An indicator built with no input named reads
+exactly what it read by default before; to compute it on something else, pass the series.
+
+```csharp
+// Streaming - default input: just drop the argument
+var cci = new CommodityChannelIndexState(InputName.TypicalPrice, MovingAvgType.SimpleMovingAverage, 20); // before
+var cci = new CommodityChannelIndexState(MovingAvgType.SimpleMovingAverage, 20);                         // after
+
+// Streaming - a different input: wrap the state
+var cci = new CustomInputState(new CommodityChannelIndexState(), InputSeries.MedianPrice);
+
+// Batch - default input: just drop the argument
+var ao = data.CalculateAwesomeOscillator(MovingAvgType.SimpleMovingAverage, InputName.MedianPrice); // before
+var ao = data.CalculateAwesomeOscillator(MovingAvgType.SimpleMovingAverage);                         // after
+
+// Batch - a different input: chain it
+var ao = data.UseInput(InputSeries.TypicalPrice).CalculateAwesomeOscillator();
+```
+
+| Removed | Replacement |
+|---|---|
+| `InputName` parameter on a streaming state | drop it for the default; `new CustomInputState(state, InputSeries.X)` otherwise |
+| `inputName` parameter on a `Calculate*` method | drop it for the default; `data.UseInput(InputSeries.X).CalculateY()` otherwise |
+| `new StockData(tickers, InputName.X)` and `StockData.InputName` | `new StockData(tickers).UseInput(InputSeries.X)` |
+| `StreamingOptions.InputName`, `IndicatorSubscriptionOptions.InputName` | a `CustomInputState` per indicator |
+| `VolumeFlowIndicatorSpecOptions(inputName, ...)` | nothing - it was never read |
+| the `InputName` enum, `StreamingInputSelector`, `GetInputValuesList(InputName, StockData)` | now internal; name a series with `InputSeries` |
+
+**This can change results, in the direction of correctness.** `StockData`'s input name was stored and then
+ignored by about 650 indicators: `new StockData(tickers, InputName.MedianPrice).CalculateRsi()` computed an
+RSI of the close (#182). `new StockData(tickers).UseInput(InputSeries.MedianPrice).CalculateRsi()` really
+computes it on the median price. The same holds for the two streaming options, which fed that same ignored
+value, and for `VolumeFlowIndicatorSpecOptions`, whose input name no calculation ever read.
+
 ### Removed
 
 - None - all v1.x methods are still available (will be deprecated in v3.0)

--- a/benchmarks/OoplesFinance.StockIndicators.Benchmarks/BenchmarkDataFactory.cs
+++ b/benchmarks/OoplesFinance.StockIndicators.Benchmarks/BenchmarkDataFactory.cs
@@ -61,8 +61,7 @@ internal static class BenchmarkDataFactory
             data.LowPrices,
             data.ClosePrices,
             data.Volumes,
-            data.Dates,
-            InputName.Close);
+            data.Dates);
     }
 
     public static void Reset(StockData stockData)
@@ -71,7 +70,6 @@ internal static class BenchmarkDataFactory
         stockData.OutputValues = new Dictionary<string, List<double>>();
         stockData.SignalsList = new List<Signal>();
         stockData.InputValues = stockData.ClosePrices;
-        stockData.InputName = InputName.Close;
         stockData.IndicatorName = IndicatorName.None;
     }
 

--- a/benchmarks/OoplesFinance.StockIndicators.Benchmarks/StreamingPerformanceRunner.cs
+++ b/benchmarks/OoplesFinance.StockIndicators.Benchmarks/StreamingPerformanceRunner.cs
@@ -137,8 +137,7 @@ public static class StreamingPerformanceRunner
         var subscriptionOptions = new IndicatorSubscriptionOptions
         {
             IncludeUpdates = true,
-            IncludeOutputValues = includeOutputs,
-            InputName = InputName.Close
+            IncludeOutputValues = includeOutputs
         };
 
         var updateCount = 0L;

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketches.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketches.cs
@@ -370,7 +370,7 @@ internal static class FacadeSketches
 
         private static StockData CloneWithCustomValues(StockData baseData, List<double> customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = customValues

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV2.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV2.cs
@@ -418,7 +418,7 @@ internal static class FacadeSketchesV2
 
         private static StockData CloneWithCustomValues(StockData baseData, List<double> customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = customValues

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV3.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV3.cs
@@ -583,7 +583,7 @@ internal static class FacadeSketchesV3
 
         private static StockData CloneWithCustomValues(StockData baseData, double[] customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = new List<double>(customValues)

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV4.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV4.cs
@@ -1237,7 +1237,7 @@ internal static class FacadeSketchesV4
 
         private static StockData CloneWithCustomValues(StockData baseData, double[] customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = new List<double>(customValues)

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV5.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV5.cs
@@ -1280,7 +1280,7 @@ internal static class FacadeSketchesV5
 
         private static StockData CloneWithCustomValues(StockData baseData, double[] customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = new List<double>(customValues)

--- a/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV6.cs
+++ b/examples/OoplesFinance.StockIndicators.DevConsole/FacadeSketchesV6.cs
@@ -2319,7 +2319,7 @@ internal static class FacadeSketchesV6
 
         private static StockData CloneWithCustomValues(StockData baseData, double[] customValues)
         {
-            var clone = new StockData(baseData.TickerDataList, baseData.InputName)
+            var clone = new StockData(baseData.TickerDataList)
             {
                 Options = baseData.Options,
                 CustomValuesList = new List<double>(customValues)

--- a/src/Builder/Compute/IndicatorCompute.cs
+++ b/src/Builder/Compute/IndicatorCompute.cs
@@ -1152,7 +1152,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1167,7 +1167,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1182,7 +1182,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1197,7 +1197,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDemaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1212,7 +1212,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTemaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1227,7 +1227,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1242,7 +1242,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1257,7 +1257,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWwmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1272,7 +1272,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinRegFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1287,7 +1287,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeKamaFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1302,7 +1302,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeZlemaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1321,7 +1321,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRsiFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1336,7 +1336,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRocFast(StockData data, ComputeContext context, int length = 12)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1351,7 +1351,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMomentumFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1474,7 +1474,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCmoFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1489,7 +1489,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePpoFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1504,7 +1504,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeApoFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -1539,7 +1539,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTsiFast(StockData data, ComputeContext context, int longLength = 25, int shortLength = 13)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.TrueStrengthIndex(inputSpan, buffer.WritableSpan, longLength, shortLength);
@@ -1551,7 +1551,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeStochRsiFast(StockData data, ComputeContext context, int rsiLength = 14, int stochLength = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.StochasticRsi(inputSpan, buffer.WritableSpan, rsiLength, stochLength);
@@ -1582,7 +1582,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDpoFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DetrendedPriceOscillator(inputSpan, buffer.WritableSpan, length);
@@ -1594,7 +1594,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrixFast(StockData data, ComputeContext context, int length = 15)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.Trix(inputSpan, buffer.WritableSpan, length);
@@ -1892,7 +1892,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeStdDevFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(inputList.Count);
@@ -2087,7 +2087,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePercentageChangeFast(StockData data, ComputeContext context, int length = 1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.PercentageChange(inputSpan, buffer.WritableSpan, length);
@@ -2099,7 +2099,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinRegSlopeFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.LinearRegressionSlope(inputSpan, buffer.WritableSpan, length);
@@ -2111,7 +2111,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRSquaredFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.RSquared(inputSpan, buffer.WritableSpan, length);
@@ -2123,7 +2123,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeStandardErrorFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.StandardError(inputSpan, buffer.WritableSpan, length);
@@ -2135,7 +2135,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVhfFast(StockData data, ComputeContext context, int length = 28)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.VerticalHorizontalFilter(inputSpan, buffer.WritableSpan, length);
@@ -2151,7 +2151,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHistoricalVolatilityFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         VolatilityCore.HistoricalVolatility(inputSpan, buffer.WritableSpan, length);
@@ -2182,7 +2182,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeUlcerIndexFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         VolatilityCore.UlcerIndex(inputSpan, buffer.WritableSpan, length);
@@ -2215,7 +2215,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVarianceFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         VolatilityCore.Variance(inputSpan, buffer.WritableSpan, length);
@@ -2227,7 +2227,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCoefficientOfVariationFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         VolatilityCore.CoefficientOfVariation(inputSpan, buffer.WritableSpan, length);
@@ -2261,7 +2261,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeBollingerBandsFast(StockData data, ComputeContext context, int length = 20, MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         // Use the registry to compute the MA with the specified type
@@ -2283,7 +2283,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeBollingerUpperFast(StockData data, ComputeContext context, int length = 20, double multiplier = 2, MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         // Rent temp buffers for middle and lower that we don't need
@@ -2300,7 +2300,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeBollingerLowerFast(StockData data, ComputeContext context, int length = 20, double multiplier = 2, MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         // Rent temp buffers for upper and middle that we don't need
@@ -2475,7 +2475,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeKeltnerChannelMiddleFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.KeltnerChannelMiddle(inputSpan, buffer.WritableSpan, length);
@@ -2487,7 +2487,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrendDetectionFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.TrendDetection(inputSpan, buffer.WritableSpan, length);
@@ -2617,7 +2617,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeConnorsRsiFast(StockData data, ComputeContext context, int length = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ConnorsRsi(inputSpan, buffer.WritableSpan, length);
@@ -2629,7 +2629,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePmoFast(StockData data, ComputeContext context, int length = 35)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PriceMomentumOscillator(inputSpan, buffer.WritableSpan, length);
@@ -2642,7 +2642,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeKstFast(StockData data, ComputeContext context, int length = 10)
     {
         _ = length;
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.KnowSureThing(inputSpan, buffer.WritableSpan);
@@ -2654,7 +2654,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePercentRankFast(StockData data, ComputeContext context, int length = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PercentRank(inputSpan, buffer.WritableSpan, length);
@@ -2691,7 +2691,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSmmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SmoothedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -2703,7 +2703,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMcGinleyDynamicFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.McGinleyDynamic(inputSpan, buffer.WritableSpan, length);
@@ -2715,7 +2715,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeT3Fast(StockData data, ComputeContext context, int length = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.T3MovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -2727,7 +2727,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVidyaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.Vidya(inputSpan, buffer.WritableSpan, length);
@@ -2739,7 +2739,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VariableMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -2751,7 +2751,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMacdLineFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.MacdLine(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -2763,7 +2763,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMacdSignalFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26, int signalLength = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.MacdSignal(inputSpan, buffer.WritableSpan, fastLength, slowLength, signalLength);
@@ -2775,7 +2775,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMacdHistogramFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26, int signalLength = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.MacdHistogram(inputSpan, buffer.WritableSpan, fastLength, slowLength, signalLength);
@@ -2798,7 +2798,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRelativeMomentumIndexFast(StockData data, ComputeContext context, int length = 14, int momentum = 4)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.RelativeMomentumIndex(inputSpan, buffer.WritableSpan, length, momentum);
@@ -2851,7 +2851,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeCoppockCurveFast(StockData data, ComputeContext context, int length = 14)
     {
         _ = length; // Coppock uses fixed parameters internally
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.CoppockCurve(inputSpan, buffer.WritableSpan);
@@ -2863,7 +2863,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeForecastOscillatorFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeForecastOscillator(inputSpan, buffer.WritableSpan, length);
@@ -2910,7 +2910,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSchaffTrendCycleFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.SchaffTrendCycle(inputSpan, buffer.WritableSpan, length);
@@ -2982,7 +2982,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeSpecialKFast(StockData data, ComputeContext context, int length = 14)
     {
         _ = length; // Special K uses fixed parameters
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.SpecialK(inputSpan, buffer.WritableSpan);
@@ -2994,7 +2994,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAlmaFast(StockData data, ComputeContext context, int length = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ArnaudLegouxMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3006,7 +3006,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLsmaFast(StockData data, ComputeContext context, int length = 25)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3031,7 +3031,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAmaFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.AdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3043,7 +3043,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSineWmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SineWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3055,7 +3055,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHammingMaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HammingMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3067,7 +3067,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeGeoMaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.GeometricMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -3079,7 +3079,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRegularizedEmaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.RegularizedEma(inputSpan, buffer.WritableSpan, length);
@@ -3091,7 +3091,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeModifiedMaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ModifiedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -4465,7 +4465,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeBollingerBandsPercentBFast(StockData data, ComputeContext context, int length = 20, double multiplier = 2)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         VolatilityCore.BollingerBandsPercentB(inputSpan, buffer.WritableSpan, length, multiplier);
@@ -4494,7 +4494,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeMomentumOscillatorAbsoluteFast(StockData data, ComputeContext context, int length = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeMomentumOscillatorAbsolute(inputSpan, buffer.WritableSpan, length);
@@ -4506,7 +4506,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePercentChangeFast(StockData data, ComputeContext context, int length = 1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PercentChange(inputSpan, buffer.WritableSpan, length);
@@ -4518,7 +4518,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePriceChangeFast(StockData data, ComputeContext context)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PriceChange(inputSpan, buffer.WritableSpan);
@@ -4581,7 +4581,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDoubleSmoothedMomentaFast(StockData data, ComputeContext context, int momentumLength = 1, int firstSmooth = 25, int secondSmooth = 13)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DoubleSmoothedMomenta(inputSpan, buffer.WritableSpan, momentumLength, firstSmooth, secondSmooth);
@@ -4620,7 +4620,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrendScoreFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.TrendScore(inputSpan, buffer.WritableSpan, length);
@@ -4632,7 +4632,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMedianValueFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.MedianValue(inputSpan, buffer.WritableSpan, length);
@@ -4644,7 +4644,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLogReturnsFast(StockData data, ComputeContext context, int length = 1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.LogReturns(inputSpan, buffer.WritableSpan, length);
@@ -4656,7 +4656,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSimpleReturnsFast(StockData data, ComputeContext context, int length = 1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.SimpleReturns(inputSpan, buffer.WritableSpan, length);
@@ -4668,7 +4668,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCumulativeSumFast(StockData data, ComputeContext context)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.CumulativeSum(inputSpan, buffer.WritableSpan);
@@ -4680,7 +4680,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRollingMaxFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.RollingMax(inputSpan, buffer.WritableSpan, length);
@@ -4692,7 +4692,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRollingMinFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.RollingMin(inputSpan, buffer.WritableSpan, length);
@@ -4730,7 +4730,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeMomentumOscillatorAbsoluteAverageFast(StockData data, ComputeContext context, int length = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeMomentumOscillatorAbsoluteAverage(inputSpan, buffer.WritableSpan, length, 5);
@@ -4742,7 +4742,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeMomentumOscillatorAverageFast(StockData data, ComputeContext context, int length = 9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeMomentumOscillatorAverage(inputSpan, buffer.WritableSpan, length, 5);
@@ -4780,7 +4780,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeComparePriceMomentumOscillatorFast(StockData data, ComputeContext context, int length = 35)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ComparePriceMomentumOscillator(inputSpan, buffer.WritableSpan, length, 10, 10);
@@ -4792,7 +4792,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDailyAveragePriceDeltaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DailyAveragePriceDelta(inputSpan, buffer.WritableSpan, length);
@@ -4818,7 +4818,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDoubleSmoothedRelativeStrengthIndexFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DoubleSmoothedRelativeStrengthIndex(inputSpan, buffer.WritableSpan, length, 5);
@@ -4830,7 +4830,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDynamicMomentumOscillatorFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DynamicMomentumOscillator(inputSpan, buffer.WritableSpan, length, 5);
@@ -4869,7 +4869,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCCTStochRelativeStrengthIndexFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.CCTStochRsi(inputSpan, buffer.WritableSpan, length, 5, 3);
@@ -6677,7 +6677,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAdaptiveAutonomousRecursiveMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.AdaptiveAutonomousRecursiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6689,7 +6689,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCorrectedMovingAverageFast(StockData data, ComputeContext context, int length = 35)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.CorrectedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6701,7 +6701,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCubedWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.CubedWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6713,7 +6713,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDynamicallyAdjustableFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.DynamicallyAdjustableFilter(inputSpan, buffer.WritableSpan, length);
@@ -6725,7 +6725,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEdgePreservingFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EdgePreservingFilter(inputSpan, buffer.WritableSpan, length);
@@ -6737,7 +6737,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersAllPassPhaseShifterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersAllPassPhaseShifter(inputSpan, buffer.WritableSpan, length);
@@ -6749,7 +6749,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersAverageErrorFilterFast(StockData data, ComputeContext context, int length = 27)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersAverageErrorFilter(inputSpan, buffer.WritableSpan, length);
@@ -6761,7 +6761,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersDistanceCoefficientFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersDistanceCoefficientFilter(inputSpan, buffer.WritableSpan, length);
@@ -6773,7 +6773,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersKaufmanAdaptiveMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersKaufmanAdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6785,7 +6785,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersModifiedOptimumEllipticFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersModifiedOptimumEllipticFilter(inputSpan, buffer.WritableSpan, length);
@@ -6797,7 +6797,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersNoiseEliminationTechnologyFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersNoiseEliminationTechnology(inputSpan, buffer.WritableSpan, length);
@@ -6809,7 +6809,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersOptimumEllipticFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersOptimumEllipticFilter(inputSpan, buffer.WritableSpan, length);
@@ -6821,7 +6821,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersVariableIndexDynamicAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersVariableIndexDynamicAverage(inputSpan, buffer.WritableSpan, length);
@@ -6833,7 +6833,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeFallingRisingFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.FallingRisingFilter(inputSpan, buffer.WritableSpan, length);
@@ -6845,7 +6845,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeFareySequenceWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.FareySequenceWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6857,7 +6857,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeFisherLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.FisherLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6869,7 +6869,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeFollowingAdaptiveMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.FollowingAdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6881,7 +6881,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeGeneralFilterEstimatorFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.GeneralFilterEstimator(inputSpan, buffer.WritableSpan, length);
@@ -6893,7 +6893,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHendersonWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 7)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HendersonWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6905,7 +6905,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHullEstimateFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HullEstimate(inputSpan, buffer.WritableSpan, length);
@@ -6917,7 +6917,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHybridConvolutionFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HybridConvolutionFilter(inputSpan, buffer.WritableSpan, length);
@@ -6929,7 +6929,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeIIRLeastSquaresEstimateFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.IIRLeastSquaresEstimate(inputSpan, buffer.WritableSpan, length);
@@ -6941,7 +6941,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeInverseDistanceWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.InverseDistanceWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6953,7 +6953,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeInverseFisherTransformCoreFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.InverseFisherTransform(inputSpan, buffer.WritableSpan, length);
@@ -6965,7 +6965,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeJsaMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.JsaMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -6977,7 +6977,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeKalmanSmootherFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.KalmanSmoother(inputSpan, buffer.WritableSpan, length);
@@ -6989,7 +6989,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeKaufmanAdaptiveLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.KaufmanAdaptiveLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7001,7 +7001,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLeoMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LeoMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7013,7 +7013,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLightLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 250)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LightLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7025,7 +7025,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearExtrapolationFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LinearExtrapolation(inputSpan, buffer.WritableSpan, length);
@@ -7037,7 +7037,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearRegressionLineFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LinearRegressionLine(inputSpan, buffer.WritableSpan, length);
@@ -7049,7 +7049,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearWeightedMovingAverageCoreFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.LinearWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7061,7 +7061,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMcNichollMovingAverageFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.McNichollMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7073,7 +7073,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMovingAverageAdaptiveQFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.MovingAverageAdaptiveQ(inputSpan, buffer.WritableSpan, length);
@@ -7085,7 +7085,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMovingAverageV3Fast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.MovingAverageV3(inputSpan, buffer.WritableSpan, length);
@@ -7097,7 +7097,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeOneLCLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 32)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.OneLCLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7109,7 +7109,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeOptimalWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.OptimalWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7121,7 +7121,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeOvershootReductionMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.OvershootReductionMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7133,7 +7133,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeParametricCorrectiveLinearMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ParametricCorrectiveLinearMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7145,7 +7145,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeParametricKalmanFilterFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ParametricKalmanFilter(inputSpan, buffer.WritableSpan, length);
@@ -7161,7 +7161,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeZeroLowLagMovingAverageFast(StockData data, ComputeContext context, int length = 32)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ZeroLowLagMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7173,7 +7173,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRecursiveMovingTrendAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.RecursiveMovingTrendAverage(inputSpan, buffer.WritableSpan, length);
@@ -7185,7 +7185,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrimeanFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.Trimean(inputSpan, buffer.WritableSpan, length);
@@ -7197,7 +7197,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSkewnessFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.Skewness(inputSpan, buffer.WritableSpan, length);
@@ -7209,7 +7209,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHampelFilterFast(StockData data, ComputeContext context, int length = 14, double scalingFactor = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HampelFilter(inputSpan, buffer.WritableSpan, length, scalingFactor);
@@ -7221,7 +7221,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeModularFilterFast(StockData data, ComputeContext context, int length = 200, double beta = 0.8, double z = 0.5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ModularFilter(inputSpan, buffer.WritableSpan, length, beta, z);
@@ -7233,7 +7233,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDynamicallyAdjustableMovingAverageFast(StockData data, ComputeContext context, int fastLength = 6, int slowLength = 200)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.DynamicallyAdjustableMovingAverage(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -7245,7 +7245,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEquityMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var volume = SpanCompat.AsReadOnlySpan(data.Volumes);
         var buffer = context.Rent(inputList.Count);
@@ -7258,7 +7258,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMultiDepthZeroLagExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.MultiDepthZeroLagExponentialMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7270,7 +7270,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePolynomialLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.PolynomialLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7282,7 +7282,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePoweredKaufmanAdaptiveMovingAverageFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.PoweredKaufmanAdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7294,7 +7294,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeQuadraticLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.QuadraticLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7306,7 +7306,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeQuadraticMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.QuadraticMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7318,7 +7318,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeQuadraticRegressionFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.QuadraticRegression(inputSpan, buffer.WritableSpan, length);
@@ -7330,7 +7330,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeR2AdaptiveRegressionFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.R2AdaptiveRegression(inputSpan, buffer.WritableSpan, length);
@@ -7342,7 +7342,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRetentionAccelerationFilterFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.RetentionAccelerationFilter(inputSpan, buffer.WritableSpan, length);
@@ -7354,7 +7354,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRightSidedRickerMovingAverageFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.RightSidedRickerMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7366,7 +7366,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSelfWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SelfWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7378,7 +7378,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSequentiallyFilteredMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SequentiallyFilteredMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7390,7 +7390,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSettingLessTrendStepFilteringFast(StockData data, ComputeContext context, int length = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SettingLessTrendStepFiltering(inputSpan, buffer.WritableSpan, length);
@@ -7402,7 +7402,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeShapeshiftingMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ShapeshiftingMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7414,7 +7414,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSharpModifiedMovingAverageFast(StockData data, ComputeContext context, int length = 7)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SharpModifiedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7426,7 +7426,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSimplifiedLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 25)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SimplifiedLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7438,7 +7438,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSimplifiedWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.SimplifiedWeightedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7450,7 +7450,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSvamaFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.Svama(inputSpan, buffer.WritableSpan, length);
@@ -7462,7 +7462,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeThreeHMAFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ThreeHMA(inputSpan, buffer.WritableSpan, length);
@@ -7474,7 +7474,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTillsonIE2Fast(StockData data, ComputeContext context, int length = 15)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.TillsonIE2(inputSpan, buffer.WritableSpan, length);
@@ -7486,7 +7486,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTStepLeastSquaresMovingAverageFast(StockData data, ComputeContext context, int length = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.TStepLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7498,7 +7498,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVariableAdaptiveMovingAverageFast(StockData data, ComputeContext context, int length = 6)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VariableAdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7510,7 +7510,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVariableLengthMovingAverageFast(StockData data, ComputeContext context, int length = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VariableLengthMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7522,7 +7522,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVerticalHorizontalMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VerticalHorizontalMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7534,7 +7534,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVolatilityMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VolatilityMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7546,7 +7546,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVolatilityWaveMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.VolatilityWaveMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7558,7 +7558,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWellRoundedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.WellRoundedMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7570,7 +7570,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWildersSummationMethodFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.WildersSummationMethod(inputSpan, buffer.WritableSpan, length);
@@ -7582,7 +7582,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeZeroLagTripleExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ZeroLagTripleExponentialMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7648,7 +7648,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVolumeWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var volume = SpanCompat.AsReadOnlySpan(data.Volumes);
         var buffer = context.Rent(inputList.Count);
@@ -7675,7 +7675,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersChebyshevLowPassFilterFast(StockData data, ComputeContext context, int length = 14, double ripple = 0.5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersChebyshevLowPassFilter(inputSpan, buffer.WritableSpan, length, ripple);
@@ -7687,7 +7687,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersGaussianFilterFast(StockData data, ComputeContext context, int length = 14, int poles = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersGaussianFilter(inputSpan, buffer.WritableSpan, length, poles);
@@ -7699,7 +7699,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersMedianAverageAdaptiveFilterFast(StockData data, ComputeContext context, int length = 39, double threshold = 0.002)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersMedianAverageAdaptiveFilter(inputSpan, buffer.WritableSpan, length, threshold);
@@ -7711,7 +7711,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersMesaAdaptiveMovingAverageFast(StockData data, ComputeContext context, int length = 14, double fastLimit = 0.5, double slowLimit = 0.05)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersMesaAdaptiveMovingAverage(inputSpan, buffer.WritableSpan, length, fastLimit, slowLimit);
@@ -7723,7 +7723,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersRecursiveMedianFilterFast(StockData data, ComputeContext context, int length = 5, double alpha = 0.5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersRecursiveMedianFilter(inputSpan, buffer.WritableSpan, length, alpha);
@@ -7735,7 +7735,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersRoofingFilterFast(StockData data, ComputeContext context, int hpLength = 10, int lpLength = 48)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersRoofingFilter(inputSpan, buffer.WritableSpan, hpLength, lpLength);
@@ -7751,7 +7751,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersDeviationScaledSuperSmootherFast(StockData data, ComputeContext context, int length = 20, int poles = 2)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersDeviationScaledSuperSmoother(inputSpan, buffer.WritableSpan, length, poles);
@@ -7763,7 +7763,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePpoMaFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.PpoMa(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -7775,7 +7775,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePriceOscillatorFast(StockData data, ComputeContext context, int shortLength = 10, int longLength = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PriceOscillator(inputSpan, buffer.WritableSpan, shortLength, longLength);
@@ -7787,7 +7787,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeReverseEngineeringRsiFast(StockData data, ComputeContext context, int length = 14, double rsiLevel = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ReverseEngineeringRsi(inputSpan, buffer.WritableSpan, length, rsiLevel);
@@ -7799,7 +7799,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeReverseMovingAverageConvergenceDivergenceFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26, double macdLevel = 0)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ReverseMovingAverageConvergenceDivergence(inputSpan, buffer.WritableSpan, fastLength, slowLength, macdLevel);
@@ -7822,7 +7822,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeStochasticRsiOscillatorFast(StockData data, ComputeContext context, int rsiLength = 14, int stochLength = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.StochasticRsiOscillator(inputSpan, buffer.WritableSpan, rsiLength, stochLength);
@@ -7834,7 +7834,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeElasticVolumeWeightedMovingAverageV2Fast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var volume = SpanCompat.AsReadOnlySpan(data.Volumes);
         var buffer = context.Rent(inputList.Count);
@@ -7847,7 +7847,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWindowedVolumeWeightedMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var volume = SpanCompat.AsReadOnlySpan(data.Volumes);
         var buffer = context.Rent(inputList.Count);
@@ -7860,7 +7860,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAtrFilteredExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 45, int atrLength = 20, int stdDevLength = 10, int lbLength = 20, double min = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var high = SpanCompat.AsReadOnlySpan(data.HighPrices);
         var low = SpanCompat.AsReadOnlySpan(data.LowPrices);
@@ -7874,7 +7874,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrueRangeAdjustedExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 14, double mult = 1.5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var high = SpanCompat.AsReadOnlySpan(data.HighPrices);
         var low = SpanCompat.AsReadOnlySpan(data.LowPrices);
@@ -7941,7 +7941,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTripleHullMovingAverageFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.TripleHullMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -7953,7 +7953,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAdaptiveAutonomousRecursiveMovingAverageFast(StockData data, ComputeContext context, int length = 14, double lambda = 1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.AdaptiveAutonomousRecursiveMovingAverage(inputSpan, buffer.WritableSpan, length, lambda);
@@ -7969,7 +7969,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeGeneralizedDoubleExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 14, double volumeFactor = 1.0)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.GeneralizedDoubleExponentialMovingAverage(inputSpan, buffer.WritableSpan, length, volumeFactor);
@@ -7981,7 +7981,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersFiniteImpulseResponseFilterFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersFiniteImpulseResponseFilter(inputSpan, buffer.WritableSpan, length);
@@ -7993,7 +7993,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersInfiniteImpulseResponseFilterFast(StockData data, ComputeContext context, int length = 15)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersInfiniteImpulseResponseFilter(inputSpan, buffer.WritableSpan, length);
@@ -8076,7 +8076,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeNarrowBandpassFilterFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.NarrowBandpassFilter(inputSpan, buffer.WritableSpan, length);
@@ -8187,7 +8187,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersTrendflexFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersTrendflex(inputSpan, buffer.WritableSpan, length);
@@ -8199,7 +8199,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersReflexFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersReflex(inputSpan, buffer.WritableSpan, length);
@@ -8211,7 +8211,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCorrelationTrendIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCorrelationTrendIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8235,7 +8235,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrendDetectionIndexFast(StockData data, ComputeContext context, int length1 = 20, int length2 = 40)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.TrendDetectionIndex(inputSpan, buffer.WritableSpan, length1, length2);
@@ -8259,7 +8259,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePercentageTrendFast(StockData data, ComputeContext context, int length = 20, double pct = 0.15)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PercentageTrend(inputSpan, buffer.WritableSpan, length, pct);
@@ -8283,7 +8283,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAsymmetricalRelativeStrengthIndexFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.AsymmetricalRelativeStrengthIndex(inputSpan, buffer.WritableSpan, length);
@@ -8295,7 +8295,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAverageAbsoluteErrorNormalizationFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.AverageAbsoluteErrorNormalization(inputSpan, buffer.WritableSpan, length);
@@ -8307,7 +8307,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRecursiveStochasticFast(StockData data, ComputeContext context, int length = 200, double alpha = 0.1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.RecursiveStochastic(inputSpan, buffer.WritableSpan, length, alpha);
@@ -8472,7 +8472,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSimpleCycleIndicatorFast(StockData data, ComputeContext context, double alpha = 0.07)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSimpleCycleIndicator(inputSpan, buffer.WritableSpan, alpha);
@@ -8484,7 +8484,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersFisherTransformFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersFisherTransform(inputSpan, buffer.WritableSpan, length);
@@ -8496,7 +8496,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersVossPredictiveFilterFast(StockData data, ComputeContext context, int length = 20, double predict = 3, double bw = 0.25)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersVossPredictiveFilter(inputSpan, buffer.WritableSpan, length, predict, bw);
@@ -8508,7 +8508,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSpearmanRankIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSpearmanRankIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8520,7 +8520,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCorrelationCycleIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var realBuffer = context.Rent(inputList.Count);
         var imagBuffer = context.Rent(inputList.Count);
@@ -8534,7 +8534,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCorrelationAngleIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCorrelationAngleIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8546,7 +8546,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersTruncatedBandPassFilterFast(StockData data, ComputeContext context, int length1 = 20, int length2 = 10, double bw = 0.1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersTruncatedBandPassFilter(inputSpan, buffer.WritableSpan, length1, length2, bw);
@@ -8558,7 +8558,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSimpleDecyclerFast(StockData data, ComputeContext context, int length = 125)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSimpleDecycler(inputSpan, buffer.WritableSpan, length);
@@ -8570,7 +8570,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersEvenBetterSineWaveIndicatorFast(StockData data, ComputeContext context, int length1 = 40, int length2 = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersEvenBetterSineWaveIndicator(inputSpan, buffer.WritableSpan, length1, length2);
@@ -8582,7 +8582,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersMarketStateIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersMarketStateIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8594,7 +8594,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersInstantaneousTrendlineV2Fast(StockData data, ComputeContext context, double alpha = 0.07)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersInstantaneousTrendlineV2(inputSpan, buffer.WritableSpan, alpha);
@@ -8606,7 +8606,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCyberCycleOscillatorFast(StockData data, ComputeContext context, double alpha = 0.07)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCyberCycleOscillator(inputSpan, buffer.WritableSpan, alpha);
@@ -8618,7 +8618,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersBandPassFilterV1Fast(StockData data, ComputeContext context, int length = 20, double bw = 0.3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersBandPassFilterV1(inputSpan, buffer.WritableSpan, length, bw);
@@ -8630,7 +8630,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersBandPassFilterV2Fast(StockData data, ComputeContext context, int length = 20, double bw = 0.3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersBandPassFilterV2(inputSpan, buffer.WritableSpan, length, bw);
@@ -8642,7 +8642,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCycleBandPassFilterFast(StockData data, ComputeContext context, int length = 20, double delta = 0.1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCycleBandPassFilter(inputSpan, buffer.WritableSpan, length, delta);
@@ -8654,7 +8654,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCycleAmplitudeFast(StockData data, ComputeContext context, int length = 20, double delta = 0.1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCycleAmplitude(inputSpan, buffer.WritableSpan, length, delta);
@@ -8666,7 +8666,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersHpLpRoofingFilterFast(StockData data, ComputeContext context, int length1 = 48, int length2 = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersHpLpRoofingFilter(inputSpan, buffer.WritableSpan, length1, length2);
@@ -8678,7 +8678,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersEarlyOnsetTrendIndicatorFast(StockData data, ComputeContext context, int length1 = 30, int length2 = 100, double k = 0.85)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersEarlyOnsetTrendIndicator(inputSpan, buffer.WritableSpan, length1, length2, k);
@@ -8703,7 +8703,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersClassicHilbertTransformerFast(StockData data, ComputeContext context, int length1 = 48, int length2 = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var realBuffer = context.Rent(inputList.Count);
         var imagBuffer = context.Rent(inputList.Count);
@@ -8723,7 +8723,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersZeroMeanRoofingFilterFast(StockData data, ComputeContext context, int length1 = 48, int length2 = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersZeroMeanRoofingFilter(inputSpan, buffer.WritableSpan, length1, length2);
@@ -8735,7 +8735,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSuperPassbandFilterFast(StockData data, ComputeContext context, int fastLength = 40, int slowLength = 60, int length1 = 5, int length2 = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSuperPassbandFilter(inputSpan, buffer.WritableSpan, fastLength, slowLength, length1, length2);
@@ -8747,7 +8747,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersRoofingFilterV2Fast(StockData data, ComputeContext context, int upperLength = 80, int lowerLength = 40)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersRoofingFilterV2(inputSpan, buffer.WritableSpan, upperLength, lowerLength);
@@ -8759,7 +8759,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersImpulseReactionFast(StockData data, ComputeContext context, int length1 = 2, int length2 = 20, double q = 0.9)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersImpulseReaction(inputSpan, buffer.WritableSpan, length1, length2, q);
@@ -8771,7 +8771,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersReverseEmaIndicatorV1Fast(StockData data, ComputeContext context, double alpha = 0.1)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersReverseEmaIndicatorV1(inputSpan, buffer.WritableSpan, alpha);
@@ -8783,7 +8783,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSquelchIndicatorFast(StockData data, ComputeContext context, int length1 = 6, int length2 = 20, int length3 = 40)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSquelchIndicator(inputSpan, buffer.WritableSpan, length1, length2, length3);
@@ -8795,7 +8795,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersReverseEmaIndicatorV2Fast(StockData data, ComputeContext context, double trendAlpha = 0.05, double cycleAlpha = 0.3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersReverseEmaIndicatorV2(inputSpan, buffer.WritableSpan, trendAlpha, cycleAlpha);
@@ -8807,7 +8807,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersStochasticCyberCycleFast(StockData data, ComputeContext context, int length = 14, double alpha = 0.7)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersStochasticCyberCycle(inputSpan, buffer.WritableSpan, length, alpha);
@@ -8819,7 +8819,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersCenterofGravityOscillatorFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersCenterofGravityOscillator(inputSpan, buffer.WritableSpan, length);
@@ -8831,7 +8831,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersReflexIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersReflexIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8843,7 +8843,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersTrendflexIndicatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersTrendflexIndicator(inputSpan, buffer.WritableSpan, length);
@@ -8855,7 +8855,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeJmaRsxCloneFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.JmaRsxClone(inputSpan, buffer.WritableSpan, length);
@@ -8867,7 +8867,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeRateOfChangeFast(StockData data, ComputeContext context, int length = 12)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.RateOfChange(inputSpan, buffer.WritableSpan, length);
@@ -8899,7 +8899,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDetrendedPriceOscillatorFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DetrendedPriceOscillator(inputSpan, buffer.WritableSpan, length);
@@ -8922,7 +8922,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSchaffTrendCycleFast(StockData data, ComputeContext context, int cycleLength = 10, int fastLength = 23, int slowLength = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.SchaffTrendCycle(inputSpan, buffer.WritableSpan, cycleLength, fastLength, slowLength);
@@ -8934,7 +8934,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeSmoothedRateOfChangeFast(StockData data, ComputeContext context, int rocLength = 12, int smoothLength = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.SmoothedRateOfChange(inputSpan, buffer.WritableSpan, rocLength, smoothLength);
@@ -9038,7 +9038,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearChannelMiddleFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.LinearChannelMiddle(inputSpan, buffer.WritableSpan, length);
@@ -9094,7 +9094,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeThreeHmaFast(StockData data, ComputeContext context, int length = 50)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.ThreeHma(inputSpan, buffer.WritableSpan, length);
@@ -9145,7 +9145,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeWellesWilderSummationFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.WellesWilderSummation(inputSpan, buffer.WritableSpan, length);
@@ -9157,7 +9157,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDampingIndexFast(StockData data, ComputeContext context, int length = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.DampingIndex(inputSpan, buffer.WritableSpan, length);
@@ -9169,7 +9169,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDidiIndexFast(StockData data, ComputeContext context, int shortLength = 3, int mediumLength = 8, int longLength = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.DidiIndex(inputSpan, buffer.WritableSpan, shortLength, mediumLength, longLength);
@@ -9192,7 +9192,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearRegressionSlopeFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.LinearRegressionSlope(inputSpan, buffer.WritableSpan, length);
@@ -9204,7 +9204,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeLinearRegressionInterceptFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.LinearRegressionIntercept(inputSpan, buffer.WritableSpan, length);
@@ -9220,7 +9220,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAbsolutePriceOscillatorFast(StockData data, ComputeContext context, int fastLength = 10, int slowLength = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.AbsolutePriceOscillator(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -9255,7 +9255,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAdaptiveExponentialMovingAverageFast(StockData data, ComputeContext context, int length = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.AdaptiveExponentialMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9309,7 +9309,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeMomentumOscillatorFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeMomentumOscillator(inputSpan, buffer.WritableSpan, length);
@@ -9342,7 +9342,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeHullMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.HullMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9379,7 +9379,7 @@ internal static partial class IndicatorCompute
         int roc1 = 10, int roc2 = 15, int roc3 = 20, int roc4 = 30,
         int sma1 = 10, int sma2 = 10, int sma3 = 10, int sma4 = 15)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.KnowSureThing(inputSpan, buffer.WritableSpan, roc1, roc2, roc3, roc4, sma1, sma2, sma3, sma4);
@@ -9429,7 +9429,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePercentagePriceOscillatorFast(StockData data, ComputeContext context, int fastLength = 12, int slowLength = 26)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PercentagePriceOscillator(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -9471,7 +9471,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputePriceMomentumOscillatorFast(StockData data, ComputeContext context, int firstLength = 35, int secondLength = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.PriceMomentumOscillator(inputSpan, buffer.WritableSpan, firstLength, secondLength);
@@ -9502,7 +9502,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTriangularMovingAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.TriangularMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9514,7 +9514,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTrueStrengthIndexFast(StockData data, ComputeContext context, int longLength = 25, int shortLength = 13)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.TrueStrengthIndex(inputSpan, buffer.WritableSpan, longLength, shortLength);
@@ -9553,7 +9553,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeDeltaMovingAverageFast(StockData data, ComputeContext context, int fastLength = 10, int slowLength = 5)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.DeltaMovingAverage(inputSpan, buffer.WritableSpan, fastLength, slowLength);
@@ -9565,7 +9565,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeFoldedRsiFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.FoldedRelativeStrengthIndex(inputSpan, buffer.WritableSpan, length);
@@ -9598,7 +9598,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeConnorsRsiFast(StockData data, ComputeContext context, int rsiLength = 3, int streakLength = 2, int rankLength = 100)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ConnorsRelativeStrengthIndex(inputSpan, buffer.WritableSpan, rsiLength, streakLength, rankLength);
@@ -9610,7 +9610,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeStochasticRsiFast(StockData data, ComputeContext context, int rsiLength = 14, int smoothK = 3, int smoothD = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.StochasticRelativeStrengthIndex(inputSpan, buffer.WritableSpan, rsiLength, rsiLength, smoothK, smoothD);
@@ -9643,7 +9643,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeCCTStochRsiFast(StockData data, ComputeContext context, int rsiLength = 14, int stochLength = 5, int smaLength = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.CCTStochRsi(inputSpan, buffer.WritableSpan, rsiLength, stochLength, smaLength);
@@ -9697,7 +9697,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMomentumOscillatorFast(StockData data, ComputeContext context, int length = 10, int smoothLength = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         // Momentum oscillator is momentum with smoothing
@@ -9785,7 +9785,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeKeltnerMiddleFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         TrendCore.KeltnerChannelMiddle(inputSpan, buffer.WritableSpan, length);
@@ -9797,7 +9797,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeOneLCLeastSquaresFast(StockData data, ComputeContext context, int length = 32)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.OneLCLeastSquaresMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9809,7 +9809,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeAdaptiveRsiFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.AdaptiveRsi(inputSpan, buffer.WritableSpan, 5, length);
@@ -9842,7 +9842,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeChandeMomentumOscillatorSignalFast(StockData data, ComputeContext context, int length = 14, int signalLength = 3)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.ChandeMomentumOscillatorAverage(inputSpan, buffer.WritableSpan, length, signalLength);
@@ -9854,7 +9854,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersRoofingFilterV1Fast(StockData data, ComputeContext context, int hpLength = 10, int lpLength = 48)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersRoofingFilter(inputSpan, buffer.WritableSpan, hpLength, lpLength);
@@ -9866,7 +9866,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSpearmanRankFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersSpearmanRankIndicator(inputSpan, buffer.WritableSpan, length);
@@ -9878,7 +9878,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeTillsonT3Fast(StockData data, ComputeContext context, int length = 5, double vFactor = 0.7)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.T3MovingAverage(inputSpan, buffer.WritableSpan, length, vFactor);
@@ -9890,7 +9890,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersHammingWindowFast(StockData data, ComputeContext context, int length = 20, double pedestal = 10)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersHammingMovingAverage(inputSpan, buffer.WritableSpan, length, pedestal);
@@ -9902,7 +9902,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersHannWindowFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersHannMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9914,7 +9914,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersTriangleWindowFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersTriangleMovingAverage(inputSpan, buffer.WritableSpan, length);
@@ -9926,7 +9926,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersImpulseReactionFast(StockData data, ComputeContext context, int length = 20)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         OscillatorCore.EhlersImpulseReaction(inputSpan, buffer.WritableSpan, 2, length);
@@ -9960,7 +9960,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeVariableIndexDynamicAverageFast(StockData data, ComputeContext context, int length = 14)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var buffer = context.Rent(inputList.Count);
         MovingAverageCore.EhlersVariableIndexDynamicAverage(inputSpan, buffer.WritableSpan, length);
@@ -9977,7 +9977,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSimpleDerivIndicatorFast(StockData data, ComputeContext context, int length = 2, int signalLength = 8, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var count = inputList.Count;
 
@@ -10034,7 +10034,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeEhlersSimpleClipIndicatorFast(StockData data, ComputeContext context, int length1 = 2, int length3 = 50, int signalLength = 22, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
         var count = inputList.Count;
 
@@ -10161,7 +10161,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeEhlersMovingAverageDifferenceFast(StockData data, ComputeContext context, int fastLength = 8, int slowLength = 23, MovingAvgType maType = MovingAvgType.WeightedMovingAverage)
     {
         var count = data.Count;
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var pool = ArrayPool<double>.Shared;
@@ -10266,7 +10266,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeDema2LinesFast(StockData data, ComputeContext context, int fastLength = 10, int slowLength = 40, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage)
     {
         var count = data.Count;
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var buffer = context.Rent(count);
@@ -10325,7 +10325,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeGainLossMovingAverageFast(StockData data, ComputeContext context, int length = 14, int signalLength = 7, MovingAvgType maType = MovingAvgType.WildersSmoothingMethod)
     {
         var count = data.Count;
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var pool = ArrayPool<double>.Shared;
@@ -10392,7 +10392,7 @@ internal static partial class IndicatorCompute
     internal static ComputeBuffer ComputeErgodicMeanDeviationIndicatorFast(StockData data, ComputeContext context, int length1 = 32, int length2 = 5, int length3 = 5, int signalLength = 5, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage)
     {
         var count = data.Count;
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var inputSpan = SpanCompat.AsReadOnlySpan(inputList);
 
         var pool = ArrayPool<double>.Shared;
@@ -10713,7 +10713,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeMarketMeannessIndexFast(StockData data, ComputeContext context, int length = 100, MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var input = SpanCompat.AsReadOnlySpan(inputList);
         var count = data.Count;
         var pool = ArrayPool<double>.Shared;
@@ -11081,7 +11081,7 @@ internal static partial class IndicatorCompute
     /// </summary>
     internal static ComputeBuffer ComputeOptimizedTrendTrackerFast(StockData data, ComputeContext context, int length = 2, double percent = 1.4, MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
-        var inputList = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var inputList = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         var input = SpanCompat.AsReadOnlySpan(inputList);
         var count = data.Count;
         var pool = ArrayPool<double>.Shared;

--- a/src/Builder/Evaluation/SeriesEvaluator.cs
+++ b/src/Builder/Evaluation/SeriesEvaluator.cs
@@ -365,7 +365,7 @@ internal sealed class SeriesEvaluator
     private static double[] ExtractOutput(StockData result, IndicatorSpec spec)
     {
         var key = IndicatorOutputRegistry.GetOutputKey(spec.Name, spec.Output);
-        if (key is not null && result.OutputValues.TryGetValue(key, out var list))
+        if (key is not null && result.ChainedOutputs.TryGetValue(key, out var list))
         {
             return list.ToArray();
         }

--- a/src/Builder/Evaluation/SeriesEvaluator.cs
+++ b/src/Builder/Evaluation/SeriesEvaluator.cs
@@ -349,12 +349,12 @@ internal sealed class SeriesEvaluator
                 return _cachedDefaultInput;
             }
 
-            var defaultInput = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+            var defaultInput = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
             _cachedDefaultInput = defaultInput.ToArray();
             return _cachedDefaultInput;
         }
 
-        var input = data.CustomValuesList.Count > 0 ? data.CustomValuesList : data.InputValues;
+        var input = data.ChainedValues.Count > 0 ? data.ChainedValues : data.InputValues;
         return input.ToArray();
     }
 
@@ -370,7 +370,7 @@ internal sealed class SeriesEvaluator
             return list.ToArray();
         }
 
-        return result.CustomValuesList.ToArray();
+        return result.ChainedValues.ToArray();
     }
 }
 

--- a/src/Builder/Evaluation/SeriesEvaluator.cs
+++ b/src/Builder/Evaluation/SeriesEvaluator.cs
@@ -273,7 +273,7 @@ internal sealed class SeriesEvaluator
             });
         }
 
-        return new StockData(tickerList, InputName.Close);
+        return new StockData(tickerList);
     }
 
     /// <summary>

--- a/src/Builder/Specs/IndicatorSpec.cs
+++ b/src/Builder/Specs/IndicatorSpec.cs
@@ -14008,16 +14008,15 @@ public sealed class VariableIndexDynamicAverageSpecOptions : IIndicatorSpecOptio
 
 public sealed class VolumeFlowIndicatorSpecOptions : IIndicatorSpecOptions
 {
-    public VolumeFlowIndicatorSpecOptions(InputName inputName = InputName.TypicalPrice, int length1 = 130, int length2 = 30,
+    public VolumeFlowIndicatorSpecOptions(int length1 = 130, int length2 = 30,
         int signalLength = 5, int smoothLength = 3, double coef = 0.2, double vcoef = 2.5)
-        : this(inputName, length1, length2, signalLength, smoothLength, coef, vcoef, MovingAvgType.SimpleMovingAverage)
+        : this(length1, length2, signalLength, smoothLength, coef, vcoef, MovingAvgType.SimpleMovingAverage)
     {
     }
 
-    public VolumeFlowIndicatorSpecOptions(InputName inputName, int length1, int length2, int signalLength, int smoothLength,
+    public VolumeFlowIndicatorSpecOptions(int length1, int length2, int signalLength, int smoothLength,
         double coef, double vcoef, MovingAvgType maType)
     {
-        InputName = inputName;
         Length1 = Math.Max(1, length1);
         Length2 = Math.Max(1, length2);
         SignalLength = Math.Max(1, signalLength);
@@ -14027,7 +14026,6 @@ public sealed class VolumeFlowIndicatorSpecOptions : IIndicatorSpecOptions
         MaType = maType;
     }
 
-    public InputName InputName { get; }
     public int Length1 { get; }
     public int Length2 { get; }
     public int SignalLength { get; }

--- a/src/Builder/StockIndicatorBuilder.cs
+++ b/src/Builder/StockIndicatorBuilder.cs
@@ -595,7 +595,6 @@ public sealed class StockIndicatorBuilder
             ProcessingMode = source.ProcessingMode,
             BackpressurePolicy = source.BackpressurePolicy,
             MaxPendingMessages = source.MaxPendingMessages,
-            InputName = source.InputName,
             IncludeOutputValues = source.IncludeOutputValues,
             IndicatorOptions = source.IndicatorOptions,
             Indicators = source.Indicators

--- a/src/Calculations/BollingerBands/BollingerBandsPart1.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart1.cs
@@ -237,7 +237,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -307,7 +307,7 @@ public static partial class Calculations
         // Bollinger Bands publish no single series, and an ATR asked to read one refuses. Hand it the
         // caller's series, which is what its true range is a range of.
         stockData.RestoreInputSeries(callerSeries);
-        var atrList = CalculateAverageTrueRange(stockData, maType, atrLength).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, atrLength).ChainedValues;
 
         double prevAtrDev = 0;
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/BollingerBands/BollingerBandsPart1.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart1.cs
@@ -301,8 +301,8 @@ public static partial class Calculations
         var callerSeries = stockData.CaptureInputSeries();
 
         var bollingerBands = CalculateBollingerBands(stockData, maType, length, stdDevMult);
-        var upperBandList = bollingerBands.OutputValues["UpperBand"];
-        var lowerBandList = bollingerBands.OutputValues["LowerBand"];
+        var upperBandList = bollingerBands.ChainedOutputs["UpperBand"];
+        var lowerBandList = bollingerBands.ChainedOutputs["LowerBand"];
         var emaList = GetMovingAverageList(stockData, maType, atrLength, inputList);
         // Bollinger Bands publish no single series, and an ATR asked to read one refuses. Hand it the
         // caller's series, which is what its true range is a range of.

--- a/src/Calculations/BollingerBands/BollingerBandsPart2.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart2.cs
@@ -175,7 +175,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>
     /// <param name="smoothLength"></param>

--- a/src/Calculations/BollingerBands/BollingerBandsPart2.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart2.cs
@@ -224,7 +224,7 @@ public static partial class Calculations
 
         var zlhaTemaList = GetMovingAverageList(stockData, maType, smoothLength, zlhaList);
         stockData.SetCustomValues(zlhaTemaList);
-        var zlhaTemaStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).CustomValuesList;
+        var zlhaTemaStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).ChainedValues;
         var wmaZlhaTemaList = GetMovingAverageList(stockData, MovingAvgType.WeightedMovingAverage, length1, zlhaTemaList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -237,7 +237,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(percbList);
-        var percbStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length2).CustomValuesList;
+        var percbStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = percbList[i];

--- a/src/Calculations/BollingerBands/BollingerBandsPart2.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart2.cs
@@ -92,8 +92,8 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var bbList = CalculateBollingerBands(stockData, maType, length, stdDevMult);
-        var upperBandList = bbList.OutputValues["UpperBand"];
-        var lowerBandList = bbList.OutputValues["LowerBand"];
+        var upperBandList = bbList.ChainedOutputs["UpperBand"];
+        var lowerBandList = bbList.ChainedOutputs["LowerBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -138,9 +138,9 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var bbList = CalculateBollingerBands(stockData, maType, length, stdDevMult);
-        var upperBandList = bbList.OutputValues["UpperBand"];
-        var lowerBandList = bbList.OutputValues["LowerBand"];
-        var middleBandList = bbList.OutputValues["MiddleBand"];
+        var upperBandList = bbList.ChainedOutputs["UpperBand"];
+        var lowerBandList = bbList.ChainedOutputs["LowerBand"];
+        var middleBandList = bbList.ChainedOutputs["MiddleBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/BollingerBands/BollingerBandsPart2.cs
+++ b/src/Calculations/BollingerBands/BollingerBandsPart2.cs
@@ -183,7 +183,7 @@ public static partial class Calculations
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateVervoortModifiedBollingerBandIndicator(this StockData stockData,
-        MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, InputName inputName = InputName.FullTypicalPrice, int length1 = 18,
+        MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length1 = 18,
         int length2 = 200, int smoothLength = 8, double stdDevMult = 1.6)
     {
         List<double> haOpenList = new(stockData.Count);
@@ -194,7 +194,7 @@ public static partial class Calculations
         List<double> lbList = new(stockData.Count);
         List<double> percbSignalList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Chande/ChandeAtoD.cs
+++ b/src/Calculations/Chande/ChandeAtoD.cs
@@ -31,9 +31,9 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).CustomValuesList;
-        var stdDev10List = CalculateStandardDeviationVolatility(stockData, maType, length2).CustomValuesList;
-        var stdDev20List = CalculateStandardDeviationVolatility(stockData, maType, length3).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).ChainedValues;
+        var stdDev10List = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
+        var stdDev20List = CalculateStandardDeviationVolatility(stockData, maType, length3).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Chande/ChandeEtoK.cs
+++ b/src/Calculations/Chande/ChandeEtoK.cs
@@ -71,7 +71,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var linRegList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Chande/ChandeStoZ.cs
+++ b/src/Calculations/Chande/ChandeStoZ.cs
@@ -47,7 +47,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var stdDevEmaList = GetMovingAverageList(stockData, maType, length, stdDevList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Ehlers/EhlersAtoD.cs
+++ b/src/Calculations/Ehlers/EhlersAtoD.cs
@@ -2404,13 +2404,13 @@ public static partial class Calculations
     /// <param name="constant"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateEhlersAdaptiveCommodityChannelIndexV1(this StockData stockData, InputName inputName = InputName.TypicalPrice, double cycPart = 1,
+    public static StockData CalculateEhlersAdaptiveCommodityChannelIndexV1(this StockData stockData, double cycPart = 1,
         double constant = 0.015)
     {
         List<double> acciList = new(stockData.Count);
         List<double> acciEmaList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var spList = GetOutputValuesInternal(stockData,
             data => CalculateEhlersMotherOfAdaptiveMovingAverages(data))["SmoothPeriod"];
@@ -2472,7 +2472,7 @@ public static partial class Calculations
     /// <param name="constant"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateEhlersCommodityChannelIndexInverseFisherTransform(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateEhlersCommodityChannelIndexInverseFisherTransform(this StockData stockData,
         MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20, int signalLength = 9, double constant = 0.015)
     {
         length = Math.Max(length, 1);
@@ -2482,7 +2482,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var cciList = GetCustomValuesListInternal(stockData,
-            data => CalculateCommodityChannelIndex(data, inputName, maType, length, constant));
+            data => CalculateCommodityChannelIndex(data, maType, length, constant));
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Ehlers/EhlersAtoD.cs
+++ b/src/Calculations/Ehlers/EhlersAtoD.cs
@@ -877,7 +877,7 @@ public static partial class Calculations
 
             var prevUpChg = GetLastOrDefault(upChgList);
             double upChg = 0, dnChg = 0;
-            for (var j = 0; j < (int)Math.Ceiling(domCyc / 2); j++)
+            for (var j = 0; j < MathHelper.CeilingCycle(domCyc / 2); j++)
             {
                 var filt = i >= j ? roofingFilterList[i - j] : 0;
                 var prevFilt = i >= j + 1 ? roofingFilterList[i - (j + 1)] : 0;
@@ -1007,7 +1007,7 @@ public static partial class Calculations
             var prevAstoc1 = i >= 1 ? astocList[i - 1] : 0;
             var prevAstoc2 = i >= 2 ? astocList[i - 2] : 0;
 
-            var window = (int)Math.Ceiling(domCyc);
+            var window = MathHelper.CeilingCycle(domCyc);
             var highest = roofingFilter;
             var lowest = roofingFilter;
             for (var j = 1; j < window && i >= j; j++)
@@ -1151,7 +1151,7 @@ public static partial class Calculations
             var domCyc = MinOrMax(domCycList[i], length1, length2);
             var prevAcci1 = i >= 1 ? acciList[i - 1] : 0;
             var prevAcci2 = i >= 2 ? acciList[i - 2] : 0;
-            var cycLength = (int)Math.Ceiling(domCyc);
+            var cycLength = MathHelper.CeilingCycle(domCyc);
 
             var roofingFilter = roofingFilterList[i];
             tempList.Add(roofingFilter);

--- a/src/Calculations/Ehlers/EhlersAtoD.cs
+++ b/src/Calculations/Ehlers/EhlersAtoD.cs
@@ -2399,7 +2399,6 @@ public static partial class Calculations
     /// Calculates the Ehlers Adaptive Commodity Channel Index V1
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="cycPart"></param>
     /// <param name="constant"></param>
     /// <returns></returns>
@@ -2465,7 +2464,6 @@ public static partial class Calculations
     /// Calculates the Ehlers Commodity Channel Index Inverse Fisher Transform
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="length"></param>
     /// <param name="signalLength"></param>

--- a/src/Calculations/Ehlers/EhlersAtoD.cs
+++ b/src/Calculations/Ehlers/EhlersAtoD.cs
@@ -250,6 +250,7 @@ public static partial class Calculations
     public static StockData CalculateEhlersDecyclerOscillatorV1(this StockData stockData, int fastLength = 100, int slowLength = 125, 
         double fastMult = 1.2, double slowMult = 1)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         fastLength = Math.Max(fastLength, 1);
         slowLength = Math.Max(slowLength, 1);
         List<double> decycler1OscillatorList = new(stockData.Count);
@@ -259,9 +260,8 @@ public static partial class Calculations
 
         var decycler1List = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersSimpleDecycler(data, fastLength));
-        // Reset to use close prices for decycler2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var decycler2List = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersSimpleDecycler(data, slowLength));
         stockData.SetCustomValues(decycler1List);
@@ -313,6 +313,7 @@ public static partial class Calculations
     public static StockData CalculateEhlersDecyclerOscillatorV2(this StockData stockData, MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
         int fastLength = 10, int slowLength = 20)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         fastLength = Math.Max(fastLength, 1);
         slowLength = Math.Max(slowLength, 1);
         List<double> decList = new(stockData.Count);
@@ -320,9 +321,8 @@ public static partial class Calculations
 
         var hp1List = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersHighPassFilterV2(data, maType, fastLength));
-        // Reset to use close prices for second HighPassFilterV2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var hp2List = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersHighPassFilterV2(data, maType, slowLength));
 
@@ -847,6 +847,7 @@ public static partial class Calculations
     public static StockData CalculateEhlersAdaptiveRelativeStrengthIndexV2(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length1 = 48, int length2 = 10, int length3 = 3)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         length1 = Math.Max(length1, 1);
         length2 = Math.Max(length2, 1);
         length3 = Math.Max(length3, 1);
@@ -863,9 +864,8 @@ public static partial class Calculations
 
         var domCycList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersAutoCorrelationPeriodogram(data, length1, length2, length3));
-        // Reset to use close prices for RoofingFilterV2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var roofingFilterList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersRoofingFilterV2(data, length1, length2));
 
@@ -979,6 +979,7 @@ public static partial class Calculations
     public static StockData CalculateEhlersAdaptiveStochasticIndicatorV2(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length1 = 48, int length2 = 10, int length3 = 3)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         length1 = Math.Max(length1, 1);
         length2 = Math.Max(length2, 1);
         length3 = Math.Max(length3, 1);
@@ -994,9 +995,8 @@ public static partial class Calculations
 
         var domCycList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersAutoCorrelationPeriodogram(data, length1, length2, length3));
-        // Reset to use close prices for RoofingFilterV2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var roofingFilterList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersRoofingFilterV2(data, length1, length2));
 
@@ -1121,6 +1121,7 @@ public static partial class Calculations
     public static StockData CalculateEhlersAdaptiveCommodityChannelIndexV2(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, 
         int length1 = 48, int length2 = 10, int length3 = 3)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         length1 = Math.Max(length1, 1);
         length2 = Math.Max(length2, 1);
         length3 = Math.Max(length3, 1);
@@ -1140,9 +1141,8 @@ public static partial class Calculations
 
         var domCycList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersAutoCorrelationPeriodogram(data, length1, length2, length3));
-        // Reset to use close prices for RoofingFilterV2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var roofingFilterList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersRoofingFilterV2(data, length1, length2));
 
@@ -1977,6 +1977,7 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateEhlersAdaptiveBandPassFilter(this StockData stockData, int length1 = 48, int length2 = 10, int length3 = 3, double bw = 0.3)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         length1 = Math.Max(length1, 1);
         length2 = Math.Max(length2, 1);
         length3 = Math.Max(length3, 1);
@@ -1989,9 +1990,8 @@ public static partial class Calculations
 
         var domCycList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersAutoCorrelationPeriodogram(data, length1, length2, length3));
-        // Reset to use close prices for RoofingFilterV2 (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var roofingFilterList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersRoofingFilterV2(data, length1, length2));
 

--- a/src/Calculations/Ehlers/EhlersEtoK.cs
+++ b/src/Calculations/Ehlers/EhlersEtoK.cs
@@ -335,9 +335,9 @@ public static partial class Calculations
         List<double> quotientList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var hpList = CalculateEhlersHighPassFilterV1(stockData, length2, 1).CustomValuesList;
+        var hpList = CalculateEhlersHighPassFilterV1(stockData, length2, 1).ChainedValues;
         stockData.SetCustomValues(hpList);
-        var superSmoothList = CalculateEhlersSuperSmootherFilter(stockData, length1).CustomValuesList;
+        var superSmoothList = CalculateEhlersSuperSmootherFilter(stockData, length1).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -658,7 +658,7 @@ public static partial class Calculations
         List<double> qPeakList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var roofingFilterList = CalculateEhlersRoofingFilterV2(stockData, length1, length2).CustomValuesList;
+        var roofingFilterList = CalculateEhlersRoofingFilterV2(stockData, length1, length2).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -725,7 +725,7 @@ public static partial class Calculations
         var c3 = -a1 * a1;
         var c1 = 1 - c2 - c3;
 
-        var roofingFilterList = CalculateEhlersRoofingFilterV2(stockData, length1, length2).CustomValuesList;
+        var roofingFilterList = CalculateEhlersRoofingFilterV2(stockData, length1, length2).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1337,7 +1337,7 @@ public static partial class Calculations
         List<double> inverseFisherTransformList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Ehlers/EhlersEtoK.cs
+++ b/src/Calculations/Ehlers/EhlersEtoK.cs
@@ -265,8 +265,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var eteList = CalculateEhlersTrendExtraction(stockData, maType, length1, delta);
-        var trendList = eteList.OutputValues["Trend"];
-        var bpList = eteList.OutputValues["Bp"];
+        var trendList = eteList.ChainedOutputs["Trend"];
+        var bpList = eteList.ChainedOutputs["Bp"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -591,8 +591,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var ehtList = CalculateEhlersHilbertTransformIndicator(stockData, length: length1);
-        var ipList = ehtList.OutputValues["Inphase"];
-        var quList = ehtList.OutputValues["Quad"];
+        var ipList = ehtList.ChainedOutputs["Inphase"];
+        var quList = ehtList.ChainedOutputs["Quad"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -794,8 +794,8 @@ public static partial class Calculations
         var c1 = 1 - c2 - c3;
 
         var hilbertList = CalculateEhlersHilbertTransformer(stockData, length1, length2);
-        var realList = hilbertList.OutputValues["Real"];
-        var imagList = hilbertList.OutputValues["Imag"];
+        var realList = hilbertList.ChainedOutputs["Real"];
+        var imagList = hilbertList.ChainedOutputs["Imag"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -955,8 +955,8 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
 
         var ehlersMamaList = CalculateEhlersMotherOfAdaptiveMovingAverages(stockData);
-        var smoothList = ehlersMamaList.OutputValues["Smooth"];
-        var smoothPeriodList = ehlersMamaList.OutputValues["SmoothPeriod"];
+        var smoothList = ehlersMamaList.ChainedOutputs["Smooth"];
+        var smoothPeriodList = ehlersMamaList.ChainedOutputs["SmoothPeriod"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1024,9 +1024,9 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var snrv2List = CalculateEhlersEnhancedSignalToNoiseRatio(stockData, length);
-        var smoothPeriodList = snrv2List.OutputValues["SmoothPeriod"];
-        var q3List = snrv2List.OutputValues["Q3"];
-        var i3List = snrv2List.OutputValues["I3"];
+        var smoothPeriodList = snrv2List.ChainedOutputs["SmoothPeriod"];
+        var q3List = snrv2List.ChainedOutputs["Q3"];
+        var i3List = snrv2List.ChainedOutputs["I3"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1432,7 +1432,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var spList = CalculateEhlersMotherOfAdaptiveMovingAverages(stockData).OutputValues["SmoothPeriod"];
+        var spList = CalculateEhlersMotherOfAdaptiveMovingAverages(stockData).ChainedOutputs["SmoothPeriod"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Ehlers/EhlersLtoR.cs
+++ b/src/Calculations/Ehlers/EhlersLtoR.cs
@@ -1551,105 +1551,13 @@ public static partial class Calculations
         return stockData;
     }
 
-    // Ensure internal calculations can access outputs even when options disable them.
-    private static List<double> GetCustomValuesListInternal(StockData stockData, Func<StockData, StockData> calculator)
-    {
-        var options = stockData.Options;
-        if (options == null || options.IncludeCustomValues != false)
-        {
-            return calculator(stockData).ChainedValues;
-        }
+    // A component's single series and named series, unrounded and whatever the publication options say: the
+    // chained copies are kept for exactly this. These used to switch every option on around the call and hide
+    // the results again afterwards. The copies keep a later calculation on the same data from changing them.
+    private static List<double> GetCustomValuesListInternal(StockData stockData, Func<StockData, StockData> calculator) =>
+        new List<double>(calculator(stockData).ChainedValues);
 
-        var prevIncludeCustom = options.IncludeCustomValues;
-        var prevIncludeOutput = options.IncludeOutputValues;
-        var prevIncludeSignals = options.IncludeSignals;
-
-        options.IncludeCustomValues = true;
-        options.IncludeOutputValues = true;
-        options.IncludeSignals = true;
-
-        List<double> list;
-        try
-        {
-            var result = calculator(stockData);
-            list = new List<double>(result.ChainedValues);
-        }
-        finally
-        {
-            options.IncludeCustomValues = prevIncludeCustom;
-            options.IncludeOutputValues = prevIncludeOutput;
-            options.IncludeSignals = prevIncludeSignals;
-
-            if (prevIncludeCustom == false)
-            {
-                // Hidden from the caller, as the option asks, but still the next calculation's input.
-                stockData.HideCustomValues();
-            }
-
-            if (prevIncludeOutput == false)
-            {
-                stockData.OutputValues = new Dictionary<string, List<double>>();
-            }
-
-            if (prevIncludeSignals == false)
-            {
-                stockData.SignalsList = new List<Signal>();
-            }
-        }
-
-        return list;
-    }
-
-    private static Dictionary<string, List<double>> GetOutputValuesInternal(StockData stockData, Func<StockData, StockData> calculator)
-    {
-        var options = stockData.Options;
-        if (options == null || options.IncludeOutputValues != false)
-        {
-            return calculator(stockData).OutputValues;
-        }
-
-        var prevIncludeCustom = options.IncludeCustomValues;
-        var prevIncludeOutput = options.IncludeOutputValues;
-        var prevIncludeSignals = options.IncludeSignals;
-
-        options.IncludeCustomValues = true;
-        options.IncludeOutputValues = true;
-        options.IncludeSignals = true;
-
-        Dictionary<string, List<double>> outputValues;
-        try
-        {
-            var result = calculator(stockData);
-            outputValues = new Dictionary<string, List<double>>(result.OutputValues.Count);
-            foreach (var kvp in result.OutputValues)
-            {
-                outputValues[kvp.Key] = new List<double>(kvp.Value);
-            }
-        }
-        finally
-        {
-            options.IncludeCustomValues = prevIncludeCustom;
-            options.IncludeOutputValues = prevIncludeOutput;
-            options.IncludeSignals = prevIncludeSignals;
-
-            if (prevIncludeCustom == false)
-            {
-                // Hidden from the caller, as the option asks, but still the next calculation's input.
-                stockData.HideCustomValues();
-            }
-
-            if (prevIncludeOutput == false)
-            {
-                stockData.OutputValues = new Dictionary<string, List<double>>();
-            }
-
-            if (prevIncludeSignals == false)
-            {
-                stockData.SignalsList = new List<Signal>();
-            }
-        }
-
-        return outputValues;
-    }
+    private static Dictionary<string, List<double>> GetOutputValuesInternal(StockData stockData, Func<StockData, StockData> calculator) =>
+        calculator(stockData).ChainedOutputs.ToDictionary(kvp => kvp.Key, kvp => new List<double>(kvp.Value));
 }
 

--- a/src/Calculations/Ehlers/EhlersLtoR.cs
+++ b/src/Calculations/Ehlers/EhlersLtoR.cs
@@ -1557,7 +1557,7 @@ public static partial class Calculations
         var options = stockData.Options;
         if (options == null || options.IncludeCustomValues != false)
         {
-            return calculator(stockData).CustomValuesList;
+            return calculator(stockData).ChainedValues;
         }
 
         var prevIncludeCustom = options.IncludeCustomValues;
@@ -1572,7 +1572,7 @@ public static partial class Calculations
         try
         {
             var result = calculator(stockData);
-            list = new List<double>(result.CustomValuesList);
+            list = new List<double>(result.ChainedValues);
         }
         finally
         {
@@ -1582,7 +1582,8 @@ public static partial class Calculations
 
             if (prevIncludeCustom == false)
             {
-                stockData.CustomValuesList = new List<double>();
+                // Hidden from the caller, as the option asks, but still the next calculation's input.
+                stockData.HideCustomValues();
             }
 
             if (prevIncludeOutput == false)
@@ -1633,7 +1634,8 @@ public static partial class Calculations
 
             if (prevIncludeCustom == false)
             {
-                stockData.CustomValuesList = new List<double>();
+                // Hidden from the caller, as the option asks, but still the next calculation's input.
+                stockData.HideCustomValues();
             }
 
             if (prevIncludeOutput == false)

--- a/src/Calculations/Ehlers/EhlersStoZ.cs
+++ b/src/Calculations/Ehlers/EhlersStoZ.cs
@@ -1848,7 +1848,7 @@ public static partial class Calculations
         for (var i = 0; i < stockData.Count; i++)
         {
             var period = periodList[i];
-            var dcPeriod = (int)Math.Ceiling(period);
+            var dcPeriod = MathHelper.CeilingCycle(period);
 
             double realPart = 0, imagPart = 0;
             for (var j = 0; j <= dcPeriod - 1; j++)

--- a/src/Calculations/Ehlers/EhlersStoZ.cs
+++ b/src/Calculations/Ehlers/EhlersStoZ.cs
@@ -1831,6 +1831,7 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateEhlersSineWaveIndicatorV2(this StockData stockData, int length = 5, double alpha = 0.07)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         length = Math.Max(length, 1);
         List<double> sineList = new(stockData.Count);
         List<double> leadSineList = new(stockData.Count);
@@ -1839,9 +1840,8 @@ public static partial class Calculations
 
         var periodList = GetOutputValuesInternal(stockData,
             data => CalculateEhlersAdaptiveCyberCycle(data, length, alpha))["Period"];
-        // Reset to use close prices for CyberCycle (clear both CustomValues and Signals)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var cycleList = GetCustomValuesListInternal(stockData,
             data => CalculateEhlersCyberCycle(data));
 

--- a/src/Calculations/Inputs/InputsEtoK.cs
+++ b/src/Calculations/Inputs/InputsEtoK.cs
@@ -14,7 +14,7 @@ public static partial class Calculations
         // Chained: the same per-bar high and low every other indicator reads for a custom series
         // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
         List<double> fullTpList;
-        if (stockData.CustomValuesList is { Count: > 0 })
+        if (stockData.ChainedValues is { Count: > 0 })
         {
             var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
             fullTpList = new List<double>(seriesList.Count);

--- a/src/Calculations/Inputs/InputsEtoK.cs
+++ b/src/Calculations/Inputs/InputsEtoK.cs
@@ -11,7 +11,22 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateFullTypicalPrice(this StockData stockData)
     {
-        var fullTpList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Ohlc4);
+        // Chained: the same per-bar high and low every other indicator reads for a custom series
+        // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
+        List<double> fullTpList;
+        if (stockData.CustomValuesList is { Count: > 0 })
+        {
+            var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
+            fullTpList = new List<double>(seriesList.Count);
+            for (var i = 0; i < seriesList.Count; i++)
+            {
+                fullTpList.Add((seriesOpenList[i] + seriesHighList[i] + seriesLowList[i] + seriesList[i]) / 4);
+            }
+        }
+        else
+        {
+            fullTpList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Ohlc4);
+        }
         var count = fullTpList.Count;
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
 

--- a/src/Calculations/Inputs/InputsLtoR.cs
+++ b/src/Calculations/Inputs/InputsLtoR.cs
@@ -14,7 +14,7 @@ public static partial class Calculations
         // Chained: the same per-bar high and low every other indicator reads for a custom series
         // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
         List<double> medianPriceList;
-        if (stockData.CustomValuesList is { Count: > 0 })
+        if (stockData.ChainedValues is { Count: > 0 })
         {
             var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
             medianPriceList = new List<double>(seriesList.Count);

--- a/src/Calculations/Inputs/InputsLtoR.cs
+++ b/src/Calculations/Inputs/InputsLtoR.cs
@@ -11,7 +11,22 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateMedianPrice(this StockData stockData)
     {
-        var medianPriceList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Hl2);
+        // Chained: the same per-bar high and low every other indicator reads for a custom series
+        // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
+        List<double> medianPriceList;
+        if (stockData.CustomValuesList is { Count: > 0 })
+        {
+            var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
+            medianPriceList = new List<double>(seriesList.Count);
+            for (var i = 0; i < seriesList.Count; i++)
+            {
+                medianPriceList.Add((seriesHighList[i] + seriesLowList[i]) / 2);
+            }
+        }
+        else
+        {
+            medianPriceList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Hl2);
+        }
         var count = medianPriceList.Count;
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
 

--- a/src/Calculations/Inputs/InputsStoZ.cs
+++ b/src/Calculations/Inputs/InputsStoZ.cs
@@ -11,7 +11,22 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateTypicalPrice(this StockData stockData)
     {
-        var tpList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Hlc3);
+        // Chained: the same per-bar high and low every other indicator reads for a custom series
+        // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
+        List<double> tpList;
+        if (stockData.CustomValuesList is { Count: > 0 })
+        {
+            var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
+            tpList = new List<double>(seriesList.Count);
+            for (var i = 0; i < seriesList.Count; i++)
+            {
+                tpList.Add((seriesHighList[i] + seriesLowList[i] + seriesList[i]) / 3);
+            }
+        }
+        else
+        {
+            tpList = GetDerivedSeriesList(stockData, DerivedSeriesKind.Hlc3);
+        }
         var count = tpList.Count;
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
 
@@ -44,7 +59,22 @@ public static partial class Calculations
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateWeightedClose(this StockData stockData)    
     {
-        var weightedCloseList = GetDerivedSeriesList(stockData, DerivedSeriesKind.WeightedClose);
+        // Chained: the same per-bar high and low every other indicator reads for a custom series
+        // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
+        List<double> weightedCloseList;
+        if (stockData.CustomValuesList is { Count: > 0 })
+        {
+            var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
+            weightedCloseList = new List<double>(seriesList.Count);
+            for (var i = 0; i < seriesList.Count; i++)
+            {
+                weightedCloseList.Add((seriesHighList[i] + seriesLowList[i] + (seriesList[i] * 2)) / 4);
+            }
+        }
+        else
+        {
+            weightedCloseList = GetDerivedSeriesList(stockData, DerivedSeriesKind.WeightedClose);
+        }
         var count = weightedCloseList.Count;
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);

--- a/src/Calculations/Inputs/InputsStoZ.cs
+++ b/src/Calculations/Inputs/InputsStoZ.cs
@@ -14,7 +14,7 @@ public static partial class Calculations
         // Chained: the same per-bar high and low every other indicator reads for a custom series
         // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
         List<double> tpList;
-        if (stockData.CustomValuesList is { Count: > 0 })
+        if (stockData.ChainedValues is { Count: > 0 })
         {
             var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
             tpList = new List<double>(seriesList.Count);
@@ -62,7 +62,7 @@ public static partial class Calculations
         // Chained: the same per-bar high and low every other indicator reads for a custom series
         // (GetCustomRangeLists). Unchained: the cached derived series, exactly as before.
         List<double> weightedCloseList;
-        if (stockData.CustomValuesList is { Count: > 0 })
+        if (stockData.ChainedValues is { Count: > 0 })
         {
             var (seriesList, seriesHighList, seriesLowList, seriesOpenList, _) = GetInputValuesList(stockData);
             weightedCloseList = new List<double>(seriesList.Count);

--- a/src/Calculations/Inputs/InputsUse.cs
+++ b/src/Calculations/Inputs/InputsUse.cs
@@ -1,0 +1,65 @@
+using OoplesFinance.StockIndicators.Streaming;
+
+namespace OoplesFinance.StockIndicators;
+
+public static partial class Calculations
+{
+    /// <summary>
+    /// Computes an input series over every bar and chains it, so the next indicator computes on it.
+    /// </summary>
+    /// <param name="stockData">The stock data.</param>
+    /// <param name="series">
+    /// The series: a preset such as <see cref="InputSeries.MedianPrice"/>, a windowed one such as
+    /// <see cref="InputSeries.Midpoint"/>, or any <see cref="InputSeries.Of(System.Func{OhlcvBar, double})"/>.
+    /// </param>
+    /// <returns>The same <paramref name="stockData"/>, with the series chained.</returns>
+    /// <remarks>
+    /// <para>
+    /// The replacement for passing an input name, and the batch counterpart of
+    /// <see cref="CustomInputState"/> - the SAME preset objects work in both engines:
+    /// <code>
+    /// var rsi = stockData.UseInput(InputSeries.MedianPrice).CalculateRelativeStrengthIndex(14);
+    /// var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.MedianPrice);
+    /// </code>
+    /// </para>
+    /// <para>
+    /// Like every Calculate method it chains onto this StockData and returns it. The series is computed
+    /// on the bars' own prices, so it reads true opens, highs, lows and closes whatever was chained before.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Either argument is null.</exception>
+    public static StockData UseInput(this StockData stockData, IInputSeries series)
+    {
+        if (stockData is null)
+        {
+            throw new ArgumentNullException(nameof(stockData));
+        }
+
+        if (series is null)
+        {
+            throw new ArgumentNullException(nameof(series));
+        }
+
+        series.Reset();
+
+        var opens = stockData.OpenPrices;
+        var highs = stockData.HighPrices;
+        var lows = stockData.LowPrices;
+        var closes = stockData.ClosePrices;
+        var volumes = stockData.Volumes;
+        var dates = stockData.Dates;
+
+        var values = new List<double>(stockData.Count);
+        for (var i = 0; i < stockData.Count; i++)
+        {
+            var date = i < dates.Count ? dates[i] : default;
+            var bar = new OhlcvBar("BATCH", BarTimeframe.Tick, date, date,
+                opens[i], highs[i], lows[i], closes[i], volumes[i], isFinal: true);
+            values.Add(series.Next(bar, isFinal: true));
+        }
+
+        stockData.SetCustomValues(values);
+
+        return stockData;
+    }
+}

--- a/src/Calculations/Inputs/InputsUse.cs
+++ b/src/Calculations/Inputs/InputsUse.cs
@@ -58,7 +58,7 @@ public static partial class Calculations
             values.Add(series.Next(bar, isFinal: true));
         }
 
-        stockData.SetCustomValues(values);
+        stockData.SetInputSeries(values);
 
         return stockData;
     }

--- a/src/Calculations/Macd/MacdEtoK.cs
+++ b/src/Calculations/Macd/MacdEtoK.cs
@@ -76,7 +76,7 @@ public static partial class Calculations
         List<double> kcdList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var pkList = CalculateKasePeakOscillatorV1(stockData, length1, length2).OutputValues["Pk"];
+        var pkList = CalculateKasePeakOscillatorV1(stockData, length1, length2).ChainedOutputs["Pk"];
         var pkSignalList = GetMovingAverageList(stockData, maType, length3, pkList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Macd/MacdEtoK.cs
+++ b/src/Calculations/Macd/MacdEtoK.cs
@@ -13,7 +13,7 @@ public static partial class Calculations
     /// <param name="signalLength"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateImpulseMovingAverageConvergenceDivergence(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateImpulseMovingAverageConvergenceDivergence(this StockData stockData,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
     {
         List<double> macdList = new(stockData.Count);
@@ -21,7 +21,7 @@ public static partial class Calculations
         List<double> macdHistogramList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum macdSum = new();
-        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var typicalPriceZeroLagEmaList = GetMovingAverageList(stockData, MovingAvgType.ZeroLagExponentialMovingAverage, length, inputList);
         var wellesWilderHighMovingAvgList = GetMovingAverageList(stockData, maType, length, highList);

--- a/src/Calculations/Macd/MacdEtoK.cs
+++ b/src/Calculations/Macd/MacdEtoK.cs
@@ -7,7 +7,6 @@ public static partial class Calculations
     /// Calculates the Impulse Moving Average Convergence Divergence
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="length"></param>
     /// <param name="signalLength"></param>

--- a/src/Calculations/Macd/MacdLtoR.cs
+++ b/src/Calculations/Macd/MacdLtoR.cs
@@ -245,7 +245,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var fastSmaList = GetMovingAverageList(stockData, maType, fastLength, inputList);
         var slowSmaList = GetMovingAverageList(stockData, maType, slowLength, inputList);
         var wilderMovingAvgList = GetMovingAverageList(stockData, MovingAvgType.WildersSmoothingMethod, length, inputList);

--- a/src/Calculations/Momentum/MomentumAtoD.cs
+++ b/src/Calculations/Momentum/MomentumAtoD.cs
@@ -136,8 +136,8 @@ public static partial class Calculations
 
         if (stockData.Count == marketDataClass.InputValues.Count)
         {
-            var pmoList = CalculatePriceMomentumOscillator(stockData, maType, length1, length2, signalLength).CustomValuesList;
-            var spPmoList = CalculatePriceMomentumOscillator(marketDataClass, maType, length1, length2, signalLength).CustomValuesList;
+            var pmoList = CalculatePriceMomentumOscillator(stockData, maType, length1, length2, signalLength).ChainedValues;
+            var spPmoList = CalculatePriceMomentumOscillator(marketDataClass, maType, length1, length2, signalLength).ChainedValues;
 
             for (var i = 0; i < stockData.Count; i++)
             {
@@ -254,7 +254,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var standardDeviationList = CalculateStandardDeviationVolatility(stockData, maType, length1).CustomValuesList;
+        var standardDeviationList = CalculateStandardDeviationVolatility(stockData, maType, length1).ChainedValues;
         var stdDeviationSmaList = GetMovingAverageList(stockData, maType, length2, standardDeviationList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Momentum/MomentumAtoD.cs
+++ b/src/Calculations/Momentum/MomentumAtoD.cs
@@ -21,8 +21,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var stochList = CalculateStochasticOscillator(stockData, maType, length: length1, smoothLength1: length1, smoothLength2: length2);
-        var stochSmaList = stochList.OutputValues["FastD"];
-        var smaValList = stochList.OutputValues["SlowD"];
+        var stochSmaList = stochList.ChainedOutputs["FastD"];
+        var smaValList = stochList.ChainedOutputs["SlowD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Momentum/MomentumStoZ.cs
+++ b/src/Calculations/Momentum/MomentumStoZ.cs
@@ -22,11 +22,16 @@ public static partial class Calculations
         MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 13, int length2 = 19, int length3 = 21, int length4 = 39,
         int length5 = 50, int length6 = 200, double stdDevMult = 1.5)
     {
+        // Each component that takes its own inputName reads the CALLER's series. Those methods
+        // let a chained series win over their named input, and by the time this calculation calls
+        // them an earlier component has already published its output onto CustomValuesList - which
+        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
+        // their own named input exactly as before.
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> utmList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
-        var callerSeries = stockData.CaptureInputSeries();
         var moVar = CalculateMcClellanOscillator(stockData, maType, fastLength: length2, slowLength: length4);
         var advSumList = moVar.OutputValues["AdvSum"];
         var decSumList = moVar.OutputValues["DecSum"];

--- a/src/Calculations/Momentum/MomentumStoZ.cs
+++ b/src/Calculations/Momentum/MomentumStoZ.cs
@@ -32,9 +32,9 @@ public static partial class Calculations
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
         var moVar = CalculateMcClellanOscillator(stockData, maType, fastLength: length2, slowLength: length4);
-        var advSumList = moVar.OutputValues["AdvSum"];
-        var decSumList = moVar.OutputValues["DecSum"];
-        var moList = moVar.OutputValues["Mo"];
+        var advSumList = moVar.ChainedOutputs["AdvSum"];
+        var decSumList = moVar.ChainedOutputs["DecSum"];
+        var moList = moVar.ChainedOutputs["Mo"];
         stockData.RestoreInputSeries(callerSeries);
         var bbPctList = CalculateBollingerBandsPercentB(stockData, stdDevMult, maType, length5).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);

--- a/src/Calculations/Momentum/MomentumStoZ.cs
+++ b/src/Calculations/Momentum/MomentumStoZ.cs
@@ -7,7 +7,6 @@ public static partial class Calculations
     /// Calculates the Ultimate Momentum Indicator
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>

--- a/src/Calculations/Momentum/MomentumStoZ.cs
+++ b/src/Calculations/Momentum/MomentumStoZ.cs
@@ -36,13 +36,13 @@ public static partial class Calculations
         var decSumList = moVar.OutputValues["DecSum"];
         var moList = moVar.OutputValues["Mo"];
         stockData.RestoreInputSeries(callerSeries);
-        var bbPctList = CalculateBollingerBandsPercentB(stockData, stdDevMult, maType, length5).CustomValuesList;
+        var bbPctList = CalculateBollingerBandsPercentB(stockData, stdDevMult, maType, length5).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi1List = CalculateMoneyFlowIndex(stockData, length2).CustomValuesList;
+        var mfi1List = CalculateMoneyFlowIndex(stockData, length2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi2List = CalculateMoneyFlowIndex(stockData, length3).CustomValuesList;
+        var mfi2List = CalculateMoneyFlowIndex(stockData, length3).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi3List = CalculateMoneyFlowIndex(stockData, length4).CustomValuesList;
+        var mfi3List = CalculateMoneyFlowIndex(stockData, length4).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -60,7 +60,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(utmList);
-        var utmRsiList = CalculateRelativeStrengthIndex(stockData, maType, length1, length1).CustomValuesList;
+        var utmRsiList = CalculateRelativeStrengthIndex(stockData, maType, length1, length1).ChainedValues;
         var utmiList = GetMovingAverageList(stockData, maType, length1, utmRsiList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -116,7 +116,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(cumoSumList);
-        var rocList = CalculateRateOfChange(stockData, smoothLength).CustomValuesList;
+        var rocList = CalculateRateOfChange(stockData, smoothLength).ChainedValues;
         var tlmoList = GetMovingAverageList(stockData, maType, smoothLength, rocList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -170,7 +170,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(diffList);
-        var linregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var predictedToday = linregList[i];

--- a/src/Calculations/Momentum/MomentumStoZ.cs
+++ b/src/Calculations/Momentum/MomentumStoZ.cs
@@ -18,15 +18,15 @@ public static partial class Calculations
     /// <param name="stdDevMult"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateUltimateMomentumIndicator(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateUltimateMomentumIndicator(this StockData stockData,
         MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 13, int length2 = 19, int length3 = 21, int length4 = 39,
         int length5 = 50, int length6 = 200, double stdDevMult = 1.5)
     {
-        // Each component that takes its own inputName reads the CALLER's series. Those methods
-        // let a chained series win over their named input, and by the time this calculation calls
-        // them an earlier component has already published its output onto CustomValuesList - which
-        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
-        // their own named input exactly as before.
+        // The components that read their own default input - a typical or median price - read the
+        // CALLER's series instead whenever one is chained, and by the time this calculation calls them
+        // an earlier component has already published its output onto CustomValuesList, which they would
+        // otherwise take for the caller's chain. Unchained this is empty, and they read their own
+        // default input exactly as before.
         var callerSeries = stockData.CaptureInputSeries();
         List<double> utmList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
@@ -39,11 +39,11 @@ public static partial class Calculations
         stockData.RestoreInputSeries(callerSeries);
         var bbPctList = CalculateBollingerBandsPercentB(stockData, stdDevMult, maType, length5).CustomValuesList;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi1List = CalculateMoneyFlowIndex(stockData, inputName, length2).CustomValuesList;
+        var mfi1List = CalculateMoneyFlowIndex(stockData, length2).CustomValuesList;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi2List = CalculateMoneyFlowIndex(stockData, inputName, length3).CustomValuesList;
+        var mfi2List = CalculateMoneyFlowIndex(stockData, length3).CustomValuesList;
         stockData.RestoreInputSeries(callerSeries);
-        var mfi3List = CalculateMoneyFlowIndex(stockData, inputName, length4).CustomValuesList;
+        var mfi3List = CalculateMoneyFlowIndex(stockData, length4).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/EhlersMovingAverages.cs
+++ b/src/Calculations/MovingAverages/EhlersMovingAverages.cs
@@ -1325,7 +1325,7 @@ public static partial class Calculations
 
         var ssf2PoleList = GetMovingAverageList(stockData, maType, fastLength, avgZerosList);
         stockData.SetCustomValues(ssf2PoleList);
-        var ssf2PoleStdDevList = CalculateStandardDeviationVolatility(stockData, length: slowLength).CustomValuesList;
+        var ssf2PoleStdDevList = CalculateStandardDeviationVolatility(stockData, length: slowLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];

--- a/src/Calculations/MovingAverages/MovingAveragesAtoD.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesAtoD.cs
@@ -209,7 +209,7 @@ public static partial class Calculations
         double absDiffSum = 0;
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -835,7 +835,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/MovingAveragesAtoD.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesAtoD.cs
@@ -564,7 +564,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var yMaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var devList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var devList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -585,7 +585,7 @@ public static partial class Calculations
 
         var xMaList = GetMovingAverageList(stockData, maType, length, xList);
         stockData.SetCustomValues(xList);
-        var mxList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var mxList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var my = devList[i];
@@ -631,7 +631,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var devList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var devList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -671,7 +671,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1289,8 +1289,8 @@ public static partial class Calculations
         double tempSum = 0;
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var shortStdDevList = CalculateStandardDeviationVolatility(stockData, length: fastLength).CustomValuesList;
-        var longStdDevList = CalculateStandardDeviationVolatility(stockData, length: slowLength).CustomValuesList;
+        var shortStdDevList = CalculateStandardDeviationVolatility(stockData, length: fastLength).ChainedValues;
+        var longStdDevList = CalculateStandardDeviationVolatility(stockData, length: slowLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/MovingAveragesEtoL.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesEtoL.cs
@@ -240,8 +240,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var wmaList = CalculateWeightedMovingAverage(stockData, length).CustomValuesList;
-        var smaList = CalculateSimpleMovingAverage(stockData, length).CustomValuesList;
+        var wmaList = CalculateWeightedMovingAverage(stockData, length).ChainedValues;
+        var smaList = CalculateSimpleMovingAverage(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -425,8 +425,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var wmaList = CalculateWeightedMovingAverage(stockData, length).CustomValuesList;
-        var smaList = CalculateSimpleMovingAverage(stockData, length).CustomValuesList;
+        var wmaList = CalculateWeightedMovingAverage(stockData, length).ChainedValues;
+        var smaList = CalculateSimpleMovingAverage(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -480,9 +480,9 @@ public static partial class Calculations
 
         var sma1List = GetMovingAverageList(stockData, maType, length, inputList);
         var sma2List = GetMovingAverageList(stockData, maType, length1, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(indexList);
-        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var indexSmaList = GetMovingAverageList(stockData, maType, length, indexList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1257,7 +1257,7 @@ public static partial class Calculations
         RollingSum diffSum = new();
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevSrcList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevSrcList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var smaSrcList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1267,7 +1267,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(indexList);
-        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var indexSmaList = GetMovingAverageList(stockData, maType, length, indexList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1658,7 +1658,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(absOsList);
-        var pList = CalculateLinearRegression(stockData, smoothLength).CustomValuesList;
+        var pList = CalculateLinearRegression(stockData, smoothLength).ChainedValues;
         var (highestList, _) = GetMaxAndMinValuesList(pList, length);
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/MovingAveragesEtoL.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesEtoL.cs
@@ -1327,9 +1327,9 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var kamaList = CalculateKaufmanAdaptiveCorrelationOscillator(stockData, maType, length);
-        var indexStList = kamaList.OutputValues["IndexSt"];
-        var srcStList = kamaList.OutputValues["SrcSt"];
-        var rList = kamaList.OutputValues["Kaco"];
+        var indexStList = kamaList.ChainedOutputs["IndexSt"];
+        var srcStList = kamaList.ChainedOutputs["SrcSt"];
+        var rList = kamaList.ChainedOutputs["Kaco"];
         var srcMaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/MovingAverages/MovingAveragesMtoR.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesMtoR.cs
@@ -273,9 +273,9 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(nList);
-        var nVarianceList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var nVarianceList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(n2List);
-        var n2VarianceList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var n2VarianceList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -551,9 +551,9 @@ public static partial class Calculations
 
         var indexSmaList = GetMovingAverageList(stockData, maType, length, indexList);
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(indexList);
-        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -1016,10 +1016,10 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var callerSeries = stockData.CaptureInputSeries();
-        var linregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linregList = CalculateLinearRegression(stockData, length).ChainedValues;
         // The deviation is of the prices, not of the regression line just published onto CustomValuesList.
         stockData.RestoreInputSeries(callerSeries);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1564,7 +1564,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var mhlList = CalculateMidpoint(stockData, length2).CustomValuesList;
+        var mhlList = CalculateMidpoint(stockData, length2).ChainedValues;
         var mhlMaList = GetMovingAverageList(stockData, maType, length1, mhlList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/MovingAverages/MovingAveragesMtoR.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesMtoR.cs
@@ -21,7 +21,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1490,7 +1490,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
@@ -200,7 +200,7 @@ public static partial class Calculations
     /// <param name="inputName">Name of the input.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateVolumeWeightedAveragePrice(this StockData stockData, InputName inputName = InputName.TypicalPrice)
+    public static StockData CalculateVolumeWeightedAveragePrice(this StockData stockData)
     {
         List<double> vwapList = new(stockData.Count);
         List<double> tempVolList = new(stockData.Count);
@@ -208,7 +208,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         double tempVolSum = 0;
         double tempVolPriceSum = 0;
-        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
@@ -197,7 +197,6 @@ public static partial class Calculations
     /// Calculates the volume weighted average price.
     /// </summary>
     /// <param name="stockData">The stock data.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateVolumeWeightedAveragePrice(this StockData stockData)

--- a/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
@@ -317,7 +317,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var callerSeries = stockData.CaptureInputSeries();
-        var lenList = CalculateVariableLengthMovingAverage(stockData, maType, minLength, maxLength).OutputValues["Length"];
+        var lenList = CalculateVariableLengthMovingAverage(stockData, maType, minLength, maxLength).ChainedOutputs["Length"];
         // The typical price of the bars. The variable-length average publishes itself onto CustomValuesList,
         // and the typical price used to take it for the close.
         stockData.RestoreInputSeries(callerSeries);
@@ -1373,7 +1373,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var callerSeries = stockData.CaptureInputSeries();
-        var efRatioList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var efRatioList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
         // The first deviation is of the prices, not of the KAMA just published onto CustomValuesList.
         stockData.RestoreInputSeries(callerSeries);
         var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;

--- a/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
+++ b/src/Calculations/MovingAverages/MovingAveragesStoZ.cs
@@ -321,7 +321,7 @@ public static partial class Calculations
         // The typical price of the bars. The variable-length average publishes itself onto CustomValuesList,
         // and the typical price used to take it for the close.
         stockData.RestoreInputSeries(callerSeries);
-        var tpList = CalculateTypicalPrice(stockData).CustomValuesList;
+        var tpList = CalculateTypicalPrice(stockData).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -395,7 +395,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, maxLength, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, maxLength).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, maxLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -839,7 +839,7 @@ public static partial class Calculations
 
         var alpha = (double)2 / (length + 1);
 
-        var cmoList = CalculateChandeMomentumOscillator(stockData, maType, length: length).CustomValuesList;
+        var cmoList = CalculateChandeMomentumOscillator(stockData, maType, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1029,7 +1029,7 @@ public static partial class Calculations
 
         var s = MinOrMax((int)Math.Ceiling(Sqrt(length)));
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1239,7 +1239,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, lbLength, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, lbLength).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, lbLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1376,7 +1376,7 @@ public static partial class Calculations
         var efRatioList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
         // The first deviation is of the prices, not of the KAMA just published onto CustomValuesList.
         stockData.RestoreInputSeries(callerSeries);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1403,7 +1403,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(bList);
-        var bStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var bStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var bSmaList = GetMovingAverageList(stockData, maType, length, bList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1454,7 +1454,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var linRegList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/ClassicOscillators.cs
+++ b/src/Calculations/Oscillators/ClassicOscillators.cs
@@ -11,7 +11,6 @@ public static partial class Calculations
     /// <param name="stockData">The stock data.</param>
     /// <param name="length">The length.</param>
     /// <param name="maType">Type of the ma.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="constant">The constant.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
@@ -65,7 +64,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData">The stock data.</param>
     /// <param name="maType">Type of the ma.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="fastLength">Length of the fast.</param>
     /// <param name="slowLength">Length of the slow.</param>
     /// <returns></returns>
@@ -108,7 +106,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData">The stock data.</param>
     /// <param name="maType">Type of the ma.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="fastLength">Length of the fast.</param>
     /// <param name="slowLength">Length of the slow.</param>
     /// <param name="smoothLength">Length of the smooth.</param>
@@ -388,7 +385,6 @@ public static partial class Calculations
     /// Calculates the index of the alligator.
     /// </summary>
     /// <param name="stockData">The stock data.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="maType">Type of the ma.</param>
     /// <param name="iawLength">Length of the iaw.</param>
     /// <param name="iawOffset">The iaw offset.</param>
@@ -447,7 +443,6 @@ public static partial class Calculations
     /// Calculates the gator oscillator.
     /// </summary>
     /// <param name="stockData">The stock data.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="maType">Type of the ma.</param>
     /// <param name="jawLength">Length of the jaw.</param>
     /// <param name="jawOffset">The jaw offset.</param>

--- a/src/Calculations/Oscillators/ClassicOscillators.cs
+++ b/src/Calculations/Oscillators/ClassicOscillators.cs
@@ -114,7 +114,7 @@ public static partial class Calculations
     public static StockData CalculateAcceleratorOscillator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int fastLength = 5, int slowLength = 34, int smoothLength = 5)
     {
-        var awesomeOscList = CalculateAwesomeOscillator(stockData, maType, fastLength, slowLength).CustomValuesList;
+        var awesomeOscList = CalculateAwesomeOscillator(stockData, maType, fastLength, slowLength).ChainedValues;
         var count = awesomeOscList.Count;
         var acList = new List<double>(count);
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
@@ -292,7 +292,7 @@ public static partial class Calculations
         List<double> chaikinOscillatorList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var adlList = CalculateAccumulationDistributionLine(stockData, maType, fastLength).CustomValuesList;
+        var adlList = CalculateAccumulationDistributionLine(stockData, maType, fastLength).ChainedValues;
         var adl3EmaList = GetMovingAverageList(stockData, maType, fastLength, adlList);
         var adl10EmaList = GetMovingAverageList(stockData, maType, slowLength, adlList);
 

--- a/src/Calculations/Oscillators/ClassicOscillators.cs
+++ b/src/Calculations/Oscillators/ClassicOscillators.cs
@@ -15,14 +15,14 @@ public static partial class Calculations
     /// <param name="constant">The constant.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateCommodityChannelIndex(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateCommodityChannelIndex(this StockData stockData,
         MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20, double constant = 0.015)
     {
         List<double> cciList = new(stockData.Count);
         List<double> tpDevDiffList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var (inputList, _, _, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
         var tpSmaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -70,10 +70,9 @@ public static partial class Calculations
     /// <param name="slowLength">Length of the slow.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateAwesomeOscillator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.MedianPrice, int fastLength = 5, int slowLength = 34)
+    public static StockData CalculateAwesomeOscillator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5, int slowLength = 34)
     {
-        var (inputList, _, _, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, _) = GetInputValuesList(InputName.MedianPrice, stockData);
         var count = inputList.Count;
         var aoList = new List<double>(count);
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
@@ -115,10 +114,10 @@ public static partial class Calculations
     /// <param name="smoothLength">Length of the smooth.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateAcceleratorOscillator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, InputName inputName = InputName.MedianPrice,
+    public static StockData CalculateAcceleratorOscillator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int fastLength = 5, int slowLength = 34, int smoothLength = 5)
     {
-        var awesomeOscList = CalculateAwesomeOscillator(stockData, maType, inputName, fastLength, slowLength).CustomValuesList;
+        var awesomeOscList = CalculateAwesomeOscillator(stockData, maType, fastLength, slowLength).CustomValuesList;
         var count = awesomeOscList.Count;
         var acList = new List<double>(count);
         List<Signal>? signalsList = CreateSignalsList(stockData, count);
@@ -399,7 +398,7 @@ public static partial class Calculations
     /// <param name="lipsOffset">The lips offset.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateAlligatorIndex(this StockData stockData, InputName inputName = InputName.MedianPrice, 
+    public static StockData CalculateAlligatorIndex(this StockData stockData, 
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13, int jawOffset = 8, int teethLength = 8, int teethOffset = 5, 
         int lipsLength = 5, int lipsOffset = 3)
     {
@@ -407,7 +406,7 @@ public static partial class Calculations
         List<double> displacedTeethList = new(stockData.Count);
         List<double> displacedLipsList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, _) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         var jawList = GetMovingAverageList(stockData, maType, jawLength, inputList);
         var teethList = GetMovingAverageList(stockData, maType, teethLength, inputList);
@@ -458,7 +457,7 @@ public static partial class Calculations
     /// <param name="lipsOffset">The lips offset.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateGatorOscillator(this StockData stockData, InputName inputName = InputName.MedianPrice, 
+    public static StockData CalculateGatorOscillator(this StockData stockData, 
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13, int jawOffset = 8, int teethLength = 8, int teethOffset = 5, 
         int lipsLength = 5, int lipsOffset = 3)
     {
@@ -466,7 +465,7 @@ public static partial class Calculations
         List<double> bottomList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var alligatorList = CalculateAlligatorIndex(stockData, inputName, maType, jawLength, jawOffset, teethLength, teethOffset, lipsLength, lipsOffset).OutputValues;
+        var alligatorList = CalculateAlligatorIndex(stockData, maType, jawLength, jawOffset, teethLength, teethOffset, lipsLength, lipsOffset).OutputValues;
         var jawList = alligatorList["Jaws"];
         var teethList = alligatorList["Teeth"];
         var lipsList = alligatorList["Lips"];

--- a/src/Calculations/Oscillators/ClassicOscillators.cs
+++ b/src/Calculations/Oscillators/ClassicOscillators.cs
@@ -460,7 +460,7 @@ public static partial class Calculations
         List<double> bottomList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var alligatorList = CalculateAlligatorIndex(stockData, maType, jawLength, jawOffset, teethLength, teethOffset, lipsLength, lipsOffset).OutputValues;
+        var alligatorList = CalculateAlligatorIndex(stockData, maType, jawLength, jawOffset, teethLength, teethOffset, lipsLength, lipsOffset).ChainedOutputs;
         var jawList = alligatorList["Jaws"];
         var teethList = alligatorList["Teeth"];
         var lipsList = alligatorList["Lips"];

--- a/src/Calculations/Oscillators/OscillatorsAtoD.cs
+++ b/src/Calculations/Oscillators/OscillatorsAtoD.cs
@@ -601,15 +601,14 @@ public static partial class Calculations
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateChartmillValueIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, 
-        InputName inputName = InputName.MedianPrice, int length = 5)
+    public static StockData CalculateChartmillValueIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 5)
     {
         List<double> cmvCList = new(stockData.Count);
         List<double> cmvOList = new(stockData.Count);
         List<double> cmvHList = new(stockData.Count);
         List<double> cmvLList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
         var fList = GetMovingAverageList(stockData, maType, length, inputList);
@@ -787,12 +786,11 @@ public static partial class Calculations
     /// <param name="length2"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateChopZone(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, 
-        InputName inputName = InputName.TypicalPrice, int length1 = 30, int length2 = 34)
+    public static StockData CalculateChopZone(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 30, int length2 = 34)
     {
         List<double> emaAngleList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length1);
 
         var emaList = GetMovingAverageList(stockData, maType, length2, closeList);
@@ -929,8 +927,7 @@ public static partial class Calculations
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateConfluenceIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, 
-        InputName inputName = InputName.FullTypicalPrice, int length = 10)
+    public static StockData CalculateConfluenceIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10)
     {
         List<double> value5List = new(stockData.Count);
         List<double> value6List = new(stockData.Count);
@@ -941,7 +938,7 @@ public static partial class Calculations
         List<double> value70List = new(stockData.Count);
         List<double> confluenceList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, _, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, closeList, _) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
         var errSumWindow = new RollingSum();
         var value70SumWindow = new RollingSum();
 

--- a/src/Calculations/Oscillators/OscillatorsAtoD.cs
+++ b/src/Calculations/Oscillators/OscillatorsAtoD.cs
@@ -324,8 +324,8 @@ public static partial class Calculations
         var probBbBasisDownSumWindow = new RollingSum();
 
         var bbList = CalculateBollingerBands(stockData, maType, length, stdDevMult);
-        var upperBbList = bbList.OutputValues["UpperBand"];
-        var basisList = bbList.OutputValues["MiddleBand"];
+        var upperBbList = bbList.ChainedOutputs["UpperBand"];
+        var basisList = bbList.ChainedOutputs["MiddleBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/OscillatorsAtoD.cs
+++ b/src/Calculations/Oscillators/OscillatorsAtoD.cs
@@ -597,7 +597,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
@@ -781,7 +780,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>
     /// <returns></returns>
@@ -923,7 +921,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]

--- a/src/Calculations/Oscillators/OscillatorsAtoD.cs
+++ b/src/Calculations/Oscillators/OscillatorsAtoD.cs
@@ -1220,6 +1220,7 @@ public static partial class Calculations
     public static StockData CalculateCommoditySelectionIndex(this StockData stockData, MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, 
         int length = 14, double pointValue = 50, double margin = 3000, double commission = 10)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> csiList = new(stockData.Count);
         List<double> csiSmaList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
@@ -1229,7 +1230,7 @@ public static partial class Calculations
 
         var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
         // Clear state to prevent pollution of CalculateAverageDirectionalIndex inputs
-        stockData.SetCustomValues(new List<double>());
+        stockData.RestoreInputSeries(callerSeries);
         stockData.SetSignals(null);
         var adxList = CalculateAverageDirectionalIndex(stockData, maType, length).CustomValuesList;
 

--- a/src/Calculations/Oscillators/OscillatorsAtoD.cs
+++ b/src/Calculations/Oscillators/OscillatorsAtoD.cs
@@ -158,7 +158,7 @@ public static partial class Calculations
         var mep = (double)2 / (smoothLength + 1);
         double ce = (stochLength + smoothLength) * 2;
 
-        var stochList = CalculateStochasticOscillator(stockData, maType, length: stochLength).CustomValuesList;
+        var stochList = CalculateStochasticOscillator(stockData, maType, length: stochLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -609,7 +609,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(InputName.MedianPrice, stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         var fList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1107,8 +1107,8 @@ public static partial class Calculations
         List<double> rocTotalList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var roc11List = CalculateRateOfChange(stockData, fastLength).CustomValuesList;
-        var roc14List = CalculateRateOfChange(stockData, slowLength).CustomValuesList;
+        var roc11List = CalculateRateOfChange(stockData, fastLength).ChainedValues;
+        var roc14List = CalculateRateOfChange(stockData, slowLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1160,8 +1160,8 @@ public static partial class Calculations
         List<double> bearSlopeList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rsi1List = CalculateRelativeStrengthIndex(stockData, length: length1).CustomValuesList;
-        var rsi2List = CalculateRelativeStrengthIndex(stockData, length: smoothLength).CustomValuesList;
+        var rsi1List = CalculateRelativeStrengthIndex(stockData, length: length1).ChainedValues;
+        var rsi2List = CalculateRelativeStrengthIndex(stockData, length: smoothLength).ChainedValues;
         var rsiSmaList = GetMovingAverageList(stockData, maType, smoothLength, rsi2List);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1228,11 +1228,11 @@ public static partial class Calculations
 
         var k = 100 * (pointValue / Sqrt(margin) / (150 + commission));
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         // Clear state to prevent pollution of CalculateAverageDirectionalIndex inputs
         stockData.RestoreInputSeries(callerSeries);
         stockData.SetSignals(null);
-        var adxList = CalculateAverageDirectionalIndex(stockData, maType, length).CustomValuesList;
+        var adxList = CalculateAverageDirectionalIndex(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1443,7 +1443,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var s1SumWindow = new RollingSum();
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
         var rsiEma1List = GetMovingAverageList(stockData, maType, length3, rsiList);
         var rsiEma2List = GetMovingAverageList(stockData, maType, length4, rsiEma1List);
 

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -494,35 +494,25 @@ public static partial class Calculations
         var rocSumWindow = new RollingSum();
 
         var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).CustomValuesList;
-        // Reset CustomValuesList to prevent contamination of derived series (TypicalPrice uses CustomValuesList as close)
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
-        stockData.SetInputSeries(new List<double>(callerSeries));
+        // Each component reads the caller's series; each Calculate call leaves its own output on CustomValuesList.
+        stockData.RestoreInputSeries(callerSeries);
         var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
-        stockData.SetInputSeries(new List<double>(callerSeries));
+        stockData.RestoreInputSeries(callerSeries);
         var mfiList = CalculateMoneyFlowIndex(stockData, length: mfiLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var macdList = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength,
             signalLength: signalLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var bbIndicatorList = CalculateBollingerBandsPercentB(stockData, stdDevMult: stdDevMult, length: bbLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var dpoList = CalculateDetrendedPriceOscillator(stockData, length: dpoLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var rocList = CalculateRateOfChange(stockData, length: rocLength).CustomValuesList;
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var stochasticList = CalculateStochasticOscillator(stockData, length: stochLength, smoothLength1: stochKLength, smoothLength2: stochDLength);
         var stochKList = stochasticList.OutputValues["FastD"];
         var stochDList = stochasticList.OutputValues["SlowD"];
-        stockData.SetInputSeries(new List<double>(callerSeries));
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var emvList = CalculateEaseOfMovement(stockData, length: emoLength, divisor: divisor).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -1379,7 +1379,10 @@ public static partial class Calculations
         List<double> fsrsiList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
+        // Both components read the caller's series; the kurtosis used to read the RSI just published.
+        var callerSeries = stockData.CaptureInputSeries();
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length3).ChainedValues;
+        stockData.RestoreInputSeries(callerSeries);
         var fskList = CalculateFastandSlowKurtosisOscillator(stockData, maType, length: length1).ChainedValues;
         var v4List = GetMovingAverageList(stockData, maType, length2, fskList);
 

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -495,33 +495,33 @@ public static partial class Calculations
 
         var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).CustomValuesList;
         // Reset CustomValuesList to prevent contamination of derived series (TypicalPrice uses CustomValuesList as close)
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
-        stockData.SetCustomValues(new List<double>(callerSeries));
+        stockData.SetInputSeries(new List<double>(callerSeries));
         var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
-        stockData.SetCustomValues(new List<double>(callerSeries));
+        stockData.SetInputSeries(new List<double>(callerSeries));
         var mfiList = CalculateMoneyFlowIndex(stockData, length: mfiLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var macdList = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength,
             signalLength: signalLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var bbIndicatorList = CalculateBollingerBandsPercentB(stockData, stdDevMult: stdDevMult, length: bbLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var dpoList = CalculateDetrendedPriceOscillator(stockData, length: dpoLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var rocList = CalculateRateOfChange(stockData, length: rocLength).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var stochasticList = CalculateStochasticOscillator(stockData, length: stochLength, smoothLength1: stochKLength, smoothLength2: stochDLength);
         var stochKList = stochasticList.OutputValues["FastD"];
         var stochDList = stochasticList.OutputValues["SlowD"];
-        stockData.SetCustomValues(new List<double>());
+        stockData.SetInputSeries(new List<double>(callerSeries));
         stockData.SignalsList = new List<Signal>();
         var emvList = CalculateEaseOfMovement(stockData, length: emoLength, divisor: divisor).CustomValuesList;
 

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -473,6 +473,12 @@ public static partial class Calculations
         int cciLength = 14, int dpoLength = 18, int rocLength = 10, int rsiLength = 14, int stochLength = 14, int stochKLength = 1,
         int stochDLength = 3, int smaLength = 10, double stdDevMult = 2, double divisor = 10000)
     {
+        // Each component that takes its own inputName reads the CALLER's series. Those methods
+        // let a chained series win over their named input, and by the time this calculation calls
+        // them an earlier component has already published its output onto CustomValuesList - which
+        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
+        // their own named input exactly as before.
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> iidxList = new(stockData.Count);
         List<double> tempMacdList = new(stockData.Count);
         List<double> tempDpoList = new(stockData.Count);
@@ -491,9 +497,11 @@ public static partial class Calculations
         // Reset CustomValuesList to prevent contamination of derived series (TypicalPrice uses CustomValuesList as close)
         stockData.SetCustomValues(new List<double>());
         stockData.SignalsList = new List<Signal>();
+        stockData.SetCustomValues(new List<double>(callerSeries));
         var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).CustomValuesList;
         stockData.SetCustomValues(new List<double>());
         stockData.SignalsList = new List<Signal>();
+        stockData.SetCustomValues(new List<double>(callerSeries));
         var mfiList = CalculateMoneyFlowIndex(stockData, length: mfiLength).CustomValuesList;
         stockData.SetCustomValues(new List<double>());
         stockData.SignalsList = new List<Signal>();

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -2800,7 +2800,6 @@ public static partial class Calculations
     /// Calculates the Earning Support Resistance Levels
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateEarningSupportResistanceLevels(this StockData stockData)

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -271,7 +271,7 @@ public static partial class Calculations
     {
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rviList = CalculateRelativeVolatilityIndexV2(stockData).CustomValuesList;
+        var rviList = CalculateRelativeVolatilityIndexV2(stockData).ChainedValues;
         var inertiaList = GetMovingAverageList(stockData, maType, length, rviList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -363,11 +363,11 @@ public static partial class Calculations
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         stockData.SetCustomValues(smaList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(smaList);
-        var linreg1List = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linreg1List = CalculateLinearRegression(stockData, length).ChainedValues;
         stockData.SetCustomValues(smaList);
-        var linreg2List = CalculateLinearRegression(stockData, length1).CustomValuesList;
+        var linreg2List = CalculateLinearRegression(stockData, length1).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -415,7 +415,7 @@ public static partial class Calculations
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -493,27 +493,27 @@ public static partial class Calculations
         var dpoSumWindow = new RollingSum();
         var rocSumWindow = new RollingSum();
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).ChainedValues;
         // Each component reads the caller's series; each Calculate call leaves its own output on CustomValuesList.
         stockData.RestoreInputSeries(callerSeries);
-        var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).CustomValuesList;
+        var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var mfiList = CalculateMoneyFlowIndex(stockData, length: mfiLength).CustomValuesList;
+        var mfiList = CalculateMoneyFlowIndex(stockData, length: mfiLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var macdList = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength,
-            signalLength: signalLength).CustomValuesList;
+            signalLength: signalLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var bbIndicatorList = CalculateBollingerBandsPercentB(stockData, stdDevMult: stdDevMult, length: bbLength).CustomValuesList;
+        var bbIndicatorList = CalculateBollingerBandsPercentB(stockData, stdDevMult: stdDevMult, length: bbLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var dpoList = CalculateDetrendedPriceOscillator(stockData, length: dpoLength).CustomValuesList;
+        var dpoList = CalculateDetrendedPriceOscillator(stockData, length: dpoLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var rocList = CalculateRateOfChange(stockData, length: rocLength).CustomValuesList;
+        var rocList = CalculateRateOfChange(stockData, length: rocLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var stochasticList = CalculateStochasticOscillator(stockData, length: stochLength, smoothLength1: stochKLength, smoothLength2: stochDLength);
         var stochKList = stochasticList.OutputValues["FastD"];
         var stochDList = stochasticList.OutputValues["SlowD"];
         stockData.RestoreInputSeries(callerSeries);
-        var emvList = CalculateEaseOfMovement(stockData, length: emoLength, divisor: divisor).CustomValuesList;
+        var emvList = CalculateEaseOfMovement(stockData, length: emoLength, divisor: divisor).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -697,7 +697,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -715,7 +715,7 @@ public static partial class Calculations
 
         var smoList = GetMovingAverageList(stockData, maType, smoothLength, oscList);
         stockData.SetCustomValues(smoList);
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: smoothLength).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: smoothLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var rsi = rsiList[i];
@@ -754,7 +754,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1379,8 +1379,8 @@ public static partial class Calculations
         List<double> fsrsiList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length3).CustomValuesList;
-        var fskList = CalculateFastandSlowKurtosisOscillator(stockData, maType, length: length1).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length3).ChainedValues;
+        var fskList = CalculateFastandSlowKurtosisOscillator(stockData, maType, length: length1).ChainedValues;
         var v4List = GetMovingAverageList(stockData, maType, length2, fskList);
 
         for (var i = 0; i < v4List.Count; i++)
@@ -1578,7 +1578,7 @@ public static partial class Calculations
 
         var v3List = GetMovingAverageList(stockData, maType, length, v2List);
         stockData.SetCustomValues(v2List);
-        var v4List = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var v4List = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var v2 = v2List[i];
@@ -1706,7 +1706,7 @@ public static partial class Calculations
         var w1 = 2 / (nr + 1);
         var w2 = 1 - w1;
 
-        var cciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: cciLength).CustomValuesList;
+        var cciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: cciLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1845,13 +1845,13 @@ public static partial class Calculations
         var (inputList, highList, lowList, openList, _) = GetInputValuesList(stockData);
 
         stockData.SetCustomValues(inputList);
-        var rsiCList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiCList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(openList);
-        var rsiOList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiOList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(highList);
-        var rsiHList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiHList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(lowList);
-        var rsiLList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiLList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1961,7 +1961,7 @@ public static partial class Calculations
 
         var sqrt = Sqrt(length);
 
-        var atrList = CalculateAverageTrueRange(stockData, length: length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1980,7 +1980,7 @@ public static partial class Calculations
         var pkList = GetMovingAverageList(stockData, MovingAvgType.WeightedMovingAverage, smoothLength, diffList);
         var mnList = GetMovingAverageList(stockData, MovingAvgType.SimpleMovingAverage, length, pkList);
         stockData.SetCustomValues(pkList);
-        var sdList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var sdList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var pk = pkList[i];
@@ -2052,7 +2052,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(ccLogList);
-        var ccDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).CustomValuesList;
+        var ccDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).ChainedValues;
         var ccDevAvgList = GetMovingAverageList(stockData, maType, length2, ccDevList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2092,7 +2092,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(xpAbsList);
-        var xpAbsStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length3).CustomValuesList;
+        var xpAbsStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length3).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var xpAbsAvg = xpAbsAvgList[i];
@@ -2155,7 +2155,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(tempList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentHigh = highList[i];
@@ -2230,7 +2230,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(diffList);
-        var diffStdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var diffStdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -2433,13 +2433,13 @@ public static partial class Calculations
         List<double> kstList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var roc1List = CalculateRateOfChange(stockData, rocLength1).CustomValuesList;
+        var roc1List = CalculateRateOfChange(stockData, rocLength1).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc2List = CalculateRateOfChange(stockData, rocLength2).CustomValuesList;
+        var roc2List = CalculateRateOfChange(stockData, rocLength2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc3List = CalculateRateOfChange(stockData, rocLength3).CustomValuesList;
+        var roc3List = CalculateRateOfChange(stockData, rocLength3).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc4List = CalculateRateOfChange(stockData, rocLength4).CustomValuesList;
+        var roc4List = CalculateRateOfChange(stockData, rocLength4).ChainedValues;
         var roc1SmaList = GetMovingAverageList(stockData, maType, length1, roc1List);
         var roc2SmaList = GetMovingAverageList(stockData, maType, length2, roc2List);
         var roc3SmaList = GetMovingAverageList(stockData, maType, length3, roc3List);
@@ -2498,7 +2498,7 @@ public static partial class Calculations
         var sqrtPeriod = Sqrt(length);
 
         var volumeSmaList = GetMovingAverageList(stockData, maType, length, volumeList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2550,7 +2550,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
         var corrWindow = new RollingCorrelation();
 
-        var linRegList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2616,7 +2616,7 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -3186,7 +3186,7 @@ public static partial class Calculations
 
         var k = 100 * (pointValue / Sqrt(length) / (150 + smoothLength));
 
-        var adxList = CalculateAverageDirectionalIndex(stockData, maType, length).CustomValuesList;
+        var adxList = CalculateAverageDirectionalIndex(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -473,11 +473,11 @@ public static partial class Calculations
         int cciLength = 14, int dpoLength = 18, int rocLength = 10, int rsiLength = 14, int stochLength = 14, int stochKLength = 1,
         int stochDLength = 3, int smaLength = 10, double stdDevMult = 2, double divisor = 10000)
     {
-        // Each component that takes its own inputName reads the CALLER's series. Those methods
-        // let a chained series win over their named input, and by the time this calculation calls
-        // them an earlier component has already published its output onto CustomValuesList - which
-        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
-        // their own named input exactly as before.
+        // The components that read their own default input - a typical or median price - read the
+        // CALLER's series instead whenever one is chained, and by the time this calculation calls them
+        // an earlier component has already published its output onto CustomValuesList, which they would
+        // otherwise take for the caller's chain. Unchained this is empty, and they read their own
+        // default input exactly as before.
         var callerSeries = stockData.CaptureInputSeries();
         List<double> iidxList = new(stockData.Count);
         List<double> tempMacdList = new(stockData.Count);
@@ -2803,12 +2803,12 @@ public static partial class Calculations
     /// <param name="inputName"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateEarningSupportResistanceLevels(this StockData stockData, InputName inputName = InputName.MedianPrice)
+    public static StockData CalculateEarningSupportResistanceLevels(this StockData stockData)
     {
         List<double> mode1List = new(stockData.Count);
         List<double> mode2List = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -510,8 +510,8 @@ public static partial class Calculations
         var rocList = CalculateRateOfChange(stockData, length: rocLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var stochasticList = CalculateStochasticOscillator(stockData, length: stochLength, smoothLength1: stochKLength, smoothLength2: stochDLength);
-        var stochKList = stochasticList.OutputValues["FastD"];
-        var stochDList = stochasticList.OutputValues["SlowD"];
+        var stochKList = stochasticList.ChainedOutputs["FastD"];
+        var stochDList = stochasticList.ChainedOutputs["SlowD"];
         stockData.RestoreInputSeries(callerSeries);
         var emvList = CalculateEaseOfMovement(stockData, length: emoLength, divisor: divisor).ChainedValues;
 
@@ -1520,8 +1520,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var fractalChaosBandsList = CalculateFractalChaosBands(stockData);
-        var upperBandList = fractalChaosBandsList.OutputValues["UpperBand"];
-        var lowerBandList = fractalChaosBandsList.OutputValues["LowerBand"];
+        var upperBandList = fractalChaosBandsList.ChainedOutputs["UpperBand"];
+        var lowerBandList = fractalChaosBandsList.ChainedOutputs["LowerBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2216,7 +2216,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var efRatioList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var efRatioList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -3423,7 +3423,7 @@ public static partial class Calculations
         double chgErSum = 0;
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -3470,7 +3470,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/OscillatorsEtoK.cs
+++ b/src/Calculations/Oscillators/OscillatorsEtoK.cs
@@ -407,14 +407,14 @@ public static partial class Calculations
     public static StockData CalculateInverseFisherZScore(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int length = 100)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> fList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        // Reset CustomValuesList to prevent contamination of stdDev calculation
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)
@@ -2429,18 +2429,16 @@ public static partial class Calculations
         int length2 = 10, int length3 = 10, int length4 = 15, int rocLength1 = 10, int rocLength2 = 15, int rocLength3 = 20, int rocLength4 = 30,
         int signalLength = 9, double weight1 = 1, double weight2 = 2, double weight3 = 3, double weight4 = 4)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> kstList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var roc1List = CalculateRateOfChange(stockData, rocLength1).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var roc2List = CalculateRateOfChange(stockData, rocLength2).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var roc3List = CalculateRateOfChange(stockData, rocLength3).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var roc4List = CalculateRateOfChange(stockData, rocLength4).CustomValuesList;
         var roc1SmaList = GetMovingAverageList(stockData, maType, length1, roc1List);
         var roc2SmaList = GetMovingAverageList(stockData, maType, length2, roc2List);

--- a/src/Calculations/Oscillators/OscillatorsLtoR.cs
+++ b/src/Calculations/Oscillators/OscillatorsLtoR.cs
@@ -730,13 +730,13 @@ public static partial class Calculations
     public static StockData CalculateNaturalDirectionalCombo(this StockData stockData, MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length = 40, int smoothLength = 20)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> nxcList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var ndxList = CalculateNaturalDirectionalIndex(stockData, maType, length, smoothLength).CustomValuesList;
-        // Reset CustomValuesList to prevent contamination of NST calculation
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var nstList = CalculateNaturalStochasticIndicator(stockData, maType, length, smoothLength).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)
@@ -952,13 +952,13 @@ public static partial class Calculations
     public static StockData CalculateNaturalMarketCombo(this StockData stockData, MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
         int length = 40, int smoothLength = 20)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> nmcList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var nmrList = CalculateNaturalMarketRiver(stockData, maType, length).CustomValuesList;
-        // Reset CustomValuesList to prevent contamination of NMM calculation
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var nmmList = CalculateNaturalMarketMirror(stockData, maType, length).CustomValuesList;
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Oscillators/OscillatorsLtoR.cs
+++ b/src/Calculations/Oscillators/OscillatorsLtoR.cs
@@ -160,7 +160,7 @@ public static partial class Calculations
         List<double> whiteNoiseVarianceList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var connorsRsiList = CalculateConnorsRelativeStrengthIndex(stockData, maType, noiseLength, noiseLength, length).CustomValuesList;
+        var connorsRsiList = CalculateConnorsRelativeStrengthIndex(stockData, maType, noiseLength, noiseLength, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var connorsRsi = connorsRsiList[i];
@@ -176,7 +176,7 @@ public static partial class Calculations
 
         var whiteNoiseSmaList = GetMovingAverageList(stockData, maType, noiseLength, whiteNoiseList);
         stockData.SetCustomValues(whiteNoiseList);
-        var whiteNoiseStdDevList = CalculateStandardDeviationVolatility(stockData, maType, noiseLength).CustomValuesList;
+        var whiteNoiseStdDevList = CalculateStandardDeviationVolatility(stockData, maType, noiseLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var whiteNoiseStdDev = whiteNoiseStdDevList[i];
@@ -219,7 +219,7 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, lbLength);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -274,8 +274,8 @@ public static partial class Calculations
         List<double> histList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var linregList = CalculateLinearRegression(stockData, length).CustomValuesList;
-        var yList = CalculateQuadraticRegression(stockData, maType, length).CustomValuesList;
+        var linregList = CalculateLinearRegression(stockData, length).ChainedValues;
+        var yList = CalculateQuadraticRegression(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -451,7 +451,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDeviationList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDeviationList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -511,9 +511,9 @@ public static partial class Calculations
         var (_, highList, lowList, _, _) = GetInputValuesList(stockData);
 
         stockData.SetCustomValues(highList);
-        var rviHighList = CalculateRelativeVolatilityIndexV1(stockData, maType, length, smoothLength).CustomValuesList;
+        var rviHighList = CalculateRelativeVolatilityIndexV1(stockData, maType, length, smoothLength).ChainedValues;
         stockData.SetCustomValues(lowList);
-        var rviLowList = CalculateRelativeVolatilityIndexV1(stockData, maType, length, smoothLength).CustomValuesList;
+        var rviLowList = CalculateRelativeVolatilityIndexV1(stockData, maType, length, smoothLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -734,10 +734,10 @@ public static partial class Calculations
         List<double> nxcList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var ndxList = CalculateNaturalDirectionalIndex(stockData, maType, length, smoothLength).CustomValuesList;
+        var ndxList = CalculateNaturalDirectionalIndex(stockData, maType, length, smoothLength).ChainedValues;
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var nstList = CalculateNaturalStochasticIndicator(stockData, maType, length, smoothLength).CustomValuesList;
+        var nstList = CalculateNaturalStochasticIndicator(stockData, maType, length, smoothLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -956,10 +956,10 @@ public static partial class Calculations
         List<double> nmcList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var nmrList = CalculateNaturalMarketRiver(stockData, maType, length).CustomValuesList;
+        var nmrList = CalculateNaturalMarketRiver(stockData, maType, length).ChainedValues;
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var nmmList = CalculateNaturalMarketMirror(stockData, maType, length).CustomValuesList;
+        var nmmList = CalculateNaturalMarketMirror(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1016,7 +1016,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(lnList);
-        var linRegList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var linReg = linRegList[i];
@@ -1225,7 +1225,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length2).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length2).ChainedValues;
         var smaList = GetMovingAverageList(stockData, maType, length1, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1423,29 +1423,29 @@ public static partial class Calculations
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
         var callerSeries = stockData.CaptureInputSeries();
-        var rocList = CalculateRateOfChange(stockData, length1).CustomValuesList;
+        var rocList = CalculateRateOfChange(stockData, length1).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc15List = CalculateRateOfChange(stockData, length2).CustomValuesList;
+        var roc15List = CalculateRateOfChange(stockData, length2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc20List = CalculateRateOfChange(stockData, length3).CustomValuesList;
+        var roc20List = CalculateRateOfChange(stockData, length3).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc30List = CalculateRateOfChange(stockData, length4).CustomValuesList;
+        var roc30List = CalculateRateOfChange(stockData, length4).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc40List = CalculateRateOfChange(stockData, length5).CustomValuesList;
+        var roc40List = CalculateRateOfChange(stockData, length5).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc65List = CalculateRateOfChange(stockData, length7).CustomValuesList;
+        var roc65List = CalculateRateOfChange(stockData, length7).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc75List = CalculateRateOfChange(stockData, length8).CustomValuesList;
+        var roc75List = CalculateRateOfChange(stockData, length8).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc100List = CalculateRateOfChange(stockData, length9).CustomValuesList;
+        var roc100List = CalculateRateOfChange(stockData, length9).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc195List = CalculateRateOfChange(stockData, length11).CustomValuesList;
+        var roc195List = CalculateRateOfChange(stockData, length11).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc265List = CalculateRateOfChange(stockData, length12).CustomValuesList;
+        var roc265List = CalculateRateOfChange(stockData, length12).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc390List = CalculateRateOfChange(stockData, length13).CustomValuesList;
+        var roc390List = CalculateRateOfChange(stockData, length13).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var roc530List = CalculateRateOfChange(stockData, length14).CustomValuesList;
+        var roc530List = CalculateRateOfChange(stockData, length14).ChainedValues;
         var roc10SmaList = GetMovingAverageList(stockData, maType, length1, rocList);
         var roc15SmaList = GetMovingAverageList(stockData, maType, length1, roc15List);
         var roc20SmaList = GetMovingAverageList(stockData, maType, length1, roc20List);
@@ -1664,7 +1664,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1707,7 +1707,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, lowList, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1840,7 +1840,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(absOsList);
-        var pList = CalculateLinearRegression(stockData, smoothLength).CustomValuesList;
+        var pList = CalculateLinearRegression(stockData, smoothLength).ChainedValues;
         var (highestList, _) = GetMaxAndMinValuesList(pList, length);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2095,7 +2095,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (_, highList, lowList, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         var sqrt = Sqrt(length);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -2246,7 +2246,7 @@ public static partial class Calculations
 
         var emaList = GetMovingAverageList(stockData, maType, length, inputList);
         stockData.SetCustomValues(emaList);
-        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2290,7 +2290,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var linRegList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2399,7 +2399,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(spreadList);
-        var rsList = CalculateRelativeStrengthIndex(stockData, length: length).CustomValuesList;
+        var rsList = CalculateRelativeStrengthIndex(stockData, length: length).ChainedValues;
         var rssList = GetMovingAverageList(stockData, maType, smoothLength, rsList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2800,9 +2800,9 @@ public static partial class Calculations
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         var indexSmaList = GetMovingAverageList(stockData, maType, length, indexList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(indexList);
-        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var indexStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -2869,7 +2869,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(rangeList);
-        var stdevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentVolume = volumeList[i];

--- a/src/Calculations/Oscillators/OscillatorsLtoR.cs
+++ b/src/Calculations/Oscillators/OscillatorsLtoR.cs
@@ -50,9 +50,9 @@ public static partial class Calculations
 
         stockData.SetCustomValues(ranaList);
         var moList = CalculateMovingAverageConvergenceDivergence(stockData, maType, fastLength, slowLength, signalLength);
-        var mcclellanOscillatorList = moList.OutputValues["Macd"];
-        var mcclellanSignalLineList = moList.OutputValues["Signal"];
-        var mcclellanHistogramList = moList.OutputValues["Histogram"];
+        var mcclellanOscillatorList = moList.ChainedOutputs["Macd"];
+        var mcclellanSignalLineList = moList.ChainedOutputs["Signal"];
+        var mcclellanHistogramList = moList.ChainedOutputs["Histogram"];
         for (var i = 0; i < stockData.Count; i++)
         {
             var mcclellanHistogram = mcclellanHistogramList[i];
@@ -100,7 +100,7 @@ public static partial class Calculations
         var wildersLength = (length * 2) - 1;
 
         var rsiValueList = CalculateRelativeStrengthIndex(stockData, maType, length, smoothLength);
-        var rsiEmaList = rsiValueList.OutputValues["Signal"];
+        var rsiEmaList = rsiValueList.ChainedOutputs["Signal"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -3365,10 +3365,18 @@ public static partial class Calculations
 
         if (stockData.Count == marketData.Count)
         {
+            // Each rate of change is of the price, as SectorRotationModelState takes them; the second of each pair
+            // used to be a rate of change of the first.
+            var stockSeries = stockData.CaptureInputSeries();
+            var marketSeries = marketData.CaptureInputSeries();
             var bull1List = CalculateRateOfChange(stockData, length1).ChainedValues;
+            stockData.RestoreInputSeries(stockSeries);
             var bull2List = CalculateRateOfChange(stockData, length2).ChainedValues;
+            stockData.RestoreInputSeries(stockSeries);
             var bear1List = CalculateRateOfChange(marketData, length1).ChainedValues;
+            marketData.RestoreInputSeries(marketSeries);
             var bear2List = CalculateRateOfChange(marketData, length2).ChainedValues;
+            marketData.RestoreInputSeries(marketSeries);
 
             for (var i = 0; i < stockData.Count; i++)
             {

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -423,11 +423,11 @@ public static partial class Calculations
     public static StockData CalculateWoodieCommodityChannelIndex(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, 
         int fastLength = 6, int slowLength = 14)
     {
-        // Each component that takes its own inputName reads the CALLER's series. Those methods
-        // let a chained series win over their named input, and by the time this calculation calls
-        // them an earlier component has already published its output onto CustomValuesList - which
-        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
-        // their own named input exactly as before.
+        // The components that read their own default input - a typical or median price - read the
+        // CALLER's series instead whenever one is chained, and by the time this calculation calls them
+        // an earlier component has already published its output onto CustomValuesList, which they would
+        // otherwise take for the caller's chain. Unchained this is empty, and they read their own
+        // default input exactly as before.
         var callerSeries = stockData.CaptureInputSeries();
         List<double> histogramList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
@@ -791,15 +791,14 @@ public static partial class Calculations
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateValueChartIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-       InputName inputName = InputName.MedianPrice, int length = 5)
+    public static StockData CalculateValueChartIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 5)
     {
         List<double> vOpenList = new(stockData.Count);
         List<double> vHighList = new(stockData.Count);
         List<double> vLowList = new(stockData.Count);
         List<double> vCloseList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         var varp = MinOrMax((int)Math.Ceiling((double)length / 5));
 
@@ -893,7 +892,7 @@ public static partial class Calculations
     /// <param name="stdDevMult"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateVervoortSmoothedOscillator(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateVervoortSmoothedOscillator(this StockData stockData,
         int length1 = 18, int length2 = 30, int length3 = 2, int smoothLength = 3, double stdDevMult = 2)
     {
         List<double> rainbowList = new(stockData.Count);
@@ -903,7 +902,7 @@ public static partial class Calculations
         List<double> fastKList = new(stockData.Count);
         List<double> skList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length2);
         var rbcWindow = new RollingMinMax(length2);
         var fastKSumWindow = new RollingSum();
@@ -1008,7 +1007,7 @@ public static partial class Calculations
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateVervoortHeikenAshiLongTermCandlestickOscillator(this StockData stockData,
-        MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, InputName inputName = InputName.FullTypicalPrice, int length = 55,
+        MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length = 55,
         double factor = 1.1)
     {
         List<double> haoList = new(stockData.Count);
@@ -1022,7 +1021,7 @@ public static partial class Calculations
         List<bool> dtrList = new(stockData.Count);
         List<double> hacoList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1350,7 +1349,7 @@ public static partial class Calculations
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateVervoortHeikenAshiCandlestickOscillator(this StockData stockData,
-        MovingAvgType maType = MovingAvgType.ZeroLagTripleExponentialMovingAverage, InputName inputName = InputName.FullTypicalPrice, int length = 34)
+        MovingAvgType maType = MovingAvgType.ZeroLagTripleExponentialMovingAverage, int length = 34)
     {
         List<double> haoList = new(stockData.Count);
         List<double> hacList = new(stockData.Count);
@@ -1363,7 +1362,7 @@ public static partial class Calculations
         List<bool> upTrendList = new(stockData.Count);
         List<double> hacoList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, openList, closeList, _) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -2122,11 +2121,11 @@ public static partial class Calculations
         int macdLength3 = 9, int bullBearLength = 13, int williamRLength = 14, int maLength1 = 10, int maLength2 = 20, int maLength3 = 30, 
         int maLength4 = 50, int maLength5 = 100, int maLength6 = 200, int hullMaLength = 9)
     {
-        // Each component that takes its own inputName reads the CALLER's series. Those methods
-        // let a chained series win over their named input, and by the time this calculation calls
-        // them an earlier component has already published its output onto CustomValuesList - which
-        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
-        // their own named input exactly as before.
+        // The components that read their own default input - a typical or median price - read the
+        // CALLER's series instead whenever one is chained, and by the time this calculation calls them
+        // an earlier component has already published its output onto CustomValuesList, which they would
+        // otherwise take for the caller's chain. Unchained this is empty, and they read their own
+        // default input exactly as before.
         var callerSeries = stockData.CaptureInputSeries();
         List<double> maRatingList = new(stockData.Count);
         List<double> oscRatingList = new(stockData.Count);

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -423,11 +423,16 @@ public static partial class Calculations
     public static StockData CalculateWoodieCommodityChannelIndex(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, 
         int fastLength = 6, int slowLength = 14)
     {
+        // Each component that takes its own inputName reads the CALLER's series. Those methods
+        // let a chained series win over their named input, and by the time this calculation calls
+        // them an earlier component has already published its output onto CustomValuesList - which
+        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
+        // their own named input exactly as before.
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> histogramList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
-        var callerSeries = stockData.CaptureInputSeries();
         var cciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: slowLength).CustomValuesList;
         stockData.RestoreInputSeries(callerSeries);
         var turboCciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: fastLength).CustomValuesList;
@@ -2117,6 +2122,12 @@ public static partial class Calculations
         int macdLength3 = 9, int bullBearLength = 13, int williamRLength = 14, int maLength1 = 10, int maLength2 = 20, int maLength3 = 30, 
         int maLength4 = 50, int maLength5 = 100, int maLength6 = 200, int hullMaLength = 9)
     {
+        // Each component that takes its own inputName reads the CALLER's series. Those methods
+        // let a chained series win over their named input, and by the time this calculation calls
+        // them an earlier component has already published its output onto CustomValuesList - which
+        // they would otherwise take for the caller's chain. Unchained this is empty, and they read
+        // their own named input exactly as before.
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> maRatingList = new(stockData.Count);
         List<double> oscRatingList = new(stockData.Count);
         List<double> totalRatingList = new(stockData.Count);
@@ -2125,7 +2136,6 @@ public static partial class Calculations
 
         // Every component reads the prices (the AO and CCI their own median and typical price); each
         // Calculate call leaves its output on CustomValuesList for the next one to mistake for its input.
-        var callerSeries = stockData.CaptureInputSeries();
         var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).CustomValuesList;
         stockData.RestoreInputSeries(callerSeries);
         var aoList = CalculateAwesomeOscillator(stockData, fastLength: aoLength1, slowLength: aoLength2).CustomValuesList;

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -646,8 +646,8 @@ public static partial class Calculations
         // The explosion line is the Bollinger width of the prices, not of the MACD just published.
         stockData.RestoreInputSeries(callerSeries);
         var bbList = CalculateBollingerBands(stockData, length: fastLength);
-        var upperBollingerBandList = bbList.OutputValues["UpperBand"];
-        var lowerBollingerBandList = bbList.OutputValues["LowerBand"];
+        var upperBollingerBandList = bbList.ChainedOutputs["UpperBand"];
+        var lowerBollingerBandList = bbList.ChainedOutputs["LowerBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1560,8 +1560,8 @@ public static partial class Calculations
         var bearCountSumWindow = new RollingSum();
 
         var elderPowerList = CalculateElderRayIndex(stockData, maType, length2);
-        var bullPowerList = elderPowerList.OutputValues["BullPower"];
-        var bearPowerList = elderPowerList.OutputValues["BearPower"];
+        var bullPowerList = elderPowerList.ChainedOutputs["BullPower"];
+        var bearPowerList = elderPowerList.ChainedOutputs["BearPower"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1713,7 +1713,7 @@ public static partial class Calculations
         var rsiList = CalculateRelativeStrengthIndex(stockData, length: length9).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var ppoHistList = CalculatePercentagePriceOscillator(stockData, MovingAvgType.ExponentialMovingAverage, length5, length6, length7).
-            OutputValues["Histogram"];
+            ChainedOutputs["Histogram"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1830,9 +1830,9 @@ public static partial class Calculations
         var callerSeries = stockData.CaptureInputSeries();
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var stochastic1List = CalculateStochasticOscillator(stockData, maType, length: length2, smoothLength, smoothLength).OutputValues["FastD"];
+        var stochastic1List = CalculateStochasticOscillator(stockData, maType, length: length2, smoothLength, smoothLength).ChainedOutputs["FastD"];
         stockData.RestoreInputSeries(callerSeries);
-        var stochastic2List = CalculateStochasticOscillator(stockData, maType, length: length1, smoothLength, smoothLength).OutputValues["FastD"];
+        var stochastic2List = CalculateStochasticOscillator(stockData, maType, length: length1, smoothLength, smoothLength).ChainedOutputs["FastD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1885,7 +1885,7 @@ public static partial class Calculations
 
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length1, length2);
         var rList = rsiList.ChainedValues;
-        var maList = rsiList.OutputValues["Signal"];
+        var maList = rsiList.ChainedOutputs["Signal"];
         stockData.SetCustomValues(rList);
         var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
         var mabList = GetMovingAverageList(stockData, maType, length3, rList);
@@ -2138,26 +2138,26 @@ public static partial class Calculations
         var macdItemsList = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: macdLength1, slowLength: macdLength2, 
             signalLength: macdLength3);
         var macdList = macdItemsList.ChainedValues;
-        var macdSignalList = macdItemsList.OutputValues["Signal"];
+        var macdSignalList = macdItemsList.ChainedOutputs["Signal"];
         stockData.RestoreInputSeries(callerSeries);
         var uoList = CalculateUltimateOscillator(stockData, ultOscLength1, ultOscLength2, ultOscLength3).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var ichiMokuList = CalculateIchimokuCloud(stockData, tenkanLength: ichiLength1, kijunLength: ichiLength2, senkouLength: ichiLength3);
-        var tenkanList = ichiMokuList.OutputValues["TenkanSen"];
-        var kijunList = ichiMokuList.OutputValues["KijunSen"];
-        var senkouAList = ichiMokuList.OutputValues["SenkouSpanA"];
-        var senkouBList = ichiMokuList.OutputValues["SenkouSpanB"];
+        var tenkanList = ichiMokuList.ChainedOutputs["TenkanSen"];
+        var kijunList = ichiMokuList.ChainedOutputs["KijunSen"];
+        var senkouAList = ichiMokuList.ChainedOutputs["SenkouSpanA"];
+        var senkouBList = ichiMokuList.ChainedOutputs["SenkouSpanB"];
         stockData.RestoreInputSeries(callerSeries);
         var adxItemsList = CalculateAverageDirectionalIndex(stockData, length: adxLength);
         var adxList = adxItemsList.ChainedValues;
-        var adxPlusList = adxItemsList.OutputValues["DiPlus"];
-        var adxMinusList = adxItemsList.OutputValues["DiMinus"];
+        var adxPlusList = adxItemsList.ChainedOutputs["DiPlus"];
+        var adxMinusList = adxItemsList.ChainedOutputs["DiMinus"];
         stockData.RestoreInputSeries(callerSeries);
         var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var bullBearPowerList = CalculateElderRayIndex(stockData, length: bullBearLength);
-        var bullPowerList = bullBearPowerList.OutputValues["BullPower"];
-        var bearPowerList = bullBearPowerList.OutputValues["BearPower"];
+        var bullPowerList = bullBearPowerList.ChainedOutputs["BullPower"];
+        var bearPowerList = bullBearPowerList.ChainedOutputs["BearPower"];
         stockData.RestoreInputSeries(callerSeries);
         var hullMaList = CalculateHullMovingAverage(stockData, length: hullMaLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
@@ -2167,7 +2167,7 @@ public static partial class Calculations
         stockData.RestoreInputSeries(callerSeries);
         var stoList = CalculateStochasticOscillator(stockData, length: stochLength1, smoothLength1: stochLength2, smoothLength2: stochLength3);
         var stoKList = stoList.ChainedValues;
-        var stoDList = stoList.OutputValues["FastD"];
+        var stoDList = stoList.ChainedOutputs["FastD"];
         var ma10List = GetMovingAverageList(stockData, maType, maLength1, inputList);
         var ma20List = GetMovingAverageList(stockData, maType, maLength2, inputList);
         var ma30List = GetMovingAverageList(stockData, maType, maLength3, inputList);

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -787,7 +787,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
@@ -884,7 +883,6 @@ public static partial class Calculations
     /// Calculates the Vervoort Smoothed Oscillator
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>
     /// <param name="length3"></param>
@@ -1001,7 +999,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <param name="factor"></param>
     /// <returns></returns>
@@ -1344,7 +1341,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]

--- a/src/Calculations/Oscillators/OscillatorsStoZ.cs
+++ b/src/Calculations/Oscillators/OscillatorsStoZ.cs
@@ -123,7 +123,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -175,7 +175,7 @@ public static partial class Calculations
         var lcoSumWindow = new RollingSum();
         var lcoSma1SumWindow = new RollingSum();
 
-        var linregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var linregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -186,7 +186,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(ax1List);
-        var ax1LinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var ax1LinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ax1 = ax1List[i];
@@ -197,7 +197,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(lx1List);
-        var lx1LinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var lx1LinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var lx1 = lx1List[i];
@@ -208,7 +208,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(ax2List);
-        var ax2LinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var ax2LinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ax2 = ax2List[i];
@@ -219,7 +219,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(lx2List);
-        var lx2LinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var lx2LinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var lx2 = lx2List[i];
@@ -230,7 +230,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(ax3List);
-        var ax3LinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var ax3LinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ax3 = ax3List[i];
@@ -299,9 +299,9 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(trList);
-        var trStoList = CalculateStochasticOscillator(stockData, maType, length: lbLength).CustomValuesList;
+        var trStoList = CalculateStochasticOscillator(stockData, maType, length: lbLength).ChainedValues;
         stockData.SetCustomValues(volumeList);
-        var vStoList = CalculateStochasticOscillator(stockData, maType, length: lbLength).CustomValuesList;
+        var vStoList = CalculateStochasticOscillator(stockData, maType, length: lbLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var close = inputList[i];
@@ -375,7 +375,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var varList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var varList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -433,9 +433,9 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
-        var cciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: slowLength).CustomValuesList;
+        var cciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: slowLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var turboCciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: fastLength).CustomValuesList;
+        var turboCciList = CalculateCommodityChannelIndex(stockData, maType: maType, length: fastLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -642,7 +642,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var callerSeries = stockData.CaptureInputSeries();
-        var macd1List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).CustomValuesList;
+        var macd1List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).ChainedValues;
         // The explosion line is the Bollinger width of the prices, not of the MACD just published.
         stockData.RestoreInputSeries(callerSeries);
         var bbList = CalculateBollingerBands(stockData, length: fastLength);
@@ -662,11 +662,11 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(temp1List);
-        var macd2List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).CustomValuesList;
+        var macd2List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).ChainedValues;
         stockData.SetCustomValues(temp2List);
-        var macd3List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).CustomValuesList;
+        var macd3List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).ChainedValues;
         stockData.SetCustomValues(temp3List);
-        var macd4List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).CustomValuesList;
+        var macd4List = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: fastLength, slowLength: slowLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentMacd1 = macd1List[i];
@@ -946,7 +946,7 @@ public static partial class Calculations
 
         var tzList = GetMovingAverageList(stockData, MovingAvgType.TripleExponentialMovingAverage, smoothLength, zlrbList);
         stockData.SetCustomValues(tzList);
-        var hwidthList = CalculateStandardDeviationVolatility(stockData, length: length1).CustomValuesList;
+        var hwidthList = CalculateStandardDeviationVolatility(stockData, length: length1).ChainedValues;
         var wmatzList = GetMovingAverageList(stockData, MovingAvgType.WeightedMovingAverage, length1, tzList);
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1706,11 +1706,11 @@ public static partial class Calculations
         var ma2List = GetMovingAverageList(stockData, MovingAvgType.SimpleMovingAverage, length3, inputList);
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
         var callerSeries = stockData.CaptureInputSeries();
-        var ltRocList = CalculateRateOfChange(stockData, length2).CustomValuesList;
+        var ltRocList = CalculateRateOfChange(stockData, length2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var mtRocList = CalculateRateOfChange(stockData, length4).CustomValuesList;
+        var mtRocList = CalculateRateOfChange(stockData, length4).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length9).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length9).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var ppoHistList = CalculatePercentagePriceOscillator(stockData, MovingAvgType.ExponentialMovingAverage, length5, length6, length7).
             OutputValues["Histogram"];
@@ -1767,7 +1767,7 @@ public static partial class Calculations
         List<double> oList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var sList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var sList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1781,7 +1781,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(uList);
-        var uLinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var uLinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var u = uLinregList[i];
@@ -1828,7 +1828,7 @@ public static partial class Calculations
 
         // Each component reads the prices; each Calculate call leaves its own output on CustomValuesList.
         var callerSeries = stockData.CaptureInputSeries();
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var stochastic1List = CalculateStochasticOscillator(stockData, maType, length: length2, smoothLength, smoothLength).OutputValues["FastD"];
         stockData.RestoreInputSeries(callerSeries);
@@ -1884,10 +1884,10 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length1, length2);
-        var rList = rsiList.CustomValuesList;
+        var rList = rsiList.ChainedValues;
         var maList = rsiList.OutputValues["Signal"];
         stockData.SetCustomValues(rList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length2).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
         var mabList = GetMovingAverageList(stockData, maType, length3, rList);
         var mbbList = GetMovingAverageList(stockData, maType, length4, rList);
 
@@ -1965,9 +1965,9 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(bList);
-        var bStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var bStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(cList);
-        var cStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var cStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var a = emaList[i];
@@ -2131,16 +2131,16 @@ public static partial class Calculations
 
         // Every component reads the prices (the AO and CCI their own median and typical price); each
         // Calculate call leaves its output on CustomValuesList for the next one to mistake for its input.
-        var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, length: rsiLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var aoList = CalculateAwesomeOscillator(stockData, fastLength: aoLength1, slowLength: aoLength2).CustomValuesList;
+        var aoList = CalculateAwesomeOscillator(stockData, fastLength: aoLength1, slowLength: aoLength2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var macdItemsList = CalculateMovingAverageConvergenceDivergence(stockData, fastLength: macdLength1, slowLength: macdLength2, 
             signalLength: macdLength3);
-        var macdList = macdItemsList.CustomValuesList;
+        var macdList = macdItemsList.ChainedValues;
         var macdSignalList = macdItemsList.OutputValues["Signal"];
         stockData.RestoreInputSeries(callerSeries);
-        var uoList = CalculateUltimateOscillator(stockData, ultOscLength1, ultOscLength2, ultOscLength3).CustomValuesList;
+        var uoList = CalculateUltimateOscillator(stockData, ultOscLength1, ultOscLength2, ultOscLength3).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var ichiMokuList = CalculateIchimokuCloud(stockData, tenkanLength: ichiLength1, kijunLength: ichiLength2, senkouLength: ichiLength3);
         var tenkanList = ichiMokuList.OutputValues["TenkanSen"];
@@ -2149,24 +2149,24 @@ public static partial class Calculations
         var senkouBList = ichiMokuList.OutputValues["SenkouSpanB"];
         stockData.RestoreInputSeries(callerSeries);
         var adxItemsList = CalculateAverageDirectionalIndex(stockData, length: adxLength);
-        var adxList = adxItemsList.CustomValuesList;
+        var adxList = adxItemsList.ChainedValues;
         var adxPlusList = adxItemsList.OutputValues["DiPlus"];
         var adxMinusList = adxItemsList.OutputValues["DiMinus"];
         stockData.RestoreInputSeries(callerSeries);
-        var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).CustomValuesList;
+        var cciList = CalculateCommodityChannelIndex(stockData, length: cciLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var bullBearPowerList = CalculateElderRayIndex(stockData, length: bullBearLength);
         var bullPowerList = bullBearPowerList.OutputValues["BullPower"];
         var bearPowerList = bullBearPowerList.OutputValues["BearPower"];
         stockData.RestoreInputSeries(callerSeries);
-        var hullMaList = CalculateHullMovingAverage(stockData, length: hullMaLength).CustomValuesList;
+        var hullMaList = CalculateHullMovingAverage(stockData, length: hullMaLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var williamsPctList = CalculateWilliamsR(stockData, length: williamRLength).CustomValuesList;
+        var williamsPctList = CalculateWilliamsR(stockData, length: williamRLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var vwmaList = CalculateVolumeWeightedMovingAverage(stockData, length: vwmaLength).CustomValuesList;
+        var vwmaList = CalculateVolumeWeightedMovingAverage(stockData, length: vwmaLength).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
         var stoList = CalculateStochasticOscillator(stockData, length: stochLength1, smoothLength1: stochLength2, smoothLength2: stochLength3);
-        var stoKList = stoList.CustomValuesList;
+        var stoKList = stoList.ChainedValues;
         var stoDList = stoList.OutputValues["FastD"];
         var ma10List = GetMovingAverageList(stockData, maType, maLength1, inputList);
         var ma20List = GetMovingAverageList(stockData, maType, maLength2, inputList);
@@ -2175,7 +2175,7 @@ public static partial class Calculations
         var ma100List = GetMovingAverageList(stockData, maType, maLength5, inputList);
         var ma200List = GetMovingAverageList(stockData, maType, maLength6, inputList);
         stockData.RestoreInputSeries(callerSeries);
-        var momentumList = CalculateMomentumOscillator(stockData, length: momLength).CustomValuesList;
+        var momentumList = CalculateMomentumOscillator(stockData, length: momLength).ChainedValues;
         // Stochastic RSI: the RSI's stochastic over the RSI's own range. Chained into the stochastic
         // indicator, the RSI was measured against the bars' highs and lows instead.
         var (rsiHighestList, rsiLowestList) = GetMaxAndMinValuesList(rsiList, stochLength1);
@@ -2633,7 +2633,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(extList);
-        var oscList = CalculateStochasticOscillator(stockData, maType, length: length * 2).CustomValuesList;
+        var oscList = CalculateStochasticOscillator(stockData, maType, length: length * 2).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var osc = oscList[i];
@@ -2929,7 +2929,7 @@ public static partial class Calculations
     {
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var wadList = CalculateWilliamsAccumulationDistribution(stockData).CustomValuesList;
+        var wadList = CalculateWilliamsAccumulationDistribution(stockData).ChainedValues;
         var wadSignalList = GetMovingAverageList(stockData, maType, length, wadList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -3130,7 +3130,7 @@ public static partial class Calculations
         var aboveSumWindow = new RollingSum();
 
         var smaList = GetMovingAverageList(stockData, maType, length1, inputList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length1).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -3365,10 +3365,10 @@ public static partial class Calculations
 
         if (stockData.Count == marketData.Count)
         {
-            var bull1List = CalculateRateOfChange(stockData, length1).CustomValuesList;
-            var bull2List = CalculateRateOfChange(stockData, length2).CustomValuesList;
-            var bear1List = CalculateRateOfChange(marketData, length1).CustomValuesList;
-            var bear2List = CalculateRateOfChange(marketData, length2).CustomValuesList;
+            var bull1List = CalculateRateOfChange(stockData, length1).ChainedValues;
+            var bull2List = CalculateRateOfChange(stockData, length2).ChainedValues;
+            var bear1List = CalculateRateOfChange(marketData, length1).ChainedValues;
+            var bear2List = CalculateRateOfChange(marketData, length2).ChainedValues;
 
             for (var i = 0; i < stockData.Count; i++)
             {

--- a/src/Calculations/Ppo/PpoAtoD.cs
+++ b/src/Calculations/Ppo/PpoAtoD.cs
@@ -135,8 +135,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var dinapoliMacdList = CalculateDiNapoliMovingAverageConvergenceDivergence(stockData, lc, sc, sp);
-        var ssList = dinapoliMacdList.OutputValues["SlowS"];
-        var rList = dinapoliMacdList.OutputValues["Macd"];
+        var ssList = dinapoliMacdList.ChainedOutputs["SlowS"];
+        var rList = dinapoliMacdList.ChainedOutputs["Macd"];
 
         var spAlpha = 2 / (1 + sp);
 

--- a/src/Calculations/Ppo/PpoEtoK.cs
+++ b/src/Calculations/Ppo/PpoEtoK.cs
@@ -7,7 +7,6 @@ public static partial class Calculations
     /// Calculates the Impulse Percentage Price Oscillator
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="length"></param>
     /// <param name="signalLength"></param>

--- a/src/Calculations/Ppo/PpoEtoK.cs
+++ b/src/Calculations/Ppo/PpoEtoK.cs
@@ -13,7 +13,7 @@ public static partial class Calculations
     /// <param name="signalLength"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateImpulsePercentagePriceOscillator(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateImpulsePercentagePriceOscillator(this StockData stockData,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
     {
         List<double> ppoList = new(stockData.Count);
@@ -21,7 +21,7 @@ public static partial class Calculations
         List<double> ppoHistogramList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum ppoSum = new();
-        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, _, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var typicalPriceZeroLagEmaList = GetMovingAverageList(stockData, MovingAvgType.ZeroLagExponentialMovingAverage, length, inputList);
         var wellesWilderHighMovingAvgList = GetMovingAverageList(stockData, maType, length, highList);

--- a/src/Calculations/Ppo/PpoLtoR.cs
+++ b/src/Calculations/Ppo/PpoLtoR.cs
@@ -80,7 +80,7 @@ public static partial class Calculations
         // replaces it - the same precedence every indicator follows, and what the streaming state's
         // selector already does. It used to read raw volumes whatever was chained in front of it.
         var (inputList, _, _, _, volumes) = GetInputValuesList(stockData);
-        var volumeList = stockData.CustomValuesList is { Count: > 0 } ? inputList : volumes;
+        var volumeList = stockData.ChainedValues is { Count: > 0 } ? inputList : volumes;
 
         var fastEmaList = GetMovingAverageList(stockData, maType, fastLength, volumeList);
         var slowEmaList = GetMovingAverageList(stockData, maType, slowLength, volumeList);

--- a/src/Calculations/Ppo/PpoLtoR.cs
+++ b/src/Calculations/Ppo/PpoLtoR.cs
@@ -139,8 +139,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var macdLeaderList = CalculateMovingAverageConvergenceDivergenceLeader(stockData, maType, fastLength, slowLength, signalLength);
-        var i1List = macdLeaderList.OutputValues["I1"];
-        var i2List = macdLeaderList.OutputValues["I2"];
+        var i1List = macdLeaderList.ChainedOutputs["I1"];
+        var i2List = macdLeaderList.ChainedOutputs["I2"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Ppo/PpoLtoR.cs
+++ b/src/Calculations/Ppo/PpoLtoR.cs
@@ -76,7 +76,11 @@ public static partial class Calculations
         List<double> pvoList = new(stockData.Count);
         List<double> pvoHistogramList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (_, _, _, _, volumeList) = GetInputValuesList(stockData);
+        // Volume is what this oscillator reads when nothing is passed in, and a chained series
+        // replaces it - the same precedence every indicator follows, and what the streaming state's
+        // selector already does. It used to read raw volumes whatever was chained in front of it.
+        var (inputList, _, _, _, volumes) = GetInputValuesList(stockData);
+        var volumeList = stockData.CustomValuesList is { Count: > 0 } ? inputList : volumes;
 
         var fastEmaList = GetMovingAverageList(stockData, maType, fastLength, volumeList);
         var slowEmaList = GetMovingAverageList(stockData, maType, slowLength, volumeList);

--- a/src/Calculations/PriceChannel/PriceChannelAtoD.cs
+++ b/src/Calculations/PriceChannel/PriceChannelAtoD.cs
@@ -68,7 +68,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -168,7 +168,7 @@ public static partial class Calculations
 
         var mult = Sqrt(length);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/PriceChannel/PriceChannelEtoK.cs
+++ b/src/Calculations/PriceChannel/PriceChannelEtoK.cs
@@ -297,11 +297,11 @@ public static partial class Calculations
         var mcl_2 = MinOrMax((int)Math.Ceiling((double)mcl / 2));
 
         var callerSeries = stockData.CaptureInputSeries();
-        var sclAtrList = CalculateAverageTrueRange(stockData, maType, scl).CustomValuesList;
+        var sclAtrList = CalculateAverageTrueRange(stockData, maType, scl).ChainedValues;
         // Both channels are ATRs of the prices. The first ATR publishes itself onto CustomValuesList, and the
         // second used to take it for the close - a true range measured against an ATR.
         stockData.RestoreInputSeries(callerSeries);
-        var mclAtrList = CalculateAverageTrueRange(stockData, maType, mcl).CustomValuesList;
+        var mclAtrList = CalculateAverageTrueRange(stockData, maType, mcl).ChainedValues;
         var sclRmaList = GetMovingAverageList(stockData, maType, scl, inputList);
         var mclRmaList = GetMovingAverageList(stockData, maType, mcl, inputList);
 
@@ -486,7 +486,7 @@ public static partial class Calculations
 
         var wmaList = GetMovingAverageList(stockData, maType, length, absD1List);
         stockData.SetCustomValues(d1List);
-        var s1List = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var s1List = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ema = emaList[i];
@@ -499,7 +499,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(d2List);
-        var s2List = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var s2List = CalculateLinearRegression(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ema = emaList[i];
@@ -562,7 +562,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -635,7 +635,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
-        var linRegList = CalculateLinearRegression(stockData, length2).CustomValuesList;
+        var linRegList = CalculateLinearRegression(stockData, length2).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -767,7 +767,7 @@ public static partial class Calculations
         // MOVING AVERAGE rather than to the previous close - on AAPL that inflated ATR(10) from 3.9553 to
         // 9.7261 and pushed the upper band from 143.74 to 155.28. The ATR is computed here, before any
         // moving average touches stockData.
-        var atrList = CalculateAverageTrueRange(stockData, atrMaType, length2).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, atrMaType, length2).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
 
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
@@ -886,9 +886,9 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(val2List);
-        var stdDevFastList = CalculateStandardDeviationVolatility(stockData, length: fastLength).CustomValuesList;
+        var stdDevFastList = CalculateStandardDeviationVolatility(stockData, length: fastLength).ChainedValues;
         stockData.SetCustomValues(val2List);
-        var stdDevSlowList = CalculateStandardDeviationVolatility(stockData, length: slowLength).CustomValuesList;
+        var stdDevSlowList = CalculateStandardDeviationVolatility(stockData, length: slowLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];

--- a/src/Calculations/PriceChannel/PriceChannelEtoK.cs
+++ b/src/Calculations/PriceChannel/PriceChannelEtoK.cs
@@ -754,6 +754,7 @@ public static partial class Calculations
         int length1 = 20, int length2 = 10, double multFactor = 2,
         MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> upperChannelList = new(stockData.Count);
         List<double> lowerChannelList = new(stockData.Count);
         List<double> midChannelList = new(stockData.Count);
@@ -767,7 +768,7 @@ public static partial class Calculations
         // 9.7261 and pushed the upper band from 143.74 to 155.28. The ATR is computed here, before any
         // moving average touches stockData.
         var atrList = CalculateAverageTrueRange(stockData, atrMaType, length2).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.RestoreInputSeries(callerSeries);
 
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
 

--- a/src/Calculations/PriceChannel/PriceChannelEtoK.cs
+++ b/src/Calculations/PriceChannel/PriceChannelEtoK.cs
@@ -78,8 +78,8 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var trimeanList = CalculateTrimean(stockData, length);
-        var q1List = trimeanList.OutputValues["Q1"];
-        var q3List = trimeanList.OutputValues["Q3"];
+        var q1List = trimeanList.ChainedOutputs["Q1"];
+        var q3List = trimeanList.ChainedOutputs["Q3"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -697,7 +697,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -875,7 +875,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length).ChainedOutputs["Er"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/PriceChannel/PriceChannelLtoR.cs
+++ b/src/Calculations/PriceChannel/PriceChannelLtoR.cs
@@ -220,9 +220,9 @@ public static partial class Calculations
         int length = 14, double stdDevMult = 3)
     {
         var narrowChannelList = CalculateBollingerBands(stockData, maType, length, stdDevMult);
-        var upperBandList = narrowChannelList.OutputValues["UpperBand"];
-        var middleBandList = narrowChannelList.OutputValues["MiddleBand"];
-        var lowerBandList = narrowChannelList.OutputValues["LowerBand"];
+        var upperBandList = narrowChannelList.ChainedOutputs["UpperBand"];
+        var middleBandList = narrowChannelList.ChainedOutputs["MiddleBand"];
+        var lowerBandList = narrowChannelList.ChainedOutputs["LowerBand"];
         var signalsList = narrowChannelList.SignalsList;
 
         stockData.SetOutputValues(() => new Dictionary<string, List<double>>{
@@ -802,9 +802,9 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
 
         stockData.SetCustomValues(lowList);
-        var lowSlopeList = CalculateLinearRegression(stockData, length).OutputValues["Slope"];
+        var lowSlopeList = CalculateLinearRegression(stockData, length).ChainedOutputs["Slope"];
         stockData.SetCustomValues(highList);
-        var highSlopeList = CalculateLinearRegression(stockData, length).OutputValues["Slope"];
+        var highSlopeList = CalculateLinearRegression(stockData, length).ChainedOutputs["Slope"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/PriceChannel/PriceChannelLtoR.cs
+++ b/src/Calculations/PriceChannel/PriceChannelLtoR.cs
@@ -456,9 +456,9 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
 
         stockData.SetCustomValues(highList);
-        var pnoUpBandList = CalculatePrimeNumberOscillator(stockData, length).CustomValuesList;
+        var pnoUpBandList = CalculatePrimeNumberOscillator(stockData, length).ChainedValues;
         stockData.SetCustomValues(lowList);
-        var pnoDnBandList = CalculatePrimeNumberOscillator(stockData, length).CustomValuesList;
+        var pnoDnBandList = CalculatePrimeNumberOscillator(stockData, length).ChainedValues;
         var (upperBandList, _) = GetMaxAndMinValuesList(pnoUpBandList, length);
         var (_, lowerBandList) = GetMaxAndMinValuesList(pnoDnBandList, length);
 
@@ -661,7 +661,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -732,7 +732,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -976,7 +976,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum rocSquaredSum = new();
 
-        var rocList = CalculateRateOfChange(stockData, length).CustomValuesList;
+        var rocList = CalculateRateOfChange(stockData, length).ChainedValues;
         var middleBandList = GetMovingAverageList(stockData, maType, smoothLength, rocList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -1344,7 +1344,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var devList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var devList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/PriceChannel/PriceChannelStoZ.cs
+++ b/src/Calculations/PriceChannel/PriceChannelStoZ.cs
@@ -18,8 +18,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDeviationList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
-        var regressionList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var stdDeviationList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
+        var regressionList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -72,7 +72,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -126,10 +126,10 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var callerSeries = stockData.CaptureInputSeries();
-        var umaList = CalculateUltimateMovingAverage(stockData, maType, minLength, maxLength, 1).CustomValuesList;
+        var umaList = CalculateUltimateMovingAverage(stockData, maType, minLength, maxLength, 1).ChainedValues;
         // The band width is the deviation of the prices, not of the UMA just published onto CustomValuesList.
         stockData.RestoreInputSeries(callerSeries);
-        var stdevList = CalculateStandardDeviationVolatility(stockData, maType, minLength).CustomValuesList;
+        var stdevList = CalculateStandardDeviationVolatility(stockData, maType, minLength).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -246,7 +246,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length, smoothLength).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length, smoothLength).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var rsi = rsiList[i];
@@ -452,7 +452,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var maList = GetMovingAverageList(stockData, maType, length, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -595,7 +595,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(inputList, length);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -840,7 +840,7 @@ public static partial class Calculations
         double absDiffSum = 0;
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var tsList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var tsList = CalculateLinearRegression(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1073,7 +1073,7 @@ public static partial class Calculations
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length1);
 
         var smaList = GetMovingAverageList(stockData, maType, length2, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length2).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length2).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -1124,7 +1124,7 @@ public static partial class Calculations
 
         var atrPeriod = (length1 * 2) - 1;
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, atrPeriod).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, atrPeriod).ChainedValues;
         var maList = GetMovingAverageList(stockData, maType, length1, inputList);
         var middleBandList = GetMovingAverageList(stockData, maType, length2, inputList);
 

--- a/src/Calculations/Ratio/RatioEtoK.cs
+++ b/src/Calculations/Ratio/RatioEtoK.cs
@@ -33,7 +33,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(retList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var retSmaList = GetMovingAverageList(stockData, maType, length, retList);
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Ratio/RatioLtoR.cs
+++ b/src/Calculations/Ratio/RatioLtoR.cs
@@ -40,7 +40,7 @@ public static partial class Calculations
 
         var retSmaList = GetMovingAverageList(stockData, maType, length, retList);
         stockData.SetCustomValues(retList);
-        var ulcerIndexList = CalculateUlcerIndex(stockData, length).CustomValuesList;
+        var ulcerIndexList = CalculateUlcerIndex(stockData, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var ulcerIndex = ulcerIndexList[i];

--- a/src/Calculations/Ratio/RatioStoZ.cs
+++ b/src/Calculations/Ratio/RatioStoZ.cs
@@ -263,7 +263,7 @@ public static partial class Calculations
 
         var retSmaList = GetMovingAverageList(stockData, maType, length, retList);
         stockData.SetCustomValues(retList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var stdDeviation = stdDevList[i];

--- a/src/Calculations/Rsi/RsiAtoD.cs
+++ b/src/Calculations/Rsi/RsiAtoD.cs
@@ -307,7 +307,6 @@ public static partial class Calculations
     /// Calculates the Breakout Relative Strength Index
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <param name="lbLength"></param>
     /// <returns></returns>

--- a/src/Calculations/Rsi/RsiAtoD.cs
+++ b/src/Calculations/Rsi/RsiAtoD.cs
@@ -26,8 +26,8 @@ public static partial class Calculations
         using var rocOrder = new RollingOrderStatistic(length3);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length2, length2).CustomValuesList;
-        var rocList = CalculateRateOfChange(stockData, length3).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length2, length2).ChainedValues;
+        var rocList = CalculateRateOfChange(stockData, length3).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -49,7 +49,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(streakList);
-        var rsiStreakList = CalculateRelativeStrengthIndex(stockData, maType, length1, length1).CustomValuesList;
+        var rsiStreakList = CalculateRelativeStrengthIndex(stockData, maType, length1, length1).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentRsi = rsiList[i];
@@ -158,7 +158,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length, length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -542,11 +542,11 @@ public static partial class Calculations
         RollingMinMax rsi13Len3Window = new(length3);
         RollingMinMax rsi8Len2Window = new(length2);
 
-        var rsi5List = CalculateRelativeStrengthIndex(stockData, maType, length: length1).CustomValuesList;
-        var rsi8List = CalculateRelativeStrengthIndex(stockData, maType, length: length2).CustomValuesList;
-        var rsi13List = CalculateRelativeStrengthIndex(stockData, maType, length: length3).CustomValuesList;
-        var rsi14List = CalculateRelativeStrengthIndex(stockData, maType, length: length4).CustomValuesList;
-        var rsi21List = CalculateRelativeStrengthIndex(stockData, maType, length: length5).CustomValuesList;
+        var rsi5List = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
+        var rsi8List = CalculateRelativeStrengthIndex(stockData, maType, length: length2).ChainedValues;
+        var rsi13List = CalculateRelativeStrengthIndex(stockData, maType, length: length3).ChainedValues;
+        var rsi14List = CalculateRelativeStrengthIndex(stockData, maType, length: length4).ChainedValues;
+        var rsi21List = CalculateRelativeStrengthIndex(stockData, maType, length: length5).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Rsi/RsiAtoD.cs
+++ b/src/Calculations/Rsi/RsiAtoD.cs
@@ -463,7 +463,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var v1List = CalculateEhlersAdaptiveCyberCycle(stockData, length).OutputValues["Period"];
+        var v1List = CalculateEhlersAdaptiveCyberCycle(stockData, length).ChainedOutputs["Period"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Rsi/RsiAtoD.cs
+++ b/src/Calculations/Rsi/RsiAtoD.cs
@@ -27,14 +27,15 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length2, length2).ChainedValues;
-        var rocList = CalculateRateOfChange(stockData, length3).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
             var prevValue = i >= 1 ? inputList[i - 1] : 0;
 
-            var roc = rocList[i];
+            // Connors ranks the one-bar rate of change of the price over length3 bars. This used to rank a
+            // length3-bar rate of change of the RSI, read back from the RSI just published.
+            var roc = prevValue != 0 ? (currentValue - prevValue) / prevValue * 100 : 0;
             tempList.Add(roc);
             rocOrder.Add(roc);
 
@@ -48,7 +49,7 @@ public static partial class Calculations
             streakList.Add(streak);
         }
 
-        stockData.SetCustomValues(streakList);
+        stockData.SetInputSeries(streakList);
         var rsiStreakList = CalculateRelativeStrengthIndex(stockData, maType, length1, length1).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -542,10 +543,17 @@ public static partial class Calculations
         RollingMinMax rsi13Len3Window = new(length3);
         RollingMinMax rsi8Len2Window = new(length2);
 
+        // Five RSIs of the caller's series. Each call publishes its RSI for the next calculation, so without the
+        // restores every RSI after the first was an RSI of the one before it.
+        var callerSeries = stockData.CaptureInputSeries();
         var rsi5List = CalculateRelativeStrengthIndex(stockData, maType, length: length1).ChainedValues;
+        stockData.RestoreInputSeries(callerSeries);
         var rsi8List = CalculateRelativeStrengthIndex(stockData, maType, length: length2).ChainedValues;
+        stockData.RestoreInputSeries(callerSeries);
         var rsi13List = CalculateRelativeStrengthIndex(stockData, maType, length: length3).ChainedValues;
+        stockData.RestoreInputSeries(callerSeries);
         var rsi14List = CalculateRelativeStrengthIndex(stockData, maType, length: length4).ChainedValues;
+        stockData.RestoreInputSeries(callerSeries);
         var rsi21List = CalculateRelativeStrengthIndex(stockData, maType, length: length5).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Rsi/RsiAtoD.cs
+++ b/src/Calculations/Rsi/RsiAtoD.cs
@@ -312,7 +312,7 @@ public static partial class Calculations
     /// <param name="lbLength"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateBreakoutRelativeStrengthIndex(this StockData stockData, InputName inputName = InputName.FullTypicalPrice,
+    public static StockData CalculateBreakoutRelativeStrengthIndex(this StockData stockData,
         int length = 14, int lbLength = 2)
     {
         List<double> brsiList = new(stockData.Count);
@@ -324,7 +324,7 @@ public static partial class Calculations
         RollingSum volumeSumWindow = new();
         RollingSum posPowerSumWindow = new();
         RollingSum negPowerSumWindow = new();
-        var (inputList, highList, lowList, openList, closeList, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, openList, closeList, volumeList) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Rsi/RsiEtoK.cs
+++ b/src/Calculations/Rsi/RsiEtoK.cs
@@ -21,7 +21,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum absRsiSum = new();
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Rsi/RsiLtoR.cs
+++ b/src/Calculations/Rsi/RsiLtoR.cs
@@ -274,7 +274,7 @@ public static partial class Calculations
 
         var srcList = GetMovingAverageList(stockData, maType, length, chgList);
         stockData.SetCustomValues(srcList);
-        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var rsi = rsiList[i];

--- a/src/Calculations/Rsi/RsiStoZ.cs
+++ b/src/Calculations/Rsi/RsiStoZ.cs
@@ -145,8 +145,8 @@ public static partial class Calculations
         var connorsRsiList = CalculateConnorsRelativeStrengthIndex(stockData, maType, length1, length2, length3).ChainedValues;
         stockData.SetCustomValues(connorsRsiList);
         var stochasticList = CalculateStochasticOscillator(stockData, maType, length2, smoothLength1, smoothLength2);
-        var fastDList = stochasticList.OutputValues["FastD"];
-        var slowDList = stochasticList.OutputValues["SlowD"];
+        var fastDList = stochasticList.ChainedOutputs["FastD"];
+        var slowDList = stochasticList.ChainedOutputs["SlowD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -189,8 +189,8 @@ public static partial class Calculations
         var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(rsiList);
         var stoRsiList = CalculateStochasticOscillator(stockData, maType, length, smoothLength1, smoothLength2);
-        var stochRsiList = stoRsiList.OutputValues["FastD"];
-        var stochRsiSignalList = stoRsiList.OutputValues["SlowD"];
+        var stochRsiList = stoRsiList.ChainedOutputs["FastD"];
+        var stochRsiSignalList = stoRsiList.ChainedOutputs["SlowD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Rsi/RsiStoZ.cs
+++ b/src/Calculations/Rsi/RsiStoZ.cs
@@ -87,9 +87,9 @@ public static partial class Calculations
         List<double> osList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(rsiList);
-        var rsiStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var rsiStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var rsiSmaList = GetMovingAverageList(stockData, maType, smoothingLength, rsiList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -142,7 +142,7 @@ public static partial class Calculations
     {
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var connorsRsiList = CalculateConnorsRelativeStrengthIndex(stockData, maType, length1, length2, length3).CustomValuesList;
+        var connorsRsiList = CalculateConnorsRelativeStrengthIndex(stockData, maType, length1, length2, length3).ChainedValues;
         stockData.SetCustomValues(connorsRsiList);
         var stochasticList = CalculateStochasticOscillator(stockData, maType, length2, smoothLength1, smoothLength2);
         var fastDList = stochasticList.OutputValues["FastD"];
@@ -186,7 +186,7 @@ public static partial class Calculations
     {
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).CustomValuesList;
+        var rsiList = CalculateRelativeStrengthIndex(stockData, maType, length: length).ChainedValues;
         stockData.SetCustomValues(rsiList);
         var stoRsiList = CalculateStochasticOscillator(stockData, maType, length, smoothLength1, smoothLength2);
         var stochRsiList = stoRsiList.OutputValues["FastD"];

--- a/src/Calculations/Stochastic/StochasticAtoD.cs
+++ b/src/Calculations/Stochastic/StochasticAtoD.cs
@@ -18,7 +18,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var srcList = CalculateLinearRegression(stockData, Math.Abs(slowLength - fastLength)).ChainedValues;
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
         var (highest1List, lowest1List) = GetMaxAndMinValuesList(srcList, fastLength);
         var (highest2List, lowest2List) = GetMaxAndMinValuesList(srcList, slowLength);
 
@@ -318,8 +318,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var adxList = CalculateAverageDirectionalIndex(stockData, maType, length1);
-        var diPlusList = adxList.OutputValues["DiPlus"];
-        var diMinusList = adxList.OutputValues["DiMinus"];
+        var diPlusList = adxList.ChainedOutputs["DiPlus"];
+        var diMinusList = adxList.ChainedOutputs["DiMinus"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Stochastic/StochasticAtoD.cs
+++ b/src/Calculations/Stochastic/StochasticAtoD.cs
@@ -17,7 +17,7 @@ public static partial class Calculations
         List<double> stcList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var srcList = CalculateLinearRegression(stockData, Math.Abs(slowLength - fastLength)).CustomValuesList;
+        var srcList = CalculateLinearRegression(stockData, Math.Abs(slowLength - fastLength)).ChainedValues;
         var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
         var (highest1List, lowest1List) = GetMaxAndMinValuesList(srcList, fastLength);
         var (highest2List, lowest2List) = GetMaxAndMinValuesList(srcList, slowLength);
@@ -261,7 +261,7 @@ public static partial class Calculations
         List<double> doubleKList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var stochasticList = CalculateStochasticOscillator(stockData, maType, length: length).CustomValuesList;
+        var stochasticList = CalculateStochasticOscillator(stockData, maType, length: length).ChainedValues;
         var (highestList, lowestList) = GetMaxAndMinValuesList(stochasticList, length);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Stochastic/StochasticEtoK.cs
+++ b/src/Calculations/Stochastic/StochasticEtoK.cs
@@ -107,6 +107,7 @@ public static partial class Calculations
     public static StockData CalculateFastandSlowStochasticOscillator(this StockData stockData,
         MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length1 = 3, int length2 = 6, int length3 = 9, int length4 = 9)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> fsstList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
@@ -114,8 +115,7 @@ public static partial class Calculations
         var v4List = GetMovingAverageList(stockData, maType, length2, fskList);
         // Reset CustomValuesList and SignalsList so stochastic uses original close prices, not v4List
         // Use SetCustomValues to create a new empty list (don't clear, which would affect v4List reference)
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        stockData.RestoreInputSeries(callerSeries);
         var fastKList = CalculateStochasticOscillator(stockData, maType, length: length3).CustomValuesList;
         var slowKList = GetMovingAverageList(stockData, maType, length3, fastKList);
 

--- a/src/Calculations/Stochastic/StochasticEtoK.cs
+++ b/src/Calculations/Stochastic/StochasticEtoK.cs
@@ -111,12 +111,12 @@ public static partial class Calculations
         List<double> fsstList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var fskList = CalculateFastandSlowKurtosisOscillator(stockData, maType, length1).CustomValuesList;
+        var fskList = CalculateFastandSlowKurtosisOscillator(stockData, maType, length1).ChainedValues;
         var v4List = GetMovingAverageList(stockData, maType, length2, fskList);
         // Reset CustomValuesList and SignalsList so stochastic uses original close prices, not v4List
         // Use SetCustomValues to create a new empty list (don't clear, which would affect v4List reference)
         stockData.RestoreInputSeries(callerSeries);
-        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length3).CustomValuesList;
+        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length3).ChainedValues;
         var slowKList = GetMovingAverageList(stockData, maType, length3, fastKList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Stochastic/StochasticLtoR.cs
+++ b/src/Calculations/Stochastic/StochasticLtoR.cs
@@ -79,7 +79,7 @@ public static partial class Calculations
 
         var len = MinOrMax((int)Math.Ceiling(Sqrt(smoothLength)));
 
-        var stochasticRsiList = CalculateStochasticOscillator(stockData, maType, length).CustomValuesList;
+        var stochasticRsiList = CalculateStochasticOscillator(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Stochastic/StochasticStoZ.cs
+++ b/src/Calculations/Stochastic/StochasticStoZ.cs
@@ -243,8 +243,8 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var fastKList = CalculateStochasticOscillator(stockData, maType, length, smoothLength1, smoothLength2);
-        var pkList = fastKList.OutputValues["FastD"];
-        var pdList = fastKList.OutputValues["SlowD"];
+        var pkList = fastKList.ChainedOutputs["FastD"];
+        var pdList = fastKList.ChainedOutputs["SlowD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -353,7 +353,7 @@ public static partial class Calculations
 
         var stoList = CalculateStochasticOscillator(stockData, maType, length1, length2, length2);
         var fastKList = stoList.ChainedValues;
-        var skList = stoList.OutputValues["FastD"];
+        var skList = stoList.ChainedOutputs["FastD"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Stochastic/StochasticStoZ.cs
+++ b/src/Calculations/Stochastic/StochasticStoZ.cs
@@ -74,12 +74,12 @@ public static partial class Calculations
 
         var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
 
-        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length1).CustomValuesList;
+        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length1).ChainedValues;
         var fastDList = GetMovingAverageList(stockData, maType, length1, fastKList);
         stockData.SetCustomValues(fastKList);
-        var tsfKList = CalculateLinearRegression(stockData, length2 + turbo).CustomValuesList;
+        var tsfKList = CalculateLinearRegression(stockData, length2 + turbo).ChainedValues;
         stockData.SetCustomValues(fastDList);
-        var tsfDList = CalculateLinearRegression(stockData, length2 + turbo).CustomValuesList;
+        var tsfDList = CalculateLinearRegression(stockData, length2 + turbo).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -123,13 +123,13 @@ public static partial class Calculations
 
         var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
 
-        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length1).CustomValuesList;
+        var fastKList = CalculateStochasticOscillator(stockData, maType, length: length1).ChainedValues;
         var slowKList = GetMovingAverageList(stockData, maType, length1, fastKList);
         var slowDList = GetMovingAverageList(stockData, maType, length1, slowKList);
         stockData.SetCustomValues(slowKList);
-        var tsfKList = CalculateLinearRegression(stockData, length2 + turbo).CustomValuesList;
+        var tsfKList = CalculateLinearRegression(stockData, length2 + turbo).ChainedValues;
         stockData.SetCustomValues(slowDList);
-        var tsfDList = CalculateLinearRegression(stockData, length2 + turbo).CustomValuesList;
+        var tsfDList = CalculateLinearRegression(stockData, length2 + turbo).ChainedValues;
 
         for (var i = 0; i < tssDList.Count; i++)
         {
@@ -352,7 +352,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
         var stoList = CalculateStochasticOscillator(stockData, maType, length1, length2, length2);
-        var fastKList = stoList.CustomValuesList;
+        var fastKList = stoList.ChainedValues;
         var skList = stoList.OutputValues["FastD"];
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/TrailingStop/TrailingStopAtoD.cs
+++ b/src/Calculations/TrailingStop/TrailingStopAtoD.cs
@@ -22,7 +22,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var perList = CalculatePoweredKaufmanAdaptiveMovingAverage(stockData, length, factor).OutputValues["Per"];
+        var perList = CalculatePoweredKaufmanAdaptiveMovingAverage(stockData, length, factor).ChainedOutputs["Per"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -88,7 +88,7 @@ public static partial class Calculations
 
         var aamaList = CalculateAdaptiveAutonomousRecursiveMovingAverage(stockData, length, gamma);
         var ma2List = aamaList.ChainedValues;
-        var dList = aamaList.OutputValues["D"];
+        var dList = aamaList.ChainedOutputs["D"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/TrailingStop/TrailingStopAtoD.cs
+++ b/src/Calculations/TrailingStop/TrailingStopAtoD.cs
@@ -87,7 +87,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var aamaList = CalculateAdaptiveAutonomousRecursiveMovingAverage(stockData, length, gamma);
-        var ma2List = aamaList.CustomValuesList;
+        var ma2List = aamaList.ChainedValues;
         var dList = aamaList.OutputValues["D"];
 
         for (var i = 0; i < stockData.Count; i++)
@@ -146,7 +146,7 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -197,7 +197,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length2).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length2).ChainedValues;
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/TrailingStop/TrailingStopEtoK.cs
+++ b/src/Calculations/TrailingStop/TrailingStopEtoK.cs
@@ -134,7 +134,7 @@ public static partial class Calculations
     /// <param name="stdDev4"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateKaseDevStopV1(this StockData stockData, InputName inputName = InputName.TypicalPrice,
+    public static StockData CalculateKaseDevStopV1(this StockData stockData,
         MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5, int slowLength = 21, int length = 20, double stdDev1 = 0,
         double stdDev2 = 1, double stdDev3 = 2.2, double stdDev4 = 3.6)
     {
@@ -144,7 +144,7 @@ public static partial class Calculations
         List<double> dev3List = new(stockData.Count);
         List<double> dtrList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, closeList, _) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/TrailingStop/TrailingStopEtoK.cs
+++ b/src/Calculations/TrailingStop/TrailingStopEtoK.cs
@@ -24,7 +24,7 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
         var (highestList, lowestList) = GetMaxAndMinValuesList(highList, lowList, length);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, atrLength).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, atrLength).ChainedValues;
         var highMaList = GetMovingAverageList(stockData, maType, length, highList);
         var lowMaList = GetMovingAverageList(stockData, maType, length, lowList);
 
@@ -160,7 +160,7 @@ public static partial class Calculations
         var smaSlowList = GetMovingAverageList(stockData, maType, slowLength, inputList);
         var smaFastList = GetMovingAverageList(stockData, maType, fastLength, inputList);
         stockData.SetCustomValues(dtrList);
-        var dtrStdList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var dtrStdList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var maFast = smaFastList[i];
@@ -258,7 +258,7 @@ public static partial class Calculations
 
         var rangeAvgList = GetMovingAverageList(stockData, maType, length, rrangeList);
         stockData.SetCustomValues(rrangeList);
-        var rangeStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var rangeStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var price = priceList[i];

--- a/src/Calculations/TrailingStop/TrailingStopEtoK.cs
+++ b/src/Calculations/TrailingStop/TrailingStopEtoK.cs
@@ -123,7 +123,6 @@ public static partial class Calculations
     /// Calculates the Kase Dev Stop V1
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="fastLength"></param>
     /// <param name="slowLength"></param>

--- a/src/Calculations/TrailingStop/TrailingStopLtoR.cs
+++ b/src/Calculations/TrailingStop/TrailingStopLtoR.cs
@@ -388,7 +388,7 @@ public static partial class Calculations
 
         // Taken before any moving average runs against stockData: GetMovingAverageList writes into
         // CustomValuesList, which the true-range helper would then read as the close series.
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/TrailingStop/TrailingStopLtoR.cs
+++ b/src/Calculations/TrailingStop/TrailingStopLtoR.cs
@@ -378,6 +378,7 @@ public static partial class Calculations
     public static StockData CalculateUtBotAlerts(this StockData stockData,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 10, double keyValue = 1)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> trailingStopList = new(stockData.Count);
         List<double> positionList = new(stockData.Count);
         List<double> buyList = new(stockData.Count);
@@ -388,7 +389,7 @@ public static partial class Calculations
         // Taken before any moving average runs against stockData: GetMovingAverageList writes into
         // CustomValuesList, which the true-range helper would then read as the close series.
         var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
-        stockData.SetCustomValues(new List<double>());
+        stockData.RestoreInputSeries(callerSeries);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/TrailingStop/TrailingStopLtoR.cs
+++ b/src/Calculations/TrailingStop/TrailingStopLtoR.cs
@@ -317,8 +317,8 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var mtaList = CalculateMotionToAttractionChannels(stockData, length);
-        var aList = mtaList.OutputValues["UpperBand"];
-        var bList = mtaList.OutputValues["LowerBand"];
+        var aList = mtaList.ChainedOutputs["UpperBand"];
+        var bList = mtaList.ChainedOutputs["LowerBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Trend/TrendStoZ.cs
+++ b/src/Calculations/Trend/TrendStoZ.cs
@@ -1072,7 +1072,6 @@ public static partial class Calculations
     /// Calculates the Wave Trend Oscillator
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="maType"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>

--- a/src/Calculations/Trend/TrendStoZ.cs
+++ b/src/Calculations/Trend/TrendStoZ.cs
@@ -1079,13 +1079,13 @@ public static partial class Calculations
     /// <param name="smoothLength"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateWaveTrendOscillator(this StockData stockData, InputName inputName = InputName.FullTypicalPrice,
+    public static StockData CalculateWaveTrendOscillator(this StockData stockData,
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 10, int length2 = 21, int smoothLength = 4)
     {
         List<double> absApEsaList = new(stockData.Count);
         List<double> ciList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, _, _, _) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, _) = GetInputValuesList(InputName.FullTypicalPrice, stockData);
 
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
 

--- a/src/Calculations/Trend/TrendStoZ.cs
+++ b/src/Calculations/Trend/TrendStoZ.cs
@@ -127,7 +127,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -352,7 +352,7 @@ public static partial class Calculations
         var slowMaList = GetMovingAverageList(stockData, maType, length1, inputList);
         var fastMaList = GetMovingAverageList(stockData, maType, length2, inputList);
         stockData.SetCustomValues(slowMaList);
-        var taiList = CalculateStandardDeviationVolatility(stockData, maType, length2).CustomValuesList;
+        var taiList = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
         var taiSmaList = GetMovingAverageList(stockData, maType, length1, taiList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -400,9 +400,9 @@ public static partial class Calculations
         var (inputList, highList, lowList, _, _) = GetInputValuesList(stockData);
 
         var emaList = GetMovingAverageList(stockData, maType, length, inputList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(atrList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -803,7 +803,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volatility/VolatilityEtoK.cs
+++ b/src/Calculations/Volatility/VolatilityEtoK.cs
@@ -35,7 +35,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(tempLogList);
-        var stdDevLogList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevLogList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var stdDevLog = stdDevLogList[i];
@@ -281,11 +281,11 @@ public static partial class Calculations
 
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         stockData.SetCustomValues(smaList);
-        var smaLinregList = CalculateLinearRegression(stockData, length).CustomValuesList;
+        var smaLinregList = CalculateLinearRegression(stockData, length).ChainedValues;
         stockData.SetCustomValues(smaList);
-        var linreg2List = CalculateLinearRegression(stockData, length2).CustomValuesList;
+        var linreg2List = CalculateLinearRegression(stockData, length2).ChainedValues;
         stockData.SetCustomValues(smaList);
-        var smaStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var smaStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volatility/VolatilityLtoR.cs
+++ b/src/Calculations/Volatility/VolatilityLtoR.cs
@@ -93,7 +93,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(amaDiffList);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var stdDev = stdDevList[i];
@@ -143,8 +143,8 @@ public static partial class Calculations
         if (stockData.Count == marketData.Count)
         {
             var emaList = GetMovingAverageList(stockData, maType, length, inputList);
-            var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
-            var spStdDevList = CalculateStandardDeviationVolatility(marketData, maType, length).CustomValuesList;
+            var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
+            var spStdDevList = CalculateStandardDeviationVolatility(marketData, maType, length).ChainedValues;
 
             for (var i = 0; i < stockData.Count; i++)
             {
@@ -320,7 +320,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         var emaList = GetMovingAverageList(stockData, MovingAvgType.ExponentialMovingAverage, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -333,7 +333,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(chgList);
-        var aChgStdDevList = CalculateStandardDeviationVolatility(stockData, length: length).CustomValuesList;
+        var aChgStdDevList = CalculateStandardDeviationVolatility(stockData, length: length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];
@@ -446,11 +446,11 @@ public static partial class Calculations
 
         // All three averages are of the prices; each Calculate call leaves its own output on CustomValuesList.
         var callerSeries = stockData.CaptureInputSeries();
-        var qmaList = CalculateQuadraticMovingAverage(stockData, length).CustomValuesList;
+        var qmaList = CalculateQuadraticMovingAverage(stockData, length).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var smaList = CalculateSimpleMovingAverage(stockData, length).CustomValuesList;
+        var smaList = CalculateSimpleMovingAverage(stockData, length).ChainedValues;
         stockData.RestoreInputSeries(callerSeries);
-        var emaList = CalculateExponentialMovingAverage(stockData, length).CustomValuesList;
+        var emaList = CalculateExponentialMovingAverage(stockData, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volatility/VolatilityLtoR.cs
+++ b/src/Calculations/Volatility/VolatilityLtoR.cs
@@ -23,9 +23,9 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var mabList = CalculateMovingAverageBands(stockData, maType, fastLength, slowLength, mult);
-        var ubList = mabList.OutputValues["UpperBand"];
-        var lbList = mabList.OutputValues["LowerBand"];
-        var maList = mabList.OutputValues["MiddleBand"];
+        var ubList = mabList.ChainedOutputs["UpperBand"];
+        var lbList = mabList.ChainedOutputs["LowerBand"];
+        var maList = mabList.ChainedOutputs["MiddleBand"];
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -75,7 +75,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).OutputValues["Er"];
+        var erList = CalculateKaufmanAdaptiveMovingAverage(stockData, length: length).ChainedOutputs["Er"];
         var emaList = GetMovingAverageList(stockData, MovingAvgType.ExponentialMovingAverage, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -497,8 +497,8 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var projectionBandsList = CalculateProjectionBands(stockData, length);
-        var puList = projectionBandsList.OutputValues["UpperBand"];
-        var plList = projectionBandsList.OutputValues["LowerBand"];
+        var puList = projectionBandsList.ChainedOutputs["UpperBand"];
+        var plList = projectionBandsList.ChainedOutputs["LowerBand"];
         var wmaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -553,8 +553,8 @@ public static partial class Calculations
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
         var projectionBandsList = CalculateProjectionBands(stockData, length);
-        var puList = projectionBandsList.OutputValues["UpperBand"];
-        var plList = projectionBandsList.OutputValues["LowerBand"];
+        var puList = projectionBandsList.ChainedOutputs["UpperBand"];
+        var plList = projectionBandsList.ChainedOutputs["LowerBand"];
         var wmaList = GetMovingAverageList(stockData, maType, length, inputList);
 
         for (var i = 0; i < stockData.Count; i++)

--- a/src/Calculations/Volatility/VolatilityStoZ.cs
+++ b/src/Calculations/Volatility/VolatilityStoZ.cs
@@ -181,7 +181,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(drList);
-        var volaList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var volaList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         var vswitchList = GetMovingAverageList(stockData, maType, length, volaList);
         var wmaList = GetMovingAverageList(stockData, maType, length, inputList);
         for (var i = 0; i < stockData.Count; i++)
@@ -419,7 +419,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length2).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length2).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -548,7 +548,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(retList);
-        var stdList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var prevStd = i >= 1 ? stdList[i - 1] : 0;

--- a/src/Calculations/Volume/VolumeEtoK.cs
+++ b/src/Calculations/Volume/VolumeEtoK.cs
@@ -344,10 +344,10 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, volumeList) = GetInputValuesList(stockData);
 
-        var medianPriceList = CalculateMedianPrice(stockData).CustomValuesList;
+        var medianPriceList = CalculateMedianPrice(stockData).ChainedValues;
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var typicalPriceList = CalculateTypicalPrice(stockData).CustomValuesList;
+        var typicalPriceList = CalculateTypicalPrice(stockData).ChainedValues;
         var volumeSmaList = GetMovingAverageList(stockData, maType, length, volumeList);
 
         for (var i = 0; i < stockData.Count; i++)
@@ -412,7 +412,7 @@ public static partial class Calculations
         RollingSum vBymSum = new();
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var relVolList = CalculateRelativeVolumeIndicator(stockData, maType, length).CustomValuesList;
+        var relVolList = CalculateRelativeVolumeIndicator(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -443,7 +443,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(vBymList);
-        var sdfList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var sdfList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var currentValue = inputList[i];

--- a/src/Calculations/Volume/VolumeEtoK.cs
+++ b/src/Calculations/Volume/VolumeEtoK.cs
@@ -205,7 +205,7 @@ public static partial class Calculations
     /// <param name="divisor"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateHawkeyeVolumeIndicator(this StockData stockData, InputName inputName = InputName.MedianPrice, int length = 200,
+    public static StockData CalculateHawkeyeVolumeIndicator(this StockData stockData, int length = 200,
         double divisor = 3.6)
     {
         List<double> tempRangeList = new(stockData.Count);
@@ -215,7 +215,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum volumeSum = new();
         RollingSum rangeSum = new();
-        var (inputList, highList, lowList, _, closeList, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, highList, lowList, _, closeList, volumeList) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -283,12 +283,12 @@ public static partial class Calculations
     /// <param name="pointValue"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateHerrickPayoffIndex(this StockData stockData, InputName inputName = InputName.MedianPrice, double pointValue = 100)
+    public static StockData CalculateHerrickPayoffIndex(this StockData stockData, double pointValue = 100)
     {
         List<double> kList = new(stockData.Count);
         List<double> hpicList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, openList, closeList, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, openList, closeList, volumeList) = GetInputValuesList(InputName.MedianPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volume/VolumeEtoK.cs
+++ b/src/Calculations/Volume/VolumeEtoK.cs
@@ -337,6 +337,7 @@ public static partial class Calculations
     public static StockData CalculateFiniteVolumeElements(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int length = 22, double factor = 0.3)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> fveList = new(stockData.Count);
         List<double> bullList = new(stockData.Count);
         List<double> bearList = new(stockData.Count);
@@ -344,8 +345,8 @@ public static partial class Calculations
         var (inputList, _, _, _, volumeList) = GetInputValuesList(stockData);
 
         var medianPriceList = CalculateMedianPrice(stockData).CustomValuesList;
-        // Reset CustomValuesList so TypicalPrice uses actual close prices, not medianPriceList
-        stockData.SetCustomValues(new List<double>());
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var typicalPriceList = CalculateTypicalPrice(stockData).CustomValuesList;
         var volumeSmaList = GetMovingAverageList(stockData, maType, length, volumeList);
 

--- a/src/Calculations/Volume/VolumeEtoK.cs
+++ b/src/Calculations/Volume/VolumeEtoK.cs
@@ -200,7 +200,6 @@ public static partial class Calculations
     /// Calculates the Hawkeye Volume Indicator
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <param name="divisor"></param>
     /// <returns></returns>
@@ -279,7 +278,6 @@ public static partial class Calculations
     /// Calculates the Herrick Payoff Index
     /// </summary>
     /// <param name="stockData"></param>
-    /// <param name="inputName"></param>
     /// <param name="pointValue"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]

--- a/src/Calculations/Volume/VolumeLtoR.cs
+++ b/src/Calculations/Volume/VolumeLtoR.cs
@@ -11,7 +11,7 @@ public static partial class Calculations
     /// <param name="length">The length.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateMoneyFlowIndex(this StockData stockData, InputName inputName = InputName.TypicalPrice, int length = 14)
+    public static StockData CalculateMoneyFlowIndex(this StockData stockData, int length = 14)
     {
         List<double> mfiList = new(stockData.Count);
         List<double> posMoneyFlowList = new(stockData.Count);
@@ -19,7 +19,7 @@ public static partial class Calculations
         var posMoneyFlowSumWindow = new RollingSum();
         var negMoneyFlowSumWindow = new RollingSum();
         List<Signal>? signalsList = CreateSignalsList(stockData);
-        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volume/VolumeLtoR.cs
+++ b/src/Calculations/Volume/VolumeLtoR.cs
@@ -7,7 +7,6 @@ public static partial class Calculations
     /// Calculates the Money Flow Index
     /// </summary>
     /// <param name="stockData">The stock data.</param>
-    /// <param name="inputName">Name of the input.</param>
     /// <param name="length">The length.</param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]

--- a/src/Calculations/Volume/VolumeLtoR.cs
+++ b/src/Calculations/Volume/VolumeLtoR.cs
@@ -237,7 +237,7 @@ public static partial class Calculations
     {
         List<Signal>? signalsList = CreateSignalsList(stockData);
 
-        var obvList = CalculateOnBalanceVolume(stockData, maType, length1).CustomValuesList;
+        var obvList = CalculateOnBalanceVolume(stockData, maType, length1).ChainedValues;
         var obvmList = GetMovingAverageList(stockData, maType, length1, obvList);
         var sigList = GetMovingAverageList(stockData, maType, length2, obvmList);
 
@@ -335,14 +335,14 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var obvList = CalculateOnBalanceVolume(stockData, maType, length).CustomValuesList;
+        var obvList = CalculateOnBalanceVolume(stockData, maType, length).ChainedValues;
         var obvSmaList = GetMovingAverageList(stockData, maType, length, obvList);
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(obvList);
-        var obvStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var obvStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -411,14 +411,14 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var nviList = CalculateNegativeVolumeIndex(stockData, maType, length).CustomValuesList;
+        var nviList = CalculateNegativeVolumeIndex(stockData, maType, length).ChainedValues;
         var nviSmaList = GetMovingAverageList(stockData, maType, length, nviList);
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
         // The next component reads the caller's series, not the previous component's output.
         stockData.RestoreInputSeries(callerSeries);
-        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
         stockData.SetCustomValues(nviList);
-        var nviStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var nviStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -485,7 +485,7 @@ public static partial class Calculations
 
         var smaVolumeList = GetMovingAverageList(stockData, maType, length, volumeList);
         stockData.SetCustomValues(volumeList);
-        var stdDevVolumeList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
+        var stdDevVolumeList = CalculateStandardDeviationVolatility(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {

--- a/src/Calculations/Volume/VolumeLtoR.cs
+++ b/src/Calculations/Volume/VolumeLtoR.cs
@@ -329,6 +329,7 @@ public static partial class Calculations
     public static StockData CalculateOnBalanceVolumeDisparityIndicator(this StockData stockData,
         MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 33, int signalLength = 4, double top = 1.1, double bottom = 0.9)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> obvdiList = new(stockData.Count);
         List<double> bscList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
@@ -337,9 +338,8 @@ public static partial class Calculations
         var obvList = CalculateOnBalanceVolume(stockData, maType, length).CustomValuesList;
         var obvSmaList = GetMovingAverageList(stockData, maType, length, obvList);
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        // Reset CustomValuesList to ensure stdDev uses close prices, not smaList
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
         stockData.SetCustomValues(obvList);
         var obvStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
@@ -405,6 +405,7 @@ public static partial class Calculations
     public static StockData CalculateNegativeVolumeDisparityIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int length = 33, int signalLength = 4, double top = 1.1, double bottom = 0.9)
     {
+        var callerSeries = stockData.CaptureInputSeries();
         List<double> nvdiList = new(stockData.Count);
         List<double> bscList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
@@ -413,9 +414,8 @@ public static partial class Calculations
         var nviList = CalculateNegativeVolumeIndex(stockData, maType, length).CustomValuesList;
         var nviSmaList = GetMovingAverageList(stockData, maType, length, nviList);
         var smaList = GetMovingAverageList(stockData, maType, length, inputList);
-        // Reset CustomValuesList to ensure stdDev uses close prices, not smaList
-        stockData.SetCustomValues(new List<double>());
-        stockData.SignalsList = new List<Signal>();
+        // The next component reads the caller's series, not the previous component's output.
+        stockData.RestoreInputSeries(callerSeries);
         var stdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;
         stockData.SetCustomValues(nviList);
         var nviStdDevList = CalculateStandardDeviationVolatility(stockData, maType, length).CustomValuesList;

--- a/src/Calculations/Volume/VolumeStoZ.cs
+++ b/src/Calculations/Volume/VolumeStoZ.cs
@@ -131,7 +131,7 @@ public static partial class Calculations
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
     public static StockData CalculateVolumePositiveNegativeIndicator(this StockData stockData,
-        MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, InputName inputName = InputName.TypicalPrice, int length = 30,
+        MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 30,
         int smoothLength = 3)
     {
         List<double> vmpList = new(stockData.Count);
@@ -140,7 +140,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum vmpSum = new();
         RollingSum vmnSum = new();
-        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, _, volumeList) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var mavList = GetMovingAverageList(stockData, maType, length, volumeList);
         var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
@@ -307,8 +307,7 @@ public static partial class Calculations
     /// <param name="vcoef"></param>
     /// <returns></returns>
     [Obsolete("Use the v2.0 Builder API (StockIndicatorBuilder) instead. See MIGRATION.md for details.")]
-    public static StockData CalculateVolumeFlowIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.TypicalPrice, int length1 = 130, int length2 = 30, int signalLength = 5, int smoothLength = 3,
+    public static StockData CalculateVolumeFlowIndicator(this StockData stockData, MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 130, int length2 = 30, int signalLength = 5, int smoothLength = 3,
         double coef = 0.2, double vcoef = 2.5)
     {
         List<double> interList = new(stockData.Count);
@@ -318,7 +317,7 @@ public static partial class Calculations
         List<double> dList = new(stockData.Count);
         List<Signal>? signalsList = CreateSignalsList(stockData);
         RollingSum vcpSumWindow = new();
-        var (inputList, _, _, _, closeList, volumeList) = GetInputValuesList(inputName, stockData);
+        var (inputList, _, _, _, closeList, volumeList) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var smaVolumeList = GetMovingAverageList(stockData, maType, length1, volumeList);
 

--- a/src/Calculations/Volume/VolumeStoZ.cs
+++ b/src/Calculations/Volume/VolumeStoZ.cs
@@ -125,7 +125,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length"></param>
     /// <param name="smoothLength"></param>
     /// <returns></returns>
@@ -298,7 +297,6 @@ public static partial class Calculations
     /// </summary>
     /// <param name="stockData"></param>
     /// <param name="maType"></param>
-    /// <param name="inputName"></param>
     /// <param name="length1"></param>
     /// <param name="length2"></param>
     /// <param name="signalLength"></param>

--- a/src/Calculations/Volume/VolumeStoZ.cs
+++ b/src/Calculations/Volume/VolumeStoZ.cs
@@ -142,7 +142,7 @@ public static partial class Calculations
         var (inputList, _, _, _, _, volumeList) = GetInputValuesList(InputName.TypicalPrice, stockData);
 
         var mavList = GetMovingAverageList(stockData, maType, length, volumeList);
-        var atrList = CalculateAverageTrueRange(stockData, maType, length).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length).ChainedValues;
 
         for (var i = 0; i < stockData.Count; i++)
         {
@@ -329,7 +329,7 @@ public static partial class Calculations
         }
 
         stockData.SetCustomValues(interList);
-        var vinterList = CalculateStandardDeviationVolatility(stockData, maType, length2).CustomValuesList;
+        var vinterList = CalculateStandardDeviationVolatility(stockData, maType, length2).ChainedValues;
         for (var i = 0; i < stockData.Count; i++)
         {
             var vinter = vinterList[i];

--- a/src/Calculations/Wilder/WilderStoZ.cs
+++ b/src/Calculations/Wilder/WilderStoZ.cs
@@ -22,7 +22,7 @@ public static partial class Calculations
         List<Signal>? signalsList = CreateSignalsList(stockData);
         var (inputList, _, _, _, _) = GetInputValuesList(stockData);
 
-        var atrList = CalculateAverageTrueRange(stockData, maType, length2).CustomValuesList;
+        var atrList = CalculateAverageTrueRange(stockData, maType, length2).ChainedValues;
         var emaList = GetMovingAverageList(stockData, maType, length1, inputList);
         var (highestList, lowestList) = GetMaxAndMinValuesList(inputList, length2);
 

--- a/src/Core/OscillatorCore.cs
+++ b/src/Core/OscillatorCore.cs
@@ -13547,7 +13547,7 @@ internal static class OscillatorCore
             for (int i = 0; i < close.Length; i++)
             {
                 double cycle = Math.Max(length2, Math.Min(length1, domCyc[i]));
-                int cycLength = (int)Math.Ceiling(cycle);
+                int cycLength = MathHelper.CeilingCycle(cycle);
 
                 // Compute average and RMS over cycLength
                 double sum = 0;
@@ -13620,7 +13620,7 @@ internal static class OscillatorCore
             for (int i = 0; i < close.Length; i++)
             {
                 double cycle = Math.Max(length2, Math.Min(length1, domCyc[i]));
-                int halfCycle = (int)Math.Ceiling(cycle / 2);
+                int halfCycle = MathHelper.CeilingCycle(cycle / 2);
 
                 double upChg = 0, dnChg = 0;
                 for (int j = 0; j < halfCycle && (i - j - 1) >= 0; j++)

--- a/src/Enums/InputName.cs
+++ b/src/Enums/InputName.cs
@@ -10,7 +10,7 @@
 
 namespace OoplesFinance.StockIndicators.Enums;
 
-public enum InputName
+internal enum InputName
 {
     AdjustedClose,
     Close,

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -1643,7 +1643,7 @@ public static class CalculationsHelper
     /// <param name="inputName">Name of the input.</param>
     /// <param name="stockData">The stock data.</param>
     /// <returns></returns>
-    public static (List<double> inputList, List<double> highList, List<double> lowList, List<double> openList, List<double> closeList,
+    internal static (List<double> inputList, List<double> highList, List<double> lowList, List<double> openList, List<double> closeList,
         List<double> volumeList) GetInputValuesList(InputName inputName, StockData stockData)
     {
         List<double> highList;
@@ -1653,8 +1653,8 @@ public static class CalculationsHelper
         List<double> volumeList;
 
         // A chained series wins, exactly as it does for the single-argument overload. This overload
-        // used to go straight to the named price field, so the 17 indicators that take their own
-        // inputName - AlligatorIndex, AwesomeOscillator, CommodityChannelIndex, MoneyFlowIndex,
+        // used to go straight to the named price field, so the 28 indicators whose default input is a
+        // named price - AlligatorIndex, AwesomeOscillator, CommodityChannelIndex, MoneyFlowIndex,
         // VolumeWeightedAveragePrice and the rest - silently ignored anything chained in front of
         // them, as did every indicator built on one of them (GatorOscillator on AlligatorIndex,
         // AcceleratorOscillator on AwesomeOscillator). Callers pass values; the name only decides what

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -1683,32 +1683,10 @@ public static class CalculationsHelper
             _ => stockData.ClosePrices,
         };
 
-        if (inputList.Count > 0)
+        if (inputList.Count > 0 && !SequenceEqualValues(inputList, stockData.ClosePrices))
         {
-            var sum = SumValues(inputList);
-            var isVolumeInput = SequenceEqualValues(inputList, stockData.Volumes);
-            if (isVolumeInput)
-            {
-                var minMaxList = GetMaxAndMinValuesList(inputList, 0);
-                highList = minMaxList.Item1;
-                lowList = minMaxList.Item2;
-            }
-            else
-            {
-                var lowSum = SumValues(stockData.LowPrices);
-                var highSum = SumValues(stockData.HighPrices);
-                if (sum < lowSum || sum > highSum)
-                {
-                    var minMaxList = GetMaxAndMinValuesList(inputList, 0);
-                    highList = minMaxList.Item1;
-                    lowList = minMaxList.Item2;
-                }
-                else
-                {
-                    highList = stockData.HighPrices;
-                    lowList = stockData.LowPrices;
-                }
-            }
+            // A series other than the close: the per-bar rule. See GetCustomRangeLists.
+            (highList, lowList) = GetCustomRangeLists(inputList, stockData.HighPrices, stockData.LowPrices);
         }
         else
         {
@@ -1753,32 +1731,10 @@ public static class CalculationsHelper
             inputList = stockData.InputValues;
         }
 
-        if (inputList.Count > 0)
+        if (inputList.Count > 0 && !SequenceEqualValues(inputList, stockData.ClosePrices))
         {
-            var sum = SumValues(inputList);
-            var isVolumeInput = SequenceEqualValues(inputList, stockData.Volumes);
-            if (isVolumeInput)
-            {
-                var minMaxList = GetMaxAndMinValuesList(inputList, 0);
-                highList = minMaxList.Item1;
-                lowList = minMaxList.Item2;
-            }
-            else
-            {
-                var lowSum = SumValues(stockData.LowPrices);
-                var highSum = SumValues(stockData.HighPrices);
-                if (sum < lowSum || sum > highSum)
-                {
-                    var minMaxList = GetMaxAndMinValuesList(inputList, 0);
-                    highList = minMaxList.Item1;
-                    lowList = minMaxList.Item2;
-                }
-                else
-                {
-                    highList = stockData.HighPrices;
-                    lowList = stockData.LowPrices;
-                }
-            }
+            // A series other than the close: the per-bar rule. See GetCustomRangeLists.
+            (highList, lowList) = GetCustomRangeLists(inputList, stockData.HighPrices, stockData.LowPrices);
         }
         else
         {
@@ -2040,6 +1996,54 @@ public static class CalculationsHelper
     /// <param name="inputs">The inputs.</param>
     /// <param name="length">The length.</param>
     /// <returns></returns>
+    /// <summary>
+    /// The high and low an indicator should read when its input is a series other than the close.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Decided bar by bar. A value inside that bar's range is price-like - a median or typical price,
+    /// a chained moving average - so the bar's true high and low still apply. A value outside it -
+    /// an oscillator, a volume, a rescaled series - is its own scale, and its high and low are the
+    /// max and min of the previous and current value.
+    /// </para>
+    /// <para>
+    /// This replaces a whole-series rule that summed the input and compared the sum against the sums
+    /// of the lows and highs. For a series entirely inside or entirely outside the bars' range the
+    /// two agree exactly - the out-of-range branch was GetMaxAndMinValuesList(series, 0), whose window
+    /// clamps to 2. What the per-bar rule adds is causality: it needs nothing after the current bar,
+    /// so a streaming state can apply the same rule and the two engines agree bar by bar. The
+    /// whole-series sum could not be computed by a streaming state at all.
+    /// </para>
+    /// </remarks>
+    internal static (List<double> HighList, List<double> LowList) GetCustomRangeLists(IReadOnlyList<double> values,
+        IReadOnlyList<double> highs, IReadOnlyList<double> lows)
+    {
+        var count = values.Count;
+        var highList = new List<double>(count);
+        var lowList = new List<double>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            var value = values[i];
+            var high = i < highs.Count ? highs[i] : value;
+            var low = i < lows.Count ? lows[i] : value;
+
+            if (value >= low && value <= high)
+            {
+                highList.Add(high);
+                lowList.Add(low);
+            }
+            else
+            {
+                var prev = i > 0 ? values[i - 1] : value;
+                highList.Add(Math.Max(prev, value));
+                lowList.Add(Math.Min(prev, value));
+            }
+        }
+
+        return (highList, lowList);
+    }
+
     public static (List<double>, List<double>) GetMaxAndMinValuesList(List<double> inputs, int length)
     {
         var count = inputs.Count;

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -397,10 +397,18 @@ public static class CalculationsHelper
             return list;
         }
 
-        var highs = stockData.HighPrices;
-        var lows = stockData.LowPrices;
         var opens = stockData.OpenPrices;
         var closes = GetDerivedCloseList(stockData);
+        IReadOnlyList<double> highs = stockData.HighPrices;
+        IReadOnlyList<double> lows = stockData.LowPrices;
+        if (!ReferenceEquals(closes, stockData.ClosePrices) && !SequenceEqualValues(closes, stockData.ClosePrices))
+        {
+            // A chained series stands in for the close, and each bar's range follows the per-bar rule, as
+            // GetInputValuesList and the streaming CustomInputState apply it. Built from the real high and low
+            // around a custom close, a true range measured the gap between two different series: a log-close
+            // of about 5 against highs near 180 gave ATR bands of +-400.
+            (highs, lows) = GetCustomRangeLists(closes, stockData.HighPrices, stockData.LowPrices);
+        }
 
         switch (kind)
         {
@@ -1701,7 +1709,9 @@ public static class CalculationsHelper
         }
 
         openList = stockData.OpenPrices;
-        closeList = stockData.ClosePrices;
+        // A chained series stands in for the close, as it does in the bar CustomInputState hands a streaming
+        // state; the named input only decides what is read when nothing was chained.
+        closeList = stockData.CustomValuesList is { Count: > 0 } ? inputList : stockData.ClosePrices;
         volumeList = stockData.Volumes;
 
         return (inputList, highList, lowList, openList, closeList, volumeList);

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -1651,7 +1651,21 @@ public static class CalculationsHelper
         List<double> openList;
         List<double> closeList;
         List<double> volumeList;
-        var inputList = inputName switch
+
+        // A chained series wins, exactly as it does for the single-argument overload. This overload
+        // used to go straight to the named price field, so the 17 indicators that take their own
+        // inputName - AlligatorIndex, AwesomeOscillator, CommodityChannelIndex, MoneyFlowIndex,
+        // VolumeWeightedAveragePrice and the rest - silently ignored anything chained in front of
+        // them, as did every indicator built on one of them (GatorOscillator on AlligatorIndex,
+        // AcceleratorOscillator on AwesomeOscillator). Callers pass values; the name only decides what
+        // is read when nothing was passed.
+        //
+        // Safe for every call site: each of the 24 reads its input on entry, before anything in that
+        // calculation writes to CustomValuesList, so what is found there is always the caller's chain
+        // and never an intermediate of the calculation itself (the #145 pattern).
+        var inputList = stockData.CustomValuesList is { Count: > 0 } chained
+            ? chained
+            : inputName switch
         {
             InputName.Close => stockData.ClosePrices,
             InputName.Low => stockData.LowPrices,

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -1853,6 +1853,29 @@ public static class CalculationsHelper
         var parentOrder = new List<DateTime>();
         var tickerDataList = stockData.TickerDataList;
 
+        // A chained series is the close of every bar, and each bar's high and low follow the per-bar
+        // rule (GetCustomRangeLists); the periods are then built from those adjusted bars exactly as
+        // they are built from the real ones - open first, high the max, low the min, close last. This
+        // used to rebuild from TickerDataList whatever was chained in front, so every pivot point
+        // silently ignored a custom series.
+        var chained = stockData.CustomValuesList is { Count: > 0 } custom && custom.Count == tickerDataList.Count
+            ? custom
+            : null;
+        List<double>? customHighs = null;
+        List<double>? customLows = null;
+        if (chained != null)
+        {
+            var highs = new List<double>(tickerDataList.Count);
+            var lows = new List<double>(tickerDataList.Count);
+            for (var k = 0; k < tickerDataList.Count; k++)
+            {
+                highs.Add(tickerDataList[k].High);
+                lows.Add(tickerDataList[k].Low);
+            }
+
+            (customHighs, customLows) = GetCustomRangeLists(chained, highs, lows);
+        }
+
         for (var i = 0; i < tickerDataList.Count; i++)
         {
             var ticker = tickerDataList[i];
@@ -1883,7 +1906,14 @@ public static class CalculationsHelper
                 parentGroup.ChildOrder.Add(childKey);
             }
 
-            childGroup.Add(ticker);
+            if (chained != null && customHighs != null && customLows != null)
+            {
+                childGroup.Add(ticker.Open, customHighs[i], customLows[i], chained[i], ticker.Volume);
+            }
+            else
+            {
+                childGroup.Add(ticker);
+            }
         }
 
         for (var i = 0; i < parentOrder.Count; i++)
@@ -1924,31 +1954,34 @@ public static class CalculationsHelper
         public double Close { get; private set; }
         public double Volume { get; private set; }
 
-        public void Add(TickerData ticker)
+        public void Add(TickerData ticker) =>
+            Add(ticker.Open, ticker.High, ticker.Low, ticker.Close, ticker.Volume);
+
+        public void Add(double open, double high, double low, double close, double volume)
         {
             if (!HasValue)
             {
-                Open = ticker.Open;
-                High = ticker.High;
-                Low = ticker.Low;
-                Close = ticker.Close;
-                Volume = ticker.Volume;
+                Open = open;
+                High = high;
+                Low = low;
+                Close = close;
+                Volume = volume;
                 HasValue = true;
                 return;
             }
 
-            if (ticker.High > High)
+            if (high > High)
             {
-                High = ticker.High;
+                High = high;
             }
 
-            if (ticker.Low < Low)
+            if (low < Low)
             {
-                Low = ticker.Low;
+                Low = low;
             }
 
-            Volume += ticker.Volume;
-            Close = ticker.Close;
+            Volume += volume;
+            Close = close;
         }
     }
 

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -112,21 +112,21 @@ public static class CalculationsHelper
         return true;
     }
 
+    /// <summary>
+    /// Publishes an indicator's named series, and keeps them, unrounded, for whatever is calculated next.
+    /// </summary>
+    /// <remarks>
+    /// IncludeOutputValues and RoundingDigits decide only the published copy. Composites read their components'
+    /// named series back, so emptying the one dictionary both read made 56 indicators throw, and rounding it
+    /// fed rounded inputs to the rest; it was also cleared in place, emptying a dictionary a caller held.
+    /// </remarks>
     public static void SetOutputValues(this StockData stockData, Func<Dictionary<string, List<double>>> outputFactory)
     {
-        if (!ShouldIncludeOutputValues(stockData))
-        {
-            stockData.OutputValues?.Clear();
-            return;
-        }
-
         var outputs = outputFactory();
-        if (TryGetRoundingDigits(stockData, out var roundingDigits))
-        {
-            outputs = RoundOutputValues(outputs, roundingDigits);
-        }
-
-        stockData.OutputValues = outputs;
+        var published = !ShouldIncludeOutputValues(stockData)
+            ? new Dictionary<string, List<double>>()
+            : TryGetRoundingDigits(stockData, out var roundingDigits) ? RoundOutputValues(outputs, roundingDigits) : outputs;
+        stockData.SetOutputs(outputs, published);
     }
 
     public static List<Signal>? CreateSignalsList(StockData stockData, int capacity = 0)
@@ -196,20 +196,17 @@ public static class CalculationsHelper
     /// Publishes an indicator's single series, and hands it to whatever is calculated next.
     /// </summary>
     /// <remarks>
-    /// IncludeCustomValues decides only the first. Off, the series is still the next calculation's input, the
-    /// same values it would read with the option on; it used to be cleared in place, which emptied the list a
-    /// composite had just asked a component for.
+    /// IncludeCustomValues and RoundingDigits decide only the first. Off, the series is still the next
+    /// calculation's input, the same values it would read with the option on; it used to be cleared in place,
+    /// which emptied the list a composite had just asked a component for. Rounded, it is still passed on
+    /// unrounded: the rounded copy used to be the input, so 187 indicators rounded a value they computed on.
     /// </remarks>
     public static void SetCustomValues(this StockData stockData, List<double> customValuesList)
     {
-        stockData.CustomValuesList = TryGetRoundingDigits(stockData, out var roundingDigits)
-            ? RoundValuesList(customValuesList, roundingDigits)
-            : customValuesList;
-
-        if (!ShouldIncludeCustomValues(stockData))
-        {
-            stockData.HideCustomValues();
-        }
+        var published = !ShouldIncludeCustomValues(stockData)
+            ? new List<double>()
+            : TryGetRoundingDigits(stockData, out var roundingDigits) ? RoundValuesList(customValuesList, roundingDigits) : customValuesList;
+        stockData.RestoreSeries(published, customValuesList);
     }
 
     private static bool ShouldIncludeOutputValues(StockData stockData)
@@ -1354,7 +1351,7 @@ public static class CalculationsHelper
                 movingAvgList = stockData.CalculateFisherLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.FollowingAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateEhlersMotherOfAdaptiveMovingAverages().OutputValues["Fama"];
+                movingAvgList = stockData.CalculateEhlersMotherOfAdaptiveMovingAverages().ChainedOutputs["Fama"];
                 break;
             case MovingAvgType.GeneralFilterEstimator:
                 movingAvgList = stockData.CalculateGeneralFilterEstimator(length: length).ChainedValues;

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -171,12 +171,11 @@ public static class CalculationsHelper
     /// A copy of the caller's input series, taken before a composite's components publish their own outputs.
     /// </summary>
     /// <remarks>
-    /// Empty when the caller chained nothing. <see cref="StockData.CustomValuesList"/> has a public setter and can
-    /// be null; a null series reads as the bars' own input, as <c>GetInputValuesList</c> treats it, instead of
-    /// throwing from the copy.
+    /// Empty when the caller chained nothing. It is the chained series, not the published list, so a caller
+    /// with IncludeCustomValues off still hands its input to every component.
     /// </remarks>
     internal static List<double> CaptureInputSeries(this StockData stockData) =>
-        stockData.CustomValuesList is { } series ? new List<double>(series) : new List<double>();
+        new List<double>(stockData.ChainedValues);
 
     /// <summary>
     /// Hands the next component of a composite indicator the caller's input again, after an earlier
@@ -193,21 +192,24 @@ public static class CalculationsHelper
         stockData.SignalsList = new List<Signal>();
     }
 
+    /// <summary>
+    /// Publishes an indicator's single series, and hands it to whatever is calculated next.
+    /// </summary>
+    /// <remarks>
+    /// IncludeCustomValues decides only the first. Off, the series is still the next calculation's input, the
+    /// same values it would read with the option on; it used to be cleared in place, which emptied the list a
+    /// composite had just asked a component for.
+    /// </remarks>
     public static void SetCustomValues(this StockData stockData, List<double> customValuesList)
     {
+        stockData.CustomValuesList = TryGetRoundingDigits(stockData, out var roundingDigits)
+            ? RoundValuesList(customValuesList, roundingDigits)
+            : customValuesList;
+
         if (!ShouldIncludeCustomValues(stockData))
         {
-            stockData.CustomValuesList?.Clear();
-            return;
+            stockData.HideCustomValues();
         }
-
-        if (TryGetRoundingDigits(stockData, out var roundingDigits))
-        {
-            stockData.CustomValuesList = RoundValuesList(customValuesList, roundingDigits);
-            return;
-        }
-
-        stockData.CustomValuesList = customValuesList;
     }
 
     private static bool ShouldIncludeOutputValues(StockData stockData)
@@ -375,14 +377,14 @@ public static class CalculationsHelper
             return false;
         }
 
-        return stockData.CustomValuesList == null || stockData.CustomValuesList.Count == 0;
+        return stockData.ChainedValues.Count == 0;
     }
 
     private static IReadOnlyList<double> GetDerivedCloseList(StockData stockData)
     {
-        if (stockData.CustomValuesList != null && stockData.CustomValuesList.Count > 0)
+        if (stockData.ChainedValues.Count > 0)
         {
-            return stockData.CustomValuesList;
+            return stockData.ChainedValues;
         }
 
         return stockData.ClosePrices;
@@ -497,14 +499,14 @@ public static class CalculationsHelper
     /// <remarks>
     /// Leaves the caller's series exactly as it found it. It used to publish the average onto
     /// <see cref="StockData.CustomValuesList"/>, so whatever an indicator calculated NEXT ran on the average
-    /// rather than the price: Bollinger Bands measured the standard deviation of its own middle band. It works
-    /// on a copy because the calculations it delegates to clear the current series in place when
-    /// IncludeCustomValues is off, and that series can be the very list the caller is holding.
+    /// rather than the price: Bollinger Bands measured the standard deviation of its own middle band. Both the
+    /// published list and the chained series are put back, since with IncludeCustomValues off they differ.
     /// </remarks>
     public static List<double> GetMovingAverageList(StockData stockData, MovingAvgType movingAvgType, int length, List<double>? customValuesList = null,
         int? fastLength = null, int? slowLength = null)
     {
-        var callerSeries = stockData.CustomValuesList;
+        var callerPublished = stockData.CustomValuesList;
+        var callerChained = stockData.ChainedValues;
         stockData.SetInputSeries(customValuesList is not null ? new List<double>(customValuesList) : stockData.CaptureInputSeries());
         try
         {
@@ -512,7 +514,7 @@ public static class CalculationsHelper
         }
         finally
         {
-            stockData.SetInputSeries(callerSeries);
+            stockData.RestoreSeries(callerPublished, callerChained);
         }
     }
 
@@ -1152,490 +1154,490 @@ public static class CalculationsHelper
         switch (movingAvgType)
         {
             case MovingAvgType._1LCLeastSquaresMovingAverage:
-                movingAvgList = stockData.Calculate1LCLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.Calculate1LCLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType._3HMA:
-                movingAvgList = stockData.Calculate3HMA(length: length).CustomValuesList;
+                movingAvgList = stockData.Calculate3HMA(length: length).ChainedValues;
                 break;
             case MovingAvgType.AdaptiveAutonomousRecursiveMovingAverage:
-                movingAvgList = stockData.CalculateAdaptiveAutonomousRecursiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAdaptiveAutonomousRecursiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.AdaptiveExponentialMovingAverage:
-                movingAvgList = stockData.CalculateAdaptiveExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAdaptiveExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.AdaptiveLeastSquares:
-                movingAvgList = stockData.CalculateAdaptiveLeastSquares(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAdaptiveLeastSquares(length: length).ChainedValues;
                 break;
             case MovingAvgType.AdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateAdaptiveMovingAverage(fastLength ?? default, slowLength ?? length, length).CustomValuesList;
+                movingAvgList = stockData.CalculateAdaptiveMovingAverage(fastLength ?? default, slowLength ?? length, length).ChainedValues;
                 break;
             case MovingAvgType.AhrensMovingAverage:
-                movingAvgList = stockData.CalculateAhrensMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateAhrensMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.AlphaDecreasingExponentialMovingAverage:
-                movingAvgList = stockData.CalculateAlphaDecreasingExponentialMovingAverage().CustomValuesList;
+                movingAvgList = stockData.CalculateAlphaDecreasingExponentialMovingAverage().ChainedValues;
                 break;
             case MovingAvgType.ArnaudLegouxMovingAverage:
-                movingAvgList = stockData.CalculateArnaudLegouxMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateArnaudLegouxMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.AtrFilteredExponentialMovingAverage:
-                movingAvgList = stockData.CalculateAtrFilteredExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAtrFilteredExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.AutoFilter:
-                movingAvgList = stockData.CalculateAutoFilter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAutoFilter(length: length).ChainedValues;
                 break;
             case MovingAvgType.AutonomousRecursiveMovingAverage:
-                movingAvgList = stockData.CalculateAutonomousRecursiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateAutonomousRecursiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.BryantAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateBryantAdaptiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateBryantAdaptiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.CompoundRatioMovingAverage:
-                movingAvgList = stockData.CalculateCompoundRatioMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateCompoundRatioMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.CorrectedMovingAverage:
-                movingAvgList = stockData.CalculateCorrectedMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateCorrectedMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.CubedWeightedMovingAverage:
-                movingAvgList = stockData.CalculateCubedWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateCubedWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.DampedSineWaveWeightedFilter:
-                movingAvgList = stockData.CalculateDampedSineWaveWeightedFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateDampedSineWaveWeightedFilter(length).ChainedValues;
                 break;
             case MovingAvgType.DistanceWeightedMovingAverage:
-                movingAvgList = stockData.CalculateDistanceWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateDistanceWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.DoubleExponentialMovingAverage:
-                movingAvgList = stockData.CalculateDoubleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateDoubleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.DoubleExponentialSmoothing:
-                movingAvgList = stockData.CalculateDoubleExponentialSmoothing().CustomValuesList;
+                movingAvgList = stockData.CalculateDoubleExponentialSmoothing().ChainedValues;
                 break;
             case MovingAvgType.DynamicallyAdjustableFilter:
-                movingAvgList = stockData.CalculateDynamicallyAdjustableFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateDynamicallyAdjustableFilter(length).ChainedValues;
                 break;
             case MovingAvgType.DynamicallyAdjustableMovingAverage:
-                movingAvgList = stockData.CalculateDynamicallyAdjustableMovingAverage(fastLength ?? default, slowLength ?? length).CustomValuesList;
+                movingAvgList = stockData.CalculateDynamicallyAdjustableMovingAverage(fastLength ?? default, slowLength ?? length).ChainedValues;
                 break;
             case MovingAvgType.EdgePreservingFilter:
-                movingAvgList = stockData.CalculateEdgePreservingFilter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEdgePreservingFilter(length: length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers2PoleButterworthFilterV1:
-                movingAvgList = stockData.CalculateEhlers2PoleButterworthFilterV1(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers2PoleButterworthFilterV1(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers2PoleButterworthFilterV2:
-                movingAvgList = stockData.CalculateEhlers2PoleButterworthFilterV2(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers2PoleButterworthFilterV2(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers2PoleSuperSmootherFilterV1:
-                movingAvgList = stockData.CalculateEhlers2PoleSuperSmootherFilterV1(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers2PoleSuperSmootherFilterV1(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers2PoleSuperSmootherFilterV2:
-                movingAvgList = stockData.CalculateEhlers2PoleSuperSmootherFilterV2(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers2PoleSuperSmootherFilterV2(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers3PoleButterworthFilterV1:
-                movingAvgList = stockData.CalculateEhlers3PoleButterworthFilterV1(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers3PoleButterworthFilterV1(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers3PoleButterworthFilterV2:
-                movingAvgList = stockData.CalculateEhlers3PoleButterworthFilterV2(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers3PoleButterworthFilterV2(length).ChainedValues;
                 break;
             case MovingAvgType.Ehlers3PoleSuperSmootherFilter:
-                movingAvgList = stockData.CalculateEhlers3PoleSuperSmootherFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlers3PoleSuperSmootherFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersAdaptiveLaguerreFilter:
-                movingAvgList = stockData.CalculateEhlersAdaptiveLaguerreFilter(slowLength ?? length, fastLength ?? default).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersAdaptiveLaguerreFilter(slowLength ?? length, fastLength ?? default).ChainedValues;
                 break;
             case MovingAvgType.EhlersAllPassPhaseShifter:
-                movingAvgList = stockData.CalculateEhlersAllPassPhaseShifter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersAllPassPhaseShifter(length: length).ChainedValues;
                 break;
             case MovingAvgType.EhlersAverageErrorFilter:
-                movingAvgList = stockData.CalculateEhlersAverageErrorFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersAverageErrorFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersBetterExponentialMovingAverage:
-                movingAvgList = stockData.CalculateEhlersBetterExponentialMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersBetterExponentialMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersChebyshevLowPassFilter:
-                movingAvgList = stockData.CalculateEhlersChebyshevLowPassFilter().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersChebyshevLowPassFilter().ChainedValues;
                 break;
             case MovingAvgType.EhlersDeviationScaledMovingAverage:
                 movingAvgList = stockData.CalculateEhlersDeviationScaledMovingAverage(
-                    fastLength: fastLength ?? length, slowLength: slowLength ?? length * 2).CustomValuesList;
+                    fastLength: fastLength ?? length, slowLength: slowLength ?? length * 2).ChainedValues;
                 break;
             case MovingAvgType.EhlersDeviationScaledSuperSmoother:
-                movingAvgList = stockData.CalculateEhlersDeviationScaledSuperSmoother(length1: fastLength ?? length, length2: slowLength ?? default).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersDeviationScaledSuperSmoother(length1: fastLength ?? length, length2: slowLength ?? default).ChainedValues;
                 break;
             case MovingAvgType.EhlersDistanceCoefficientFilter:
-                movingAvgList = stockData.CalculateEhlersDistanceCoefficientFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersDistanceCoefficientFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersFilter:
-                movingAvgList = stockData.CalculateEhlersFilter(slowLength ?? length, fastLength ?? default).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersFilter(slowLength ?? length, fastLength ?? default).ChainedValues;
                 break;
             case MovingAvgType.EhlersFiniteImpulseResponseFilter:
-                movingAvgList = stockData.CalculateEhlersFiniteImpulseResponseFilter().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersFiniteImpulseResponseFilter().ChainedValues;
                 break;
             case MovingAvgType.EhlersFractalAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateEhlersFractalAdaptiveMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersFractalAdaptiveMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersGaussianFilter:
-                movingAvgList = stockData.CalculateEhlersGaussianFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersGaussianFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersHammingMovingAverage:
-                movingAvgList = stockData.CalculateEhlersHammingMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersHammingMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.EhlersHannMovingAverage:
-                movingAvgList = stockData.CalculateEhlersHannMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersHannMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersInfiniteImpulseResponseFilter:
-                movingAvgList = stockData.CalculateEhlersInfiniteImpulseResponseFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersInfiniteImpulseResponseFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersKaufmanAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateEhlersKaufmanAdaptiveMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersKaufmanAdaptiveMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersLaguerreFilter:
-                movingAvgList = stockData.CalculateEhlersLaguerreFilter().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersLaguerreFilter().ChainedValues;
                 break;
             case MovingAvgType.EhlersLeadingIndicator:
-                movingAvgList = stockData.CalculateEhlersLeadingIndicator().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersLeadingIndicator().ChainedValues;
                 break;
             case MovingAvgType.EhlersMedianAverageAdaptiveFilter:
-                movingAvgList = stockData.CalculateEhlersMedianAverageAdaptiveFilter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersMedianAverageAdaptiveFilter(length: length).ChainedValues;
                 break;
             case MovingAvgType.EhlersMesaAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateEhlersMotherOfAdaptiveMovingAverages().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersMotherOfAdaptiveMovingAverages().ChainedValues;
                 break;
             case MovingAvgType.EhlersModifiedOptimumEllipticFilter:
-                movingAvgList = stockData.CalculateEhlersModifiedOptimumEllipticFilter().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersModifiedOptimumEllipticFilter().ChainedValues;
                 break;
             case MovingAvgType.EhlersOptimumEllipticFilter:
-                movingAvgList = stockData.CalculateEhlersOptimumEllipticFilter().CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersOptimumEllipticFilter().ChainedValues;
                 break;
             case MovingAvgType.EhlersRecursiveMedianFilter:
-                movingAvgList = stockData.CalculateEhlersRecursiveMedianFilter(fastLength ?? default, slowLength ?? length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersRecursiveMedianFilter(fastLength ?? default, slowLength ?? length).ChainedValues;
                 break;
             case MovingAvgType.EhlersSuperSmootherFilter:
-                movingAvgList = stockData.CalculateEhlersSuperSmootherFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersSuperSmootherFilter(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersTriangleMovingAverage:
-                movingAvgList = stockData.CalculateEhlersTriangleMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersTriangleMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersVariableIndexDynamicAverage:
                 movingAvgList = stockData.CalculateEhlersVariableIndexDynamicAverage(fastLength: fastLength ?? default, slowLength: slowLength ?? length)
-                    .CustomValuesList;
+                    .ChainedValues;
                 break;
             case MovingAvgType.EhlersZeroLagExponentialMovingAverage:
-                movingAvgList = stockData.CalculateEhlersZeroLagExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersZeroLagExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ElasticVolumeWeightedMovingAverageV1:
-                movingAvgList = stockData.CalculateElasticVolumeWeightedMovingAverageV1(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateElasticVolumeWeightedMovingAverageV1(length: length).ChainedValues;
                 break;
             case MovingAvgType.ElasticVolumeWeightedMovingAverageV2:
-                movingAvgList = stockData.CalculateElasticVolumeWeightedMovingAverageV2(length).CustomValuesList;
+                movingAvgList = stockData.CalculateElasticVolumeWeightedMovingAverageV2(length).ChainedValues;
                 break;
             case MovingAvgType.EndPointWeightedMovingAverage:
-                movingAvgList = stockData.CalculateEndPointMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEndPointMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.EquityMovingAverage:
-                movingAvgList = stockData.CalculateEquityMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateEquityMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ExponentialMovingAverage:
-                movingAvgList = stockData.CalculateExponentialMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateExponentialMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.FallingRisingFilter:
-                movingAvgList = stockData.CalculateFallingRisingFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateFallingRisingFilter(length).ChainedValues;
                 break;
             case MovingAvgType.FareySequenceWeightedMovingAverage:
-                movingAvgList = stockData.CalculateFareySequenceWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateFareySequenceWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.FibonacciWeightedMovingAverage:
-                movingAvgList = stockData.CalculateFibonacciWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateFibonacciWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.FisherLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateFisherLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateFisherLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.FollowingAdaptiveMovingAverage:
                 movingAvgList = stockData.CalculateEhlersMotherOfAdaptiveMovingAverages().OutputValues["Fama"];
                 break;
             case MovingAvgType.GeneralFilterEstimator:
-                movingAvgList = stockData.CalculateGeneralFilterEstimator(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateGeneralFilterEstimator(length: length).ChainedValues;
                 break;
             case MovingAvgType.GeneralizedDoubleExponentialMovingAverage:
-                movingAvgList = stockData.CalculateGeneralizedDoubleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateGeneralizedDoubleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.HampelFilter:
-                movingAvgList = stockData.CalculateHampelFilter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateHampelFilter(length: length).ChainedValues;
                 break;
             case MovingAvgType.HendersonWeightedMovingAverage:
-                movingAvgList = stockData.CalculateHendersonWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateHendersonWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.HoltExponentialMovingAverage:
-                movingAvgList = stockData.CalculateHoltExponentialMovingAverage(length, length).CustomValuesList;
+                movingAvgList = stockData.CalculateHoltExponentialMovingAverage(length, length).ChainedValues;
                 break;
             case MovingAvgType.HullEstimate:
-                movingAvgList = stockData.CalculateHullEstimate(length).CustomValuesList;
+                movingAvgList = stockData.CalculateHullEstimate(length).ChainedValues;
                 break;
             case MovingAvgType.HullMovingAverage:
-                movingAvgList = stockData.CalculateHullMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateHullMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.HybridConvolutionFilter:
-                movingAvgList = stockData.CalculateHybridConvolutionFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateHybridConvolutionFilter(length).ChainedValues;
                 break;
             case MovingAvgType.IIRLeastSquaresEstimate:
-                movingAvgList = stockData.CalculateIIRLeastSquaresEstimate(length).CustomValuesList;
+                movingAvgList = stockData.CalculateIIRLeastSquaresEstimate(length).ChainedValues;
                 break;
             case MovingAvgType.InverseDistanceWeightedMovingAverage:
-                movingAvgList = stockData.CalculateInverseDistanceWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateInverseDistanceWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.JsaMovingAverage:
-                movingAvgList = stockData.CalculateJsaMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateJsaMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.JurikMovingAverage:
-                movingAvgList = stockData.CalculateJurikMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateJurikMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.KalmanSmoother:
-                movingAvgList = stockData.CalculateKalmanSmoother(length).CustomValuesList;
+                movingAvgList = stockData.CalculateKalmanSmoother(length).ChainedValues;
                 break;
             case MovingAvgType.KaufmanAdaptiveLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateKaufmanAdaptiveLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateKaufmanAdaptiveLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.KaufmanAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateKaufmanAdaptiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateKaufmanAdaptiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.LeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateLeastSquaresMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateLeastSquaresMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.LeoMovingAverage:
-                movingAvgList = stockData.CalculateLeoMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateLeoMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.LightLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateLightLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateLightLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.LinearExtrapolation:
-                movingAvgList = stockData.CalculateLinearExtrapolation(length).CustomValuesList;
+                movingAvgList = stockData.CalculateLinearExtrapolation(length).ChainedValues;
                 break;
             case MovingAvgType.LinearRegression:
-                movingAvgList = stockData.CalculateLinearRegression(length).CustomValuesList;
+                movingAvgList = stockData.CalculateLinearRegression(length).ChainedValues;
                 break;
             case MovingAvgType.LinearRegressionLine:
-                movingAvgList = stockData.CalculateLinearRegressionLine(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateLinearRegressionLine(length: length).ChainedValues;
                 break;
             case MovingAvgType.LinearWeightedMovingAverage:
-                movingAvgList = stockData.CalculateLinearWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateLinearWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.McGinleyDynamicIndicator:
-                movingAvgList = stockData.CalculateMcGinleyDynamicIndicator(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateMcGinleyDynamicIndicator(length: length).ChainedValues;
                 break;
             case MovingAvgType.McNichollMovingAverage:
-                movingAvgList = stockData.CalculateMcNichollMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateMcNichollMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.MiddleHighLowMovingAverage:
-                movingAvgList = stockData.CalculateMiddleHighLowMovingAverage(length1: slowLength ?? length, length2: fastLength ?? default).CustomValuesList;
+                movingAvgList = stockData.CalculateMiddleHighLowMovingAverage(length1: slowLength ?? length, length2: fastLength ?? default).ChainedValues;
                 break;
             case MovingAvgType.ModularFilter:
-                movingAvgList = stockData.CalculateModularFilter(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateModularFilter(length: length).ChainedValues;
                 break;
             case MovingAvgType.MovingAverageAdaptiveQ:
-                movingAvgList = stockData.CalculateMovingAverageAdaptiveQ(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateMovingAverageAdaptiveQ(length: length).ChainedValues;
                 break;
             case MovingAvgType.MovingAverageV3:
-                movingAvgList = stockData.CalculateMovingAverageV3(length1: length).CustomValuesList;
+                movingAvgList = stockData.CalculateMovingAverageV3(length1: length).ChainedValues;
                 break;
             case MovingAvgType.MultiDepthZeroLagExponentialMovingAverage:
-                movingAvgList = stockData.CalculateMultiDepthZeroLagExponentialMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateMultiDepthZeroLagExponentialMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.NaturalMovingAverage:
-                movingAvgList = stockData.CalculateNaturalMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateNaturalMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.OptimalWeightedMovingAverage:
-                movingAvgList = stockData.CalculateOptimalWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateOptimalWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.OvershootReductionMovingAverage:
-                movingAvgList = stockData.CalculateOvershootReductionMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateOvershootReductionMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ParabolicWeightedMovingAverage:
-                movingAvgList = stockData.CalculateParabolicWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateParabolicWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.ParametricCorrectiveLinearMovingAverage:
-                movingAvgList = stockData.CalculateParametricCorrectiveLinearMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateParametricCorrectiveLinearMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ParametricKalmanFilter:
-                movingAvgList = stockData.CalculateParametricKalmanFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateParametricKalmanFilter(length).ChainedValues;
                 break;
             case MovingAvgType.PentupleExponentialMovingAverage:
-                movingAvgList = stockData.CalculatePentupleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculatePentupleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.PolynomialLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculatePolynomialLeastSquaresMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculatePolynomialLeastSquaresMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.PoweredKaufmanAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculatePoweredKaufmanAdaptiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculatePoweredKaufmanAdaptiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.QuadraticLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateQuadraticLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateQuadraticLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.QuadraticMovingAverage:
-                movingAvgList = stockData.CalculateQuadraticMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateQuadraticMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.QuadraticRegression:
-                movingAvgList = stockData.CalculateQuadraticRegression(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateQuadraticRegression(length: length).ChainedValues;
                 break;
             case MovingAvgType.QuadrupleExponentialMovingAverage:
-                movingAvgList = stockData.CalculateQuadrupleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateQuadrupleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.QuickMovingAverage:
-                movingAvgList = stockData.CalculateQuickMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateQuickMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.R2AdaptiveRegression:
-                movingAvgList = stockData.CalculateR2AdaptiveRegression(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateR2AdaptiveRegression(length: length).ChainedValues;
                 break;
             case MovingAvgType.RatioOCHLAverager:
-                movingAvgList = stockData.CalculateRatioOCHLAverager().CustomValuesList;
+                movingAvgList = stockData.CalculateRatioOCHLAverager().ChainedValues;
                 break;
             case MovingAvgType.RecursiveMovingTrendAverage:
-                movingAvgList = stockData.CalculateRecursiveMovingTrendAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateRecursiveMovingTrendAverage(length).ChainedValues;
                 break;
             case MovingAvgType.RegularizedExponentialMovingAverage:
-                movingAvgList = stockData.CalculateRegularizedExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateRegularizedExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.RepulsionMovingAverage:
-                movingAvgList = stockData.CalculateRepulsionMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateRepulsionMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.RetentionAccelerationFilter:
-                movingAvgList = stockData.CalculateRetentionAccelerationFilter(length).CustomValuesList;
+                movingAvgList = stockData.CalculateRetentionAccelerationFilter(length).ChainedValues;
                 break;
             case MovingAvgType.ReverseEngineeringRelativeStrengthIndex:
-                movingAvgList = stockData.CalculateReverseEngineeringRelativeStrengthIndex(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateReverseEngineeringRelativeStrengthIndex(length: length).ChainedValues;
                 break;
             case MovingAvgType.ReverseMovingAverageConvergenceDivergence:
                 movingAvgList = stockData.CalculateReverseMovingAverageConvergenceDivergence(fastLength: fastLength ?? default, slowLength: slowLength ?? length)
-                    .CustomValuesList;
+                    .ChainedValues;
                 break;
             case MovingAvgType.RightSidedRickerMovingAverage:
-                movingAvgList = stockData.CalculateRightSidedRickerMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateRightSidedRickerMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.SelfWeightedMovingAverage:
-                movingAvgList = stockData.CalculateSelfWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSelfWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SequentiallyFilteredMovingAverage:
-                movingAvgList = stockData.CalculateSequentiallyFilteredMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateSequentiallyFilteredMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.SettingLessTrendStepFiltering:
-                movingAvgList = stockData.CalculateSettingLessTrendStepFiltering().CustomValuesList;
+                movingAvgList = stockData.CalculateSettingLessTrendStepFiltering().ChainedValues;
                 break;
             case MovingAvgType.ShapeshiftingMovingAverage:
-                movingAvgList = stockData.CalculateShapeshiftingMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateShapeshiftingMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SharpModifiedMovingAverage:
-                movingAvgList = stockData.CalculateSharpModifiedMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateSharpModifiedMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.SimpleMovingAverage:
-                movingAvgList = stockData.CalculateSimpleMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSimpleMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SimplifiedLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateSimplifiedLeastSquaresMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSimplifiedLeastSquaresMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SimplifiedWeightedMovingAverage:
-                movingAvgList = stockData.CalculateSimplifiedWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSimplifiedWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SineWeightedMovingAverage:
-                movingAvgList = stockData.CalculateSineWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSineWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.SlowSmoothedMovingAverage:
-                movingAvgList = stockData.CalculateSlowSmoothedMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateSlowSmoothedMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.Spencer15PointMovingAverage:
-                movingAvgList = stockData.CalculateSpencer15PointMovingAverage().CustomValuesList;
+                movingAvgList = stockData.CalculateSpencer15PointMovingAverage().ChainedValues;
                 break;
             case MovingAvgType.Spencer21PointMovingAverage:
-                movingAvgList = stockData.CalculateSpencer21PointMovingAverage().CustomValuesList;
+                movingAvgList = stockData.CalculateSpencer21PointMovingAverage().ChainedValues;
                 break;
             case MovingAvgType.SquareRootWeightedMovingAverage:
-                movingAvgList = stockData.CalculateSquareRootWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSquareRootWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.Svama:
-                movingAvgList = stockData.CalculateSvama(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSvama(length).ChainedValues;
                 break;
             case MovingAvgType.SymmetricallyWeightedMovingAverage:
-                movingAvgList = stockData.CalculateSymmetricallyWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateSymmetricallyWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.TStepLeastSquaresMovingAverage:
-                movingAvgList = stockData.CalculateTStepLeastSquaresMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateTStepLeastSquaresMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.TillsonIE2:
-                movingAvgList = stockData.CalculateTillsonIE2(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateTillsonIE2(length: length).ChainedValues;
                 break;
             case MovingAvgType.TillsonT3MovingAverage:
-                movingAvgList = stockData.CalculateTillsonT3MovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateTillsonT3MovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.TriangularMovingAverage:
-                movingAvgList = stockData.CalculateTriangularMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateTriangularMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.Trimean:
-                movingAvgList = stockData.CalculateTrimean(length).CustomValuesList;
+                movingAvgList = stockData.CalculateTrimean(length).ChainedValues;
                 break;
             case MovingAvgType.TripleExponentialMovingAverage:
-                movingAvgList = stockData.CalculateTripleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateTripleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.UltimateMovingAverage:
-                movingAvgList = stockData.CalculateUltimateMovingAverage(minLength: fastLength ?? default, maxLength: slowLength ?? length).CustomValuesList;
+                movingAvgList = stockData.CalculateUltimateMovingAverage(minLength: fastLength ?? default, maxLength: slowLength ?? length).ChainedValues;
                 break;
             case MovingAvgType.VariableAdaptiveMovingAverage:
-                movingAvgList = stockData.CalculateVariableAdaptiveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVariableAdaptiveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.VariableIndexDynamicAverage:
-                movingAvgList = stockData.CalculateVariableIndexDynamicAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVariableIndexDynamicAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.VariableLengthMovingAverage:
-                movingAvgList = stockData.CalculateVariableLengthMovingAverage(minLength: fastLength ?? default, maxLength: slowLength ?? length).CustomValuesList;
+                movingAvgList = stockData.CalculateVariableLengthMovingAverage(minLength: fastLength ?? default, maxLength: slowLength ?? length).ChainedValues;
                 break;
             case MovingAvgType.VariableMovingAverage:
-                movingAvgList = stockData.CalculateVariableMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateVariableMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.VerticalHorizontalMovingAverage:
-                movingAvgList = stockData.CalculateVerticalHorizontalMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateVerticalHorizontalMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.VolatilityMovingAverage:
-                movingAvgList = stockData.CalculateVolatilityMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVolatilityMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.VolatilityWaveMovingAverage:
-                movingAvgList = stockData.CalculateVolatilityWaveMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVolatilityWaveMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.VolumeAdjustedMovingAverage:
-                movingAvgList = stockData.CalculateVolumeAdjustedMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVolumeAdjustedMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.VolumeWeightedAveragePrice:
-                movingAvgList = stockData.CalculateVolumeWeightedAveragePrice().CustomValuesList;
+                movingAvgList = stockData.CalculateVolumeWeightedAveragePrice().ChainedValues;
                 break;
             case MovingAvgType.VolumeWeightedMovingAverage:
-                movingAvgList = stockData.CalculateVolumeWeightedMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateVolumeWeightedMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.WeightedMovingAverage:
-                movingAvgList = stockData.CalculateWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.WellRoundedMovingAverage:
-                movingAvgList = stockData.CalculateWellRoundedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateWellRoundedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.WildersSmoothingMethod:
-                movingAvgList = stockData.CalculateWellesWilderMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateWellesWilderMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.WildersSummationMethod:
-                movingAvgList = stockData.CalculateWellesWilderSummation(length).CustomValuesList;
+                movingAvgList = stockData.CalculateWellesWilderSummation(length).ChainedValues;
                 break;
             case MovingAvgType.WindowedVolumeWeightedMovingAverage:
-                movingAvgList = stockData.CalculateWindowedVolumeWeightedMovingAverage(length).CustomValuesList;
+                movingAvgList = stockData.CalculateWindowedVolumeWeightedMovingAverage(length).ChainedValues;
                 break;
             case MovingAvgType.ZeroLagExponentialMovingAverage:
-                movingAvgList = stockData.CalculateZeroLagExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateZeroLagExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ZeroLagTripleExponentialMovingAverage:
-                movingAvgList = stockData.CalculateZeroLagTripleExponentialMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateZeroLagTripleExponentialMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.ZeroLowLagMovingAverage:
-                movingAvgList = stockData.CalculateZeroLowLagMovingAverage(length: length).CustomValuesList;
+                movingAvgList = stockData.CalculateZeroLowLagMovingAverage(length: length).ChainedValues;
                 break;
             case MovingAvgType.EhlersNoiseEliminationTechnology:
-                movingAvgList = stockData.CalculateEhlersNoiseEliminationTechnology(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersNoiseEliminationTechnology(length).ChainedValues;
                 break;
             case MovingAvgType.EhlersSimpleDecycler:
-                movingAvgList = stockData.CalculateEhlersSimpleDecycler(length).CustomValuesList;
+                movingAvgList = stockData.CalculateEhlersSimpleDecycler(length).ChainedValues;
                 break;
             default:
                 Console.WriteLine($"Moving Avg Name: {movingAvgType} not supported!");
@@ -1677,7 +1679,7 @@ public static class CalculationsHelper
         // (a three-arm control against master: TechnicalRatings, UltimateMomentumIndicator and
         // WoodieCommodityChannelIndex differed; InsyncIndex happened not to). Found by auditing every
         // call site of these methods, not just their bodies.
-        var inputList = stockData.CustomValuesList is { Count: > 0 } chained
+        var inputList = stockData.ChainedValues is { Count: > 0 } chained
             ? chained
             : inputName switch
         {
@@ -1691,8 +1693,8 @@ public static class CalculationsHelper
             InputName.WeightedClose => GetDerivedSeriesList(stockData, DerivedSeriesKind.WeightedClose),
             InputName.Open => stockData.OpenPrices,
             InputName.AdjustedClose => stockData.ClosePrices,
-            InputName.Midpoint => stockData.CalculateMidpoint().CustomValuesList,
-            InputName.Midprice => stockData.CalculateMidprice().CustomValuesList,
+            InputName.Midpoint => stockData.CalculateMidpoint().ChainedValues,
+            InputName.Midprice => stockData.CalculateMidprice().ChainedValues,
             InputName.AveragePrice => GetDerivedSeriesList(stockData, DerivedSeriesKind.AveragePrice),
             _ => stockData.ClosePrices,
         };
@@ -1711,7 +1713,7 @@ public static class CalculationsHelper
         openList = stockData.OpenPrices;
         // A chained series stands in for the close, as it does in the bar CustomInputState hands a streaming
         // state; the named input only decides what is read when nothing was chained.
-        closeList = stockData.CustomValuesList is { Count: > 0 } ? inputList : stockData.ClosePrices;
+        closeList = stockData.ChainedValues is { Count: > 0 } ? inputList : stockData.ClosePrices;
         volumeList = stockData.Volumes;
 
         return (inputList, highList, lowList, openList, closeList, volumeList);
@@ -1733,12 +1735,11 @@ public static class CalculationsHelper
         List<double> openList;
         List<double> volumeList;
 
-        if (stockData.CustomValuesList != null && stockData.CustomValuesList.Count > 0)
+        if (stockData.ChainedValues.Count > 0)
         {
-            inputList = stockData.CustomValuesList;
+            inputList = stockData.ChainedValues;
         }
-        else if ((stockData.CustomValuesList == null || (stockData.CustomValuesList != null && stockData.CustomValuesList.Count == 0)) &&
-            stockData.SignalsList != null && stockData.SignalsList.Count > 0)
+        else if (stockData.SignalsList != null && stockData.SignalsList.Count > 0)
         {
             throw new CalculationException($"Calculations based off of {stockData.IndicatorName} can't be completed because this indicator doesn't have a single output.");
         }
@@ -1874,7 +1875,7 @@ public static class CalculationsHelper
         // they are built from the real ones - open first, high the max, low the min, close last. This
         // used to rebuild from TickerDataList whatever was chained in front, so every pivot point
         // silently ignored a custom series.
-        var chained = stockData.CustomValuesList is { Count: > 0 } custom && custom.Count == tickerDataList.Count
+        var chained = stockData.ChainedValues is { Count: > 0 } custom && custom.Count == tickerDataList.Count
             ? custom
             : null;
         List<double>? customHighs = null;
@@ -2265,10 +2266,14 @@ public static class CalculationsHelper
     /// This needs to be called after you calculate an indicator if you are re-using the same input data to calculate a second indicator on a separate line
     /// </summary>
     /// <param name="stockData"></param>
+    /// <remarks>
+    /// The series is replaced, not emptied in place: a caller holding an earlier result's list keeps it, and
+    /// the chained series goes too, so the next indicator reads the bars.
+    /// </remarks>
     public static void Clear(this StockData stockData)
     {
         stockData.SignalsList?.Clear();
-        stockData.CustomValuesList?.Clear();
+        stockData.CustomValuesList = new List<double>();
     }
 
     /// <summary>

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -1660,9 +1660,15 @@ public static class CalculationsHelper
         // AcceleratorOscillator on AwesomeOscillator). Callers pass values; the name only decides what
         // is read when nothing was passed.
         //
-        // Safe for every call site: each of the 24 reads its input on entry, before anything in that
-        // calculation writes to CustomValuesList, so what is found there is always the caller's chain
-        // and never an intermediate of the calculation itself (the #145 pattern).
+        // What is on CustomValuesList must therefore be the caller's chain. Each of the 24 methods reads
+        // it on entry, before its own calculation writes anything there. But a COMPOSITE that calls one
+        // of them after another component has published its output would hand it that output as if it
+        // were a chain (the #145 pattern). Four composites make such a call - InsyncIndex,
+        // TechnicalRatings, UltimateMomentumIndicator and WoodieCommodityChannelIndex - and each now
+        // restores the caller's series first. Without that, three of them changed their UNCHAINED output
+        // (a three-arm control against master: TechnicalRatings, UltimateMomentumIndicator and
+        // WoodieCommodityChannelIndex differed; InsyncIndex happened not to). Found by auditing every
+        // call site of these methods, not just their bodies.
         var inputList = stockData.CustomValuesList is { Count: > 0 } chained
             ? chained
             : inputName switch
@@ -2024,12 +2030,6 @@ public static class CalculationsHelper
     }
 
     /// <summary>
-    /// Gets the maximum and minimum values list.
-    /// </summary>
-    /// <param name="inputs">The inputs.</param>
-    /// <param name="length">The length.</param>
-    /// <returns></returns>
-    /// <summary>
     /// The high and low an indicator should read when its input is a series other than the close.
     /// </summary>
     /// <remarks>
@@ -2077,6 +2077,12 @@ public static class CalculationsHelper
         return (highList, lowList);
     }
 
+    /// <summary>
+    /// Gets the maximum and minimum values list.
+    /// </summary>
+    /// <param name="inputs">The inputs.</param>
+    /// <param name="length">The length.</param>
+    /// <returns></returns>
     public static (List<double>, List<double>) GetMaxAndMinValuesList(List<double> inputs, int length)
     {
         var count = inputs.Count;

--- a/src/Helpers/CalculationsHelper.cs
+++ b/src/Helpers/CalculationsHelper.cs
@@ -161,8 +161,8 @@ public static class CalculationsHelper
     /// <remarks>
     /// Not SetCustomValues. That publishes an indicator's OUTPUT, and honours IncludeCustomValues (which can
     /// drop it) and RoundingDigits (which rounds it). A caller's input series is neither: with
-    /// IncludeCustomValues off SetCustomValues clears it in place, and with RoundingDigits set the next
-    /// calculation would compute on rounded input.
+    /// IncludeCustomValues off, SetCustomValues cleared it and UseInput silently did nothing, and with
+    /// RoundingDigits set the next indicator computed on rounded input.
     /// </remarks>
     internal static void SetInputSeries(this StockData stockData, List<double> series) =>
         stockData.CustomValuesList = series;

--- a/src/Helpers/MathHelper.cs
+++ b/src/Helpers/MathHelper.cs
@@ -38,6 +38,26 @@ public static class MathHelper
     }
 
     /// <summary>
+    /// Rounds a measured cycle length up to the whole number of bars it spans.
+    /// </summary>
+    /// <remarks>
+    /// A dominant cycle is a weighted mean of periods, so it is often an integer in exact arithmetic - 29 when
+    /// the periodogram's powers are all equal - and arrives a few ulps either side of it. A bare
+    /// <see cref="Math.Ceiling(double)"/> turns that noise into a window one bar longer, and whether it does
+    /// depends on the order a sum was taken in, so batch and streaming disagreed on the same bars. A value
+    /// within a relative 1e-9 of an integer is taken as that integer, the same closeness the parity tests use.
+    /// </remarks>
+    /// <param name="cycle">The measured cycle length, in bars.</param>
+    /// <returns>The cycle length rounded up to whole bars.</returns>
+    public static int CeilingCycle(double cycle)
+    {
+        var nearest = Math.Round(cycle);
+        return Math.Abs(cycle - nearest) <= 1e-9 * Math.Max(1, Math.Abs(cycle))
+            ? (int)nearest
+            : (int)Math.Ceiling(cycle);
+    }
+
+    /// <summary>
     /// Convert to Degrees From Radians
     /// </summary>
     /// <param name="val">The value to convert to degrees</param>

--- a/src/Helpers/RollingWindow.cs
+++ b/src/Helpers/RollingWindow.cs
@@ -564,8 +564,8 @@ internal sealed class RollingOrderStatistic : IDisposable
     private readonly int _length;
     private readonly bool _useLinear;
     private readonly PooledRingBuffer<double> _window;
-    private readonly OrderStatisticTree? _tree;
-    private readonly double[]? _scratch;
+    private readonly OrderStatisticTree _tree = new();
+    private readonly double[] _scratch;
     private bool _disposed;
 
     public RollingOrderStatistic(int length)
@@ -573,15 +573,7 @@ internal sealed class RollingOrderStatistic : IDisposable
         _length = Math.Max(1, length);
         _useLinear = _length <= RollingWindowSettings.SmallWindowThreshold;
         _window = new PooledRingBuffer<double>(_length);
-
-        if (_useLinear)
-        {
-            _scratch = ArrayPool<double>.Shared.Rent(_length);
-        }
-        else
-        {
-            _tree = new OrderStatisticTree();
-        }
+        _scratch = _useLinear ? ArrayPool<double>.Shared.Rent(_length) : Array.Empty<double>();
     }
 
     public int Count => _window.Count;
@@ -596,10 +588,10 @@ internal sealed class RollingOrderStatistic : IDisposable
 
         if (_window.TryAdd(value, out var removed))
         {
-            _tree!.Remove(removed);
+            _tree.Remove(removed);
         }
 
-        _tree!.Insert(value);
+        _tree.Insert(value);
     }
 
     public int CountLessThan(double value)
@@ -618,7 +610,7 @@ internal sealed class RollingOrderStatistic : IDisposable
             return count;
         }
 
-        return _tree!.CountLessThan(value);
+        return _tree.CountLessThan(value);
     }
 
     public int CountLessThanOrEqual(double value)
@@ -637,7 +629,7 @@ internal sealed class RollingOrderStatistic : IDisposable
             return count;
         }
 
-        return _tree!.CountLessThanOrEqual(value);
+        return _tree.CountLessThanOrEqual(value);
     }
 
     public double PercentileNearestRank(double percentile)
@@ -650,19 +642,63 @@ internal sealed class RollingOrderStatistic : IDisposable
 
         if (_useLinear)
         {
-            var scratch = _scratch!;
-            _window.CopyTo(scratch);
-            Array.Sort(scratch, 0, count);
-            var rank = (int)Math.Ceiling(percentile / 100 * count);
-            rank = Math.Max(rank, 1);
-            rank = Math.Min(rank, count);
-            return scratch[rank - 1];
+            _window.CopyTo(_scratch);
+            Array.Sort(_scratch, 0, count);
+            return _scratch[NearestRank(percentile, count) - 1];
         }
 
-        var treeCount = _tree!.Count;
-        var treeRank = treeCount > 0 ? (int)Math.Ceiling(percentile / 100 * treeCount) : 0;
-        return _tree.SelectByRank(Math.Max(treeRank, 1));
+        return _tree.SelectByRank(NearestRank(percentile, _tree.Count));
     }
+
+    /// <summary>
+    /// The percentile the window would have with <paramref name="pending"/> added, leaving the window as it is.
+    /// </summary>
+    /// <remarks>
+    /// A streaming preview answers for a bar it does not commit. Without this it could only read the window
+    /// before the bar, so a preview of the first bar was 0 and every later one was a bar late.
+    /// </remarks>
+    public double PercentileNearestRank(double percentile, double pending)
+    {
+        var evicts = _window.Count == _length;
+        var start = evicts ? 1 : 0;
+        var count = _window.Count - start + 1;
+
+        if (_useLinear)
+        {
+            for (var i = 0; i < count - 1; i++)
+            {
+                _scratch[i] = _window[start + i];
+            }
+
+            _scratch[count - 1] = pending;
+            Array.Sort(_scratch, 0, count);
+            return _scratch[NearestRank(percentile, count) - 1];
+        }
+
+        var evicted = evicts ? _window[0] : 0;
+        _tree.Insert(pending);
+        if (evicts)
+        {
+            _tree.Remove(evicted);
+        }
+
+        try
+        {
+            return _tree.SelectByRank(NearestRank(percentile, _tree.Count));
+        }
+        finally
+        {
+            if (evicts)
+            {
+                _tree.Insert(evicted);
+            }
+
+            _tree.Remove(pending);
+        }
+    }
+
+    private static int NearestRank(double percentile, int count) =>
+        Math.Min(Math.Max((int)Math.Ceiling(percentile / 100 * count), 1), count);
 
     public void Dispose()
     {
@@ -672,7 +708,7 @@ internal sealed class RollingOrderStatistic : IDisposable
         }
 
         _window.Dispose();
-        if (_scratch != null)
+        if (_useLinear)
         {
             ArrayPool<double>.Shared.Return(_scratch, clearArray: true);
         }

--- a/src/Helpers/RollingWindow.cs
+++ b/src/Helpers/RollingWindow.cs
@@ -601,7 +601,7 @@ internal sealed class RollingOrderStatistic : IDisposable
             var count = 0;
             for (var i = 0; i < _window.Count; i++)
             {
-                if (_window[i] < value)
+                if (_window[i].CompareTo(value) < 0)
                 {
                     count++;
                 }
@@ -620,7 +620,7 @@ internal sealed class RollingOrderStatistic : IDisposable
             var count = 0;
             for (var i = 0; i < _window.Count; i++)
             {
-                if (_window[i] <= value)
+                if (_window[i].CompareTo(value) <= 0)
                 {
                     count++;
                 }
@@ -762,11 +762,15 @@ internal sealed class OrderStatisticTree
             return new Node(key, Random.Next());
         }
 
-        if (key == node.Key)
+        // One total order for every operation, double.CompareTo's, in which NaN equals itself and sorts
+        // first. With == and < a NaN went right on insert and was never found on removal, so a preview
+        // that inserted and removed it left a node behind.
+        var order = key.CompareTo(node.Key);
+        if (order == 0)
         {
             node.Count++;
         }
-        else if (key < node.Key)
+        else if (order < 0)
         {
             node.Left = Insert(node.Left, key);
             if (node.Left.Priority > node.Priority)
@@ -794,7 +798,8 @@ internal sealed class OrderStatisticTree
             return null;
         }
 
-        if (key == node.Key)
+        var order = key.CompareTo(node.Key);
+        if (order == 0)
         {
             if (node.Count > 1)
             {
@@ -822,7 +827,7 @@ internal sealed class OrderStatisticTree
                 }
             }
         }
-        else if (key < node.Key)
+        else if (order < 0)
         {
             node.Left = Remove(node.Left, key);
         }
@@ -842,7 +847,7 @@ internal sealed class OrderStatisticTree
             return 0;
         }
 
-        if (key <= node.Key)
+        if (key.CompareTo(node.Key) <= 0)
         {
             return CountLessThan(node.Left, key);
         }
@@ -857,7 +862,7 @@ internal sealed class OrderStatisticTree
             return 0;
         }
 
-        if (key < node.Key)
+        if (key.CompareTo(node.Key) < 0)
         {
             return CountLessThanOrEqual(node.Left, key);
         }

--- a/src/Interfaces/IStockData.cs
+++ b/src/Interfaces/IStockData.cs
@@ -12,7 +12,6 @@ namespace OoplesFinance.StockIndicators.Interfaces;
 
 public interface IStockData
 {
-    InputName InputName { get; }
     IndicatorName IndicatorName { get; }
     List<double> InputValues { get; }
     List<double> OpenPrices { get; }

--- a/src/Models/StockData.cs
+++ b/src/Models/StockData.cs
@@ -24,7 +24,6 @@ public class StockData : IStockData
     private bool _columnsInitialized;
     private bool _rowsInitialized;
 
-    public InputName InputName { get; set; }
     public IndicatorName IndicatorName { get; set; }
 
     public List<double> InputValues
@@ -155,7 +154,7 @@ public class StockData : IStockData
     /// <param name="volumes"></param>
     /// <param name="dates"></param>
     public StockData(IEnumerable<double> openPrices, IEnumerable<double> highPrices, IEnumerable<double> lowPrices, IEnumerable<double> closePrices,
-        IEnumerable<double> volumes, IEnumerable<DateTime> dates, InputName inputName = InputName.Close)
+        IEnumerable<double> volumes, IEnumerable<DateTime> dates)
     {
         _openPrices = new List<double>(openPrices);
         _highPrices = new List<double>(highPrices);
@@ -169,7 +168,6 @@ public class StockData : IStockData
         CustomValuesList = new List<double>();
         OutputValues = new Dictionary<string, List<double>>();
         SignalsList = new List<Signal>();
-        InputName = inputName;
         IndicatorName = IndicatorName.None;
         Options = new IndicatorOptions();
         Count = CalculateCount(_openPrices, _highPrices, _lowPrices, _closePrices, _volumes, _dates);
@@ -179,7 +177,7 @@ public class StockData : IStockData
     /// Initializes the StockData Class using classic list of ticker information
     /// </summary>
     /// <param name="tickerDataList"></param>
-    public StockData(IEnumerable<TickerData> tickerDataList, InputName inputName = InputName.Close)
+    public StockData(IEnumerable<TickerData> tickerDataList)
     {
         _tickerDataList = new List<TickerData>();
         foreach (var ticker in tickerDataList)
@@ -198,7 +196,6 @@ public class StockData : IStockData
         CustomValuesList = new List<double>();
         OutputValues = new Dictionary<string, List<double>>();
         SignalsList = new List<Signal>();
-        InputName = inputName;
         Options = new IndicatorOptions();
         Count = _tickerDataList.Count;
     }

--- a/src/Models/StockData.cs
+++ b/src/Models/StockData.cs
@@ -15,6 +15,7 @@ public class StockData : IStockData
 {
     private List<double>? _inputValues;
     private List<double> _customValues = new List<double>();
+    private Dictionary<string, List<double>> _outputValues = new Dictionary<string, List<double>>();
     private List<double>? _openPrices;
     private List<double>? _highPrices;
     private List<double>? _lowPrices;
@@ -160,9 +161,6 @@ public class StockData : IStockData
     /// </remarks>
     internal List<double> ChainedValues { get; private set; } = new List<double>();
 
-    /// <summary>Stops publishing the current series without taking it from the next calculation.</summary>
-    internal void HideCustomValues() => _customValues = new List<double>();
-
     /// <summary>Puts back a published list and a chained series saved by a caller that borrowed both.</summary>
     internal void RestoreSeries(List<double> published, List<double> chained)
     {
@@ -170,7 +168,32 @@ public class StockData : IStockData
         ChainedValues = chained;
     }
 
-    public Dictionary<string, List<double>> OutputValues { get; set; }
+    public Dictionary<string, List<double>> OutputValues
+    {
+        get => _outputValues;
+        set
+        {
+            _outputValues = value ?? new Dictionary<string, List<double>>();
+            ChainedOutputs = _outputValues;
+        }
+    }
+
+    /// <summary>
+    /// Every named series of the last calculation, unrounded, for the calculation that reads them next.
+    /// </summary>
+    /// <remarks>
+    /// The same dictionary as <see cref="OutputValues"/> unless IncludeOutputValues or RoundingDigits says to
+    /// publish less. A composite reads its components' named series from here: from the published copy, turning
+    /// output values off made 56 indicators throw and rounding fed rounded inputs to the rest.
+    /// </remarks>
+    internal Dictionary<string, List<double>> ChainedOutputs { get; private set; } = new Dictionary<string, List<double>>();
+
+    /// <summary>Sets the named series a calculation keeps for the next one, and the copy it publishes.</summary>
+    internal void SetOutputs(Dictionary<string, List<double>> chained, Dictionary<string, List<double>> published)
+    {
+        ChainedOutputs = chained;
+        _outputValues = published;
+    }
     public List<Signal> SignalsList { get; set; }
     public IndicatorOptions? Options { get; set; }
     public int Count { get; set; }

--- a/src/Models/StockData.cs
+++ b/src/Models/StockData.cs
@@ -14,6 +14,7 @@ namespace OoplesFinance.StockIndicators.Models;
 public class StockData : IStockData
 {
     private List<double>? _inputValues;
+    private List<double> _customValues = new List<double>();
     private List<double>? _openPrices;
     private List<double>? _highPrices;
     private List<double>? _lowPrices;
@@ -138,7 +139,37 @@ public class StockData : IStockData
         }
     }
 
-    public List<double> CustomValuesList { get; set; }
+    public List<double> CustomValuesList
+    {
+        get => _customValues;
+        set
+        {
+            _customValues = value ?? new List<double>();
+            ChainedValues = _customValues;
+        }
+    }
+
+    /// <summary>
+    /// The series the next calculation on this data reads: the last one published, or the caller's input.
+    /// </summary>
+    /// <remarks>
+    /// The same list as <see cref="CustomValuesList"/> unless IncludeCustomValues is off. That option hides a
+    /// result from the caller; it must not hide it from the composite that asked a component for it, or from
+    /// the next indicator in a chain. Hiding the one list both read made 176 indicators throw and three
+    /// compute on the close instead of their own components.
+    /// </remarks>
+    internal List<double> ChainedValues { get; private set; } = new List<double>();
+
+    /// <summary>Stops publishing the current series without taking it from the next calculation.</summary>
+    internal void HideCustomValues() => _customValues = new List<double>();
+
+    /// <summary>Puts back a published list and a chained series saved by a caller that borrowed both.</summary>
+    internal void RestoreSeries(List<double> published, List<double> chained)
+    {
+        _customValues = published;
+        ChainedValues = chained;
+    }
+
     public Dictionary<string, List<double>> OutputValues { get; set; }
     public List<Signal> SignalsList { get; set; }
     public IndicatorOptions? Options { get; set; }

--- a/src/SourceGeneration/StatefulIndicatorFactoryGenerator.cs
+++ b/src/SourceGeneration/StatefulIndicatorFactoryGenerator.cs
@@ -91,7 +91,11 @@ public class StatefulIndicatorFactoryGenerator : IIncrementalGenerator
         foreach (var syntaxRef in nameProperty.DeclaringSyntaxReferences)
         {
             var propSyntax = syntaxRef.GetSyntax() as PropertyDeclarationSyntax;
-            if (propSyntax?.ExpressionBody?.Expression is MemberAccessExpressionSyntax memberAccess)
+            // Only a literal IndicatorName.X names a fixed indicator. Any other member access - a
+            // wrapper forwarding _inner.Name, for instance - is not an indicator of its own, and
+            // reading its member name as one generated a factory entry for IndicatorName.Name.
+            if (propSyntax?.ExpressionBody?.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Expression is IdentifierNameSyntax { Identifier.Text: "IndicatorName" })
             {
                 indicatorName = memberAccess.Name.Identifier.Text;
                 break;

--- a/src/Streaming/CustomInputState.cs
+++ b/src/Streaming/CustomInputState.cs
@@ -46,7 +46,7 @@ internal interface ICustomInputConsumer
 public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
 {
     private readonly IStreamingIndicatorState _inner;
-    private readonly Func<OhlcvBar, double> _selector;
+    private readonly IInputSeries _series;
     private double _prevValue;
     private bool _hasPrev;
 
@@ -60,9 +60,25 @@ public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
     /// <param name="selector">The caller's series, one value per bar.</param>
     /// <exception cref="ArgumentNullException">Either argument is null.</exception>
     public CustomInputState(IStreamingIndicatorState inner, Func<OhlcvBar, double> selector)
+        : this(inner, InputSeries.Of(selector ?? throw new ArgumentNullException(nameof(selector))))
+    {
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="inner"/> so that it computes on <paramref name="series"/>: a preset such as
+    /// <see cref="InputSeries.MedianPrice"/>, a windowed series such as <see cref="InputSeries.Midpoint"/>,
+    /// or another indicator's output via <see cref="InputSeries.Of(IStreamingIndicatorState)"/>.
+    /// </summary>
+    /// <param name="inner">
+    /// A freshly built state. It is told to read the close if its own default is another series, so
+    /// do not also update it directly.
+    /// </param>
+    /// <param name="series">The input series. One with history must not be shared with another wrapper.</param>
+    /// <exception cref="ArgumentNullException">Either argument is null.</exception>
+    public CustomInputState(IStreamingIndicatorState inner, IInputSeries series)
     {
         _inner = inner ?? throw new ArgumentNullException(nameof(inner));
-        _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+        _series = series ?? throw new ArgumentNullException(nameof(series));
 
         if (inner is ICustomInputConsumer consumer)
         {
@@ -77,6 +93,7 @@ public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
     public void Reset()
     {
         _inner.Reset();
+        _series.Reset();
         _prevValue = 0;
         _hasPrev = false;
     }
@@ -89,7 +106,7 @@ public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
             throw new ArgumentNullException(nameof(bar));
         }
 
-        var value = _selector(bar);
+        var value = _series.Next(bar, isFinal);
 
         double high;
         double low;
@@ -123,6 +140,11 @@ public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
         if (_inner is IDisposable disposable)
         {
             disposable.Dispose();
+        }
+
+        if (_series is IDisposable series)
+        {
+            series.Dispose();
         }
     }
 }

--- a/src/Streaming/CustomInputState.cs
+++ b/src/Streaming/CustomInputState.cs
@@ -1,0 +1,128 @@
+using System;
+using OoplesFinance.StockIndicators.Enums;
+
+namespace OoplesFinance.StockIndicators.Streaming;
+
+/// <summary>
+/// Implemented by a state whose own default input is something other than the close - a median or
+/// typical price, a volume - so that it can be told to read the series a caller supplies instead.
+/// </summary>
+/// <remarks>
+/// <see cref="CustomInputState"/> hands its inner state bars whose close IS the caller's series. A
+/// state that reads the close picks that up with no help. A state that reads, say, a median price
+/// would compute the median of the adjusted bar instead and silently ignore the series it was given,
+/// which is the defect this whole mechanism exists to rule out.
+/// </remarks>
+internal interface ICustomInputConsumer
+{
+    /// <summary>Read each bar's close as the input series from now on.</summary>
+    void ReadCloseAsInput();
+}
+
+/// <summary>
+/// Computes any streaming indicator on a series the caller supplies rather than on the bar's close.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Callers pass values, not a name for them:
+/// <code>
+/// var rsi = new CustomInputState(new RelativeStrengthIndexState(14), bar =&gt; (bar.High + bar.Low) / 2);
+/// </code>
+/// Every state accepts this, so no state can take custom input in one engine and not the other.
+/// </para>
+/// <para>
+/// Each bar, the inner state sees the caller's value as the close, and a high and low decided by the
+/// same per-bar rule the batch engine applies to a chained series (see
+/// <c>CalculationsHelper.GetCustomRangeLists</c>). A value inside the bar's range keeps the bar's true
+/// high and low - a median price, a chained moving average. A value outside it is its own scale, and
+/// its high and low are the max and min of the previous and current value. Open and volume are the
+/// bar's own, as they are in batch.
+/// </para>
+/// <para>
+/// A preview update (<c>isFinal: false</c>) is measured against the last FINAL value and does not
+/// replace it, so revising the forming bar any number of times gives the same answer as seeing it once.
+/// </para>
+/// </remarks>
+public sealed class CustomInputState : IStreamingIndicatorState, IDisposable
+{
+    private readonly IStreamingIndicatorState _inner;
+    private readonly Func<OhlcvBar, double> _selector;
+    private double _prevValue;
+    private bool _hasPrev;
+
+    /// <summary>
+    /// Wraps <paramref name="inner"/> so that it computes on <paramref name="selector"/>'s values.
+    /// </summary>
+    /// <param name="inner">
+    /// A freshly built state. It is told to read the close if its own default is another series, so
+    /// do not also update it directly.
+    /// </param>
+    /// <param name="selector">The caller's series, one value per bar.</param>
+    /// <exception cref="ArgumentNullException">Either argument is null.</exception>
+    public CustomInputState(IStreamingIndicatorState inner, Func<OhlcvBar, double> selector)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+
+        if (inner is ICustomInputConsumer consumer)
+        {
+            consumer.ReadCloseAsInput();
+        }
+    }
+
+    /// <inheritdoc />
+    public IndicatorName Name => _inner.Name;
+
+    /// <inheritdoc />
+    public void Reset()
+    {
+        _inner.Reset();
+        _prevValue = 0;
+        _hasPrev = false;
+    }
+
+    /// <inheritdoc />
+    public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
+    {
+        if (bar is null)
+        {
+            throw new ArgumentNullException(nameof(bar));
+        }
+
+        var value = _selector(bar);
+
+        double high;
+        double low;
+        if (value >= bar.Low && value <= bar.High)
+        {
+            high = bar.High;
+            low = bar.Low;
+        }
+        else
+        {
+            var prev = _hasPrev ? _prevValue : value;
+            high = Math.Max(prev, value);
+            low = Math.Min(prev, value);
+        }
+
+        if (isFinal)
+        {
+            _prevValue = value;
+            _hasPrev = true;
+        }
+
+        var custom = new OhlcvBar(bar.Symbol, bar.Timeframe, bar.StartTime, bar.EndTime,
+            bar.Open, high, low, value, bar.Volume, bar.IsFinal);
+
+        return _inner.Update(custom, isFinal, includeOutputs);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_inner is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/Streaming/InputSeries.cs
+++ b/src/Streaming/InputSeries.cs
@@ -1,0 +1,138 @@
+using System;
+using OoplesFinance.StockIndicators.Enums;
+
+namespace OoplesFinance.StockIndicators.Streaming;
+
+/// <summary>
+/// A series of input values an indicator computes on, supplied one bar at a time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Callers pass values, not a name for them. Most series are a plain function of the bar - a median
+/// price, a typical price - and <see cref="InputSeries"/> has one for each of the names callers used
+/// to pass. Some need history: a midpoint over 14 bars, or another indicator's output. Those are why
+/// this is an interface rather than a <see cref="Func{T, TResult}"/>: <see cref="Next"/> is told
+/// whether the bar is forming or final, and a forming bar must not advance any window. A plain
+/// function cannot tell the two apart, so a windowed series built on one would count every revision
+/// of a forming bar as a new bar.
+/// </para>
+/// <para>
+/// A series with history belongs to one consumer. Build a fresh one for each indicator rather than
+/// sharing an instance, or each consumer advances the other's window.
+/// </para>
+/// </remarks>
+public interface IInputSeries
+{
+    /// <summary>The value for this bar.</summary>
+    /// <param name="bar">The bar.</param>
+    /// <param name="isFinal">False for a forming bar, which must not advance any window.</param>
+    double Next(OhlcvBar bar, bool isFinal);
+
+    /// <summary>Forgets all history.</summary>
+    void Reset();
+}
+
+/// <summary>
+/// Ready-made input series, named after the input names they replace, plus ways to build your own.
+/// </summary>
+/// <remarks>
+/// Migrating from an input name is a one-token change: <c>InputName.MedianPrice</c> becomes
+/// <c>InputSeries.MedianPrice</c>. Each preset gives exactly the value the input name selected.
+/// <code>
+/// var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.MedianPrice);
+/// var sma = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.Of(new RelativeStrengthIndexState(14)));
+/// </code>
+/// </remarks>
+public static class InputSeries
+{
+    /// <summary>The close.</summary>
+    public static IInputSeries Close { get; } = new BarSeries(bar => bar.Close);
+
+    /// <summary>
+    /// The close. Bars carry no separate adjusted price, so this is the close, as the input name it
+    /// replaces always was.
+    /// </summary>
+    public static IInputSeries AdjustedClose { get; } = new BarSeries(bar => bar.Close);
+
+    /// <summary>The open.</summary>
+    public static IInputSeries Open { get; } = new BarSeries(bar => bar.Open);
+
+    /// <summary>The high.</summary>
+    public static IInputSeries High { get; } = new BarSeries(bar => bar.High);
+
+    /// <summary>The low.</summary>
+    public static IInputSeries Low { get; } = new BarSeries(bar => bar.Low);
+
+    /// <summary>The volume.</summary>
+    public static IInputSeries Volume { get; } = new BarSeries(bar => bar.Volume);
+
+    /// <summary>(high + low) / 2.</summary>
+    public static IInputSeries MedianPrice { get; } = new BarSeries(bar => (bar.High + bar.Low) / 2);
+
+    /// <summary>(high + low + close) / 3.</summary>
+    public static IInputSeries TypicalPrice { get; } = new BarSeries(bar => (bar.High + bar.Low + bar.Close) / 3);
+
+    /// <summary>(open + high + low + close) / 4.</summary>
+    public static IInputSeries FullTypicalPrice { get; } =
+        new BarSeries(bar => (bar.Open + bar.High + bar.Low + bar.Close) / 4);
+
+    /// <summary>(high + low + 2 * close) / 4.</summary>
+    public static IInputSeries WeightedClose { get; } =
+        new BarSeries(bar => (bar.High + bar.Low + (bar.Close * 2)) / 4);
+
+    /// <summary>(open + close) / 2.</summary>
+    public static IInputSeries AveragePrice { get; } = new BarSeries(bar => (bar.Open + bar.Close) / 2);
+
+    /// <summary>The midpoint of the close over <paramref name="length"/> bars. A new series each call.</summary>
+    public static IInputSeries Midpoint(int length = 14) => new StateSeries(new MidpointState(length));
+
+    /// <summary>The midprice over <paramref name="length"/> bars. A new series each call.</summary>
+    public static IInputSeries Midprice(int length = 14) => new StateSeries(new MidpriceState(length));
+
+    /// <summary>Any function of the bar.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is null.</exception>
+    public static IInputSeries Of(Func<OhlcvBar, double> selector) =>
+        new BarSeries(selector ?? throw new ArgumentNullException(nameof(selector)));
+
+    /// <summary>
+    /// Another indicator's output - streaming chaining, the counterpart of <c>data.CalculateX().CalculateY()</c>.
+    /// </summary>
+    /// <param name="source">A freshly built state. Its primary value is the input, bar by bar.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+    public static IInputSeries Of(IStreamingIndicatorState source) =>
+        new StateSeries(source ?? throw new ArgumentNullException(nameof(source)));
+
+    private sealed class BarSeries : IInputSeries
+    {
+        private readonly Func<OhlcvBar, double> _selector;
+
+        public BarSeries(Func<OhlcvBar, double> selector) => _selector = selector;
+
+        public double Next(OhlcvBar bar, bool isFinal) => _selector(bar);
+
+        public void Reset()
+        {
+            // Nothing to forget: a function of the bar has no history.
+        }
+    }
+
+    private sealed class StateSeries : IInputSeries, IDisposable
+    {
+        private readonly IStreamingIndicatorState _state;
+
+        public StateSeries(IStreamingIndicatorState state) => _state = state;
+
+        public double Next(OhlcvBar bar, bool isFinal) =>
+            _state.Update(bar, isFinal, includeOutputs: false).Value;
+
+        public void Reset() => _state.Reset();
+
+        public void Dispose()
+        {
+            if (_state is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/src/Streaming/InputSeries.cs
+++ b/src/Streaming/InputSeries.cs
@@ -36,8 +36,9 @@ public interface IInputSeries
 /// Ready-made input series, named after the input names they replace, plus ways to build your own.
 /// </summary>
 /// <remarks>
-/// Migrating from an input name is a one-token change: <c>InputName.MedianPrice</c> becomes
-/// <c>InputSeries.MedianPrice</c>. Each preset gives exactly the value the input name selected.
+/// Code that used to pass an input name - <c>InputName.MedianPrice</c> - passes the preset of the same
+/// name instead: <c>InputSeries.MedianPrice</c>. Each preset gives exactly the value that input name
+/// selected.
 /// <code>
 /// var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.MedianPrice);
 /// var sma = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.Of(new RelativeStrengthIndexState(14)));

--- a/src/Streaming/StatefulIndicators.Batch10.cs
+++ b/src/Streaming/StatefulIndicators.Batch10.cs
@@ -23,13 +23,12 @@ public sealed class EhlersEmpiricalModeDecompositionState : IStreamingIndicatorS
     private int _index;
 
     public EhlersEmpiricalModeDecompositionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 20, int length2 = 50, double delta = 0.5, double fraction = 0.1,
-        InputName inputName = InputName.Close)
+        int length1 = 20, int length2 = 50, double delta = 0.5, double fraction = 0.1)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         _fraction = fraction;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _trendSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1 * 2);
         _peakSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
         _valleySmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
@@ -116,10 +115,10 @@ public sealed class EhlersHammingWindowIndicatorState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public EhlersHammingWindowIndicatorState(MovingAvgType maType = MovingAvgType.EhlersHammingMovingAverage,
-        int length = 20, double pedestal = 10, InputName inputName = InputName.Close)
+        int length = 20, double pedestal = 10)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _ = pedestal;
     }
@@ -171,10 +170,10 @@ public sealed class EhlersHannMovingAverageState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
     private readonly IMovingAverageSmoother _smoother;
 
-    public EhlersHannMovingAverageState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersHannMovingAverageState(int length = 20)
     {
         var resolved = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(MovingAvgType.EhlersHannMovingAverage, resolved);
     }
 
@@ -216,11 +215,10 @@ public sealed class EhlersHannWindowIndicatorState : IStreamingIndicatorState, I
     private double _prevFilt;
     private bool _hasPrev;
 
-    public EhlersHannWindowIndicatorState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public EhlersHannWindowIndicatorState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage, int length = 20)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
     }
 
@@ -271,9 +269,9 @@ public sealed class EhlersHighPassFilterV1State : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private readonly HighPassFilterV1Engine _engine;
 
-    public EhlersHighPassFilterV1State(int length = 125, double mult = 1, InputName inputName = InputName.Close)
+    public EhlersHighPassFilterV1State(int length = 125, double mult = 1)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new HighPassFilterV1Engine(Math.Max(1, length), mult);
     }
 
@@ -307,10 +305,9 @@ public sealed class EhlersHighPassFilterV2State : IStreamingIndicatorState, IDis
     private readonly StreamingInputResolver _input;
     private readonly HighPassFilterV2Engine _engine;
 
-    public EhlersHighPassFilterV2State(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public EhlersHighPassFilterV2State(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new HighPassFilterV2Engine(maType, Math.Max(1, length));
     }
 
@@ -351,10 +348,10 @@ public sealed class EhlersHilbertOscillatorState : IStreamingIndicatorState, IDi
     private readonly PooledRingBuffer<double> _smoothValues;
     private readonly PooledRingBuffer<double> _q3Values;
 
-    public EhlersHilbertOscillatorState(int length = 7, InputName inputName = InputName.Close)
+    public EhlersHilbertOscillatorState(int length = 7)
     {
         _ = length;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _smoothValues = new PooledRingBuffer<double>(2);
         _q3Values = new PooledRingBuffer<double>(MaxSmoothPeriod);
@@ -429,10 +426,9 @@ public sealed class EhlersHilbertTransformIndicatorState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
     private readonly EhlersHilbertTransformIndicatorEngine _engine;
 
-    public EhlersHilbertTransformIndicatorState(int length = 7, double iMult = 0.635, double qMult = 0.338,
-        InputName inputName = InputName.Close)
+    public EhlersHilbertTransformIndicatorState(int length = 7, double iMult = 0.635, double qMult = 0.338)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new EhlersHilbertTransformIndicatorEngine(length, iMult, qMult);
     }
 
@@ -471,11 +467,11 @@ public sealed class EhlersHilbertTransformerState : IStreamingIndicatorState, ID
 {
     private readonly EhlersHilbertTransformerEngine _engine;
 
-    public EhlersHilbertTransformerState(int length1 = 48, int length2 = 20, InputName inputName = InputName.Close)
+    public EhlersHilbertTransformerState(int length1 = 48, int length2 = 20)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
-        _engine = new EhlersHilbertTransformerEngine(resolvedLength1, resolvedLength2, inputName);
+        _engine = new EhlersHilbertTransformerEngine(resolvedLength1, resolvedLength2, InputName.Close);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHilbertTransformer;
@@ -521,8 +517,7 @@ public sealed class EhlersHilbertTransformerIndicatorState : IStreamingIndicator
     private double _prevImag1;
     private double _prevImag2;
 
-    public EhlersHilbertTransformerIndicatorState(int length1 = 48, int length2 = 20, int length3 = 10,
-        InputName inputName = InputName.Close)
+    public EhlersHilbertTransformerIndicatorState(int length1 = 48, int length2 = 20, int length3 = 10)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
@@ -532,7 +527,7 @@ public sealed class EhlersHilbertTransformerIndicatorState : IStreamingIndicator
         _c2 = b2;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV2State(resolvedLength1, resolvedLength2, inputName);
+        _roofingFilter = new EhlersRoofingFilterV2State(resolvedLength1, resolvedLength2);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHilbertTransformerIndicator;
@@ -602,8 +597,7 @@ public sealed class EhlersHomodyneDominantCycleState : IStreamingIndicatorState,
     private double _prevDomCyc1;
     private double _prevDomCyc2;
 
-    public EhlersHomodyneDominantCycleState(int length1 = 48, int length2 = 20, int length3 = 10,
-        InputName inputName = InputName.Close)
+    public EhlersHomodyneDominantCycleState(int length1 = 48, int length2 = 20, int length3 = 10)
     {
         _length1 = Math.Max(1, length1);
         _length3 = Math.Max(1, length3);
@@ -613,7 +607,7 @@ public sealed class EhlersHomodyneDominantCycleState : IStreamingIndicatorState,
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _engine = new EhlersHilbertTransformerEngine(_length1, resolvedLength2, inputName);
+        _engine = new EhlersHilbertTransformerEngine(_length1, resolvedLength2, InputName.Close);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHomodyneDominantCycle;
@@ -681,7 +675,7 @@ public sealed class EhlersHpLpRoofingFilterState : IStreamingIndicatorState
     private double _prevFilter2;
     private int _index;
 
-    public EhlersHpLpRoofingFilterState(int length1 = 48, int length2 = 10, InputName inputName = InputName.Close)
+    public EhlersHpLpRoofingFilterState(int length1 = 48, int length2 = 10)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
@@ -693,7 +687,7 @@ public sealed class EhlersHpLpRoofingFilterState : IStreamingIndicatorState
         _c2 = b1;
         _c3 = -1 * a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHpLpRoofingFilter;
@@ -760,7 +754,7 @@ public sealed class EhlersHurstCoefficientState : IStreamingIndicatorState, IDis
     private double _prevSmoothHurst2;
     private int _index;
 
-    public EhlersHurstCoefficientState(int length1 = 30, int length2 = 20, InputName inputName = InputName.Close)
+    public EhlersHurstCoefficientState(int length1 = 30, int length2 = 20)
     {
         _length1 = Math.Max(1, length1);
         _halfLength = (int)Math.Ceiling((double)_length1 / 2);
@@ -770,7 +764,7 @@ public sealed class EhlersHurstCoefficientState : IStreamingIndicatorState, IDis
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _maxWindow1 = new RollingWindowMax(Math.Max(_length1, 2));
         _minWindow1 = new RollingWindowMin(Math.Max(_length1, 2));
         _maxWindow2 = new RollingWindowMax(Math.Max(_halfLength, 2));
@@ -871,11 +865,11 @@ public sealed class EhlersImpulseReactionState : IStreamingIndicatorState, IDisp
     private double _prevIReact2;
     private int _index;
 
-    public EhlersImpulseReactionState(int length1 = 2, int length2 = 20, double qq = 0.9, InputName inputName = InputName.Close)
+    public EhlersImpulseReactionState(int length1 = 2, int length2 = 20, double qq = 0.9)
     {
         _length1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length1);
         _c2 = 2 * qq * Math.Cos(2 * Math.PI / resolvedLength2);
         _c3 = -qq * qq;
@@ -940,12 +934,12 @@ public sealed class EhlersInfiniteImpulseResponseFilterState : IStreamingIndicat
     private double _prevFilter;
     private int _index;
 
-    public EhlersInfiniteImpulseResponseFilterState(int length = 14, InputName inputName = InputName.Close)
+    public EhlersInfiniteImpulseResponseFilterState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _alpha = 2.0 / (resolved + 1);
         _lag = MathHelper.MinOrMax((int)Math.Ceiling((1 / _alpha) - 1));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_lag);
     }
 
@@ -1003,10 +997,10 @@ public sealed class EhlersInstantaneousPhaseIndicatorState : IStreamingIndicator
     private double _prevQu;
     private int _index;
 
-    public EhlersInstantaneousPhaseIndicatorState(int length1 = 7, int length2 = 50, InputName inputName = InputName.Close)
+    public EhlersInstantaneousPhaseIndicatorState(int length1 = 7, int length2 = 50)
     {
         _length2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new EhlersHilbertTransformIndicatorEngine(Math.Max(1, length1), 0.635, 0.338);
         _dPhaseValues = new PooledRingBuffer<double>(_length2 + 1);
     }
@@ -1096,9 +1090,9 @@ public sealed class EhlersInstantaneousTrendlineV1State : IStreamingIndicatorSta
     private double _prevIt2;
     private double _prevIt3;
 
-    public EhlersInstantaneousTrendlineV1State(InputName inputName = InputName.Close)
+    public EhlersInstantaneousTrendlineV1State()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _values = new PooledRingBuffer<double>(MaxTrendPeriod);
     }
@@ -1167,10 +1161,10 @@ public sealed class EhlersInstantaneousTrendlineV2State : IStreamingIndicatorSta
     private double _prevIt2;
     private int _index;
 
-    public EhlersInstantaneousTrendlineV2State(double alpha = 0.07, InputName inputName = InputName.Close)
+    public EhlersInstantaneousTrendlineV2State(double alpha = 0.07)
     {
         _alpha = alpha;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersInstantaneousTrendlineV2;
@@ -1230,11 +1224,11 @@ public sealed class EhlersInverseFisherTransformState : IStreamingIndicatorState
     private readonly IMovingAverageSmoother _smoother;
 
     public EhlersInverseFisherTransformState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length1 = 5, int length2 = 9, InputName inputName = InputName.Close)
+        int length1 = 5, int length2 = 9)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _rsi = new RsiState(maType, resolvedLength1);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
     }
@@ -1288,10 +1282,10 @@ public sealed class EhlersKaufmanAdaptiveMovingAverageState : IStreamingIndicato
     private bool _hasPrev;
     private int _index;
 
-    public EhlersKaufmanAdaptiveMovingAverageState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersKaufmanAdaptiveMovingAverageState(int length = 20)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _diffSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length);
     }

--- a/src/Streaming/StatefulIndicators.Batch10.cs
+++ b/src/Streaming/StatefulIndicators.Batch10.cs
@@ -39,27 +39,6 @@ public sealed class EhlersEmpiricalModeDecompositionState : IStreamingIndicatorS
         _alpha = MathHelper.MinOrMax(gamma - MathHelper.Sqrt((gamma * gamma) - 1), 0.99, 0.01);
     }
 
-    public EhlersEmpiricalModeDecompositionState(MovingAvgType maType, int length1, int length2, double delta, double fraction,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _fraction = fraction;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _trendSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1 * 2);
-        _peakSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
-        _valleySmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
-
-        _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01));
-        var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / resolvedLength1, 0.99, 0.01));
-        _alpha = MathHelper.MinOrMax(gamma - MathHelper.Sqrt((gamma * gamma) - 1), 0.99, 0.01);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersEmpiricalModeDecomposition;
 
     public void Reset()
@@ -145,20 +124,6 @@ public sealed class EhlersHammingWindowIndicatorState : IStreamingIndicatorState
         _ = pedestal;
     }
 
-    public EhlersHammingWindowIndicatorState(MovingAvgType maType, int length, double pedestal,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _ = pedestal;
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHammingWindowIndicator;
 
     public void Reset()
@@ -213,18 +178,6 @@ public sealed class EhlersHannMovingAverageState : IStreamingIndicatorState, IDi
         _smoother = MovingAverageSmootherFactory.Create(MovingAvgType.EhlersHannMovingAverage, resolved);
     }
 
-    public EhlersHannMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _smoother = MovingAverageSmootherFactory.Create(MovingAvgType.EhlersHannMovingAverage, resolved);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHannMovingAverage;
 
     public void Reset()
@@ -268,18 +221,6 @@ public sealed class EhlersHannWindowIndicatorState : IStreamingIndicatorState, I
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-    }
-
-    public EhlersHannWindowIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
     }
 
@@ -336,17 +277,6 @@ public sealed class EhlersHighPassFilterV1State : IStreamingIndicatorState
         _engine = new HighPassFilterV1Engine(Math.Max(1, length), mult);
     }
 
-    public EhlersHighPassFilterV1State(int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _engine = new HighPassFilterV1Engine(Math.Max(1, length), mult);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHighPassFilterV1;
 
     public void Reset()
@@ -381,17 +311,6 @@ public sealed class EhlersHighPassFilterV2State : IStreamingIndicatorState, IDis
         InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-        _engine = new HighPassFilterV2Engine(maType, Math.Max(1, length));
-    }
-
-    public EhlersHighPassFilterV2State(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _engine = new HighPassFilterV2Engine(maType, Math.Max(1, length));
     }
 
@@ -436,20 +355,6 @@ public sealed class EhlersHilbertOscillatorState : IStreamingIndicatorState, IDi
     {
         _ = length;
         _input = new StreamingInputResolver(inputName, null);
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _smoothValues = new PooledRingBuffer<double>(2);
-        _q3Values = new PooledRingBuffer<double>(MaxSmoothPeriod);
-    }
-
-    public EhlersHilbertOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = length;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _smoothValues = new PooledRingBuffer<double>(2);
         _q3Values = new PooledRingBuffer<double>(MaxSmoothPeriod);
@@ -531,17 +436,6 @@ public sealed class EhlersHilbertTransformIndicatorState : IStreamingIndicatorSt
         _engine = new EhlersHilbertTransformIndicatorEngine(length, iMult, qMult);
     }
 
-    public EhlersHilbertTransformIndicatorState(int length, double iMult, double qMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _engine = new EhlersHilbertTransformIndicatorEngine(length, iMult, qMult);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHilbertTransformIndicator;
 
     public void Reset()
@@ -582,18 +476,6 @@ public sealed class EhlersHilbertTransformerState : IStreamingIndicatorState, ID
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         _engine = new EhlersHilbertTransformerEngine(resolvedLength1, resolvedLength2, inputName);
-    }
-
-    public EhlersHilbertTransformerState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _engine = new EhlersHilbertTransformerEngine(resolvedLength1, resolvedLength2, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHilbertTransformer;
@@ -651,24 +533,6 @@ public sealed class EhlersHilbertTransformerIndicatorState : IStreamingIndicator
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _roofingFilter = new EhlersRoofingFilterV2State(resolvedLength1, resolvedLength2, inputName);
-    }
-
-    public EhlersHilbertTransformerIndicatorState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var resolvedLength3 = Math.Max(1, length3);
-        var a1 = MathHelper.Exp(-1.414 * Math.PI / resolvedLength3);
-        var b2 = 2 * a1 * Math.Cos(1.414 * Math.PI / resolvedLength3);
-        _c2 = b2;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV2State(resolvedLength1, resolvedLength2, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersHilbertTransformerIndicator;
@@ -752,24 +616,6 @@ public sealed class EhlersHomodyneDominantCycleState : IStreamingIndicatorState,
         _engine = new EhlersHilbertTransformerEngine(_length1, resolvedLength2, inputName);
     }
 
-    public EhlersHomodyneDominantCycleState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length3 = Math.Max(1, length3);
-        var resolvedLength2 = Math.Max(1, length2);
-        var a1 = MathHelper.Exp(-1.414 * Math.PI / resolvedLength2);
-        var b1 = 2 * a1 * Math.Cos(1.414 * Math.PI / resolvedLength2);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _engine = new EhlersHilbertTransformerEngine(_length1, resolvedLength2, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHomodyneDominantCycle;
 
     public void Reset()
@@ -850,26 +696,6 @@ public sealed class EhlersHpLpRoofingFilterState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersHpLpRoofingFilterState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var alphaArg = Math.Min(2 * Math.PI / resolvedLength1, 0.99);
-        var alphaCos = Math.Cos(alphaArg);
-        _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / resolvedLength2);
-        var b1 = 2 * a1 * Math.Cos(Math.Min(MathHelper.Sqrt2 * Math.PI / resolvedLength2, 0.99));
-        _c2 = b1;
-        _c3 = -1 * a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersHpLpRoofingFilter;
 
     public void Reset()
@@ -945,29 +771,6 @@ public sealed class EhlersHurstCoefficientState : IStreamingIndicatorState, IDis
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
-        _maxWindow1 = new RollingWindowMax(Math.Max(_length1, 2));
-        _minWindow1 = new RollingWindowMin(Math.Max(_length1, 2));
-        _maxWindow2 = new RollingWindowMax(Math.Max(_halfLength, 2));
-        _minWindow2 = new RollingWindowMin(Math.Max(_halfLength, 2));
-        _values = new PooledRingBuffer<double>(_length1);
-    }
-
-    public EhlersHurstCoefficientState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _halfLength = (int)Math.Ceiling((double)_length1 / 2);
-        var resolvedLength2 = Math.Max(1, length2);
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / resolvedLength2);
-        var b1 = 2 * a1 * Math.Cos(Math.Min(MathHelper.Sqrt2 * Math.PI / resolvedLength2, 0.99));
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _maxWindow1 = new RollingWindowMax(Math.Max(_length1, 2));
         _minWindow1 = new RollingWindowMin(Math.Max(_length1, 2));
         _maxWindow2 = new RollingWindowMax(Math.Max(_halfLength, 2));
@@ -1079,22 +882,6 @@ public sealed class EhlersImpulseReactionState : IStreamingIndicatorState, IDisp
         _c1 = (1 + _c3) / 2;
     }
 
-    public EhlersImpulseReactionState(int length1, int length2, double qq, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(_length1);
-        _c2 = 2 * qq * Math.Cos(2 * Math.PI / resolvedLength2);
-        _c3 = -qq * qq;
-        _c1 = (1 + _c3) / 2;
-    }
-
     public IndicatorName Name => IndicatorName.EhlersImpulseReaction;
 
     public void Reset()
@@ -1162,20 +949,6 @@ public sealed class EhlersInfiniteImpulseResponseFilterState : IStreamingIndicat
         _values = new PooledRingBuffer<double>(_lag);
     }
 
-    public EhlersInfiniteImpulseResponseFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = 2.0 / (resolved + 1);
-        _lag = MathHelper.MinOrMax((int)Math.Ceiling((1 / _alpha) - 1));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(_lag);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersInfiniteImpulseResponseFilter;
 
     public void Reset()
@@ -1234,19 +1007,6 @@ public sealed class EhlersInstantaneousPhaseIndicatorState : IStreamingIndicator
     {
         _length2 = Math.Max(1, length2);
         _input = new StreamingInputResolver(inputName, null);
-        _engine = new EhlersHilbertTransformIndicatorEngine(Math.Max(1, length1), 0.635, 0.338);
-        _dPhaseValues = new PooledRingBuffer<double>(_length2 + 1);
-    }
-
-    public EhlersInstantaneousPhaseIndicatorState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _engine = new EhlersHilbertTransformIndicatorEngine(Math.Max(1, length1), 0.635, 0.338);
         _dPhaseValues = new PooledRingBuffer<double>(_length2 + 1);
     }
@@ -1343,18 +1103,6 @@ public sealed class EhlersInstantaneousTrendlineV1State : IStreamingIndicatorSta
         _values = new PooledRingBuffer<double>(MaxTrendPeriod);
     }
 
-    public EhlersInstantaneousTrendlineV1State(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _values = new PooledRingBuffer<double>(MaxTrendPeriod);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersInstantaneousTrendlineV1;
 
     public void Reset()
@@ -1425,17 +1173,6 @@ public sealed class EhlersInstantaneousTrendlineV2State : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersInstantaneousTrendlineV2State(double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = alpha;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersInstantaneousTrendlineV2;
 
     public void Reset()
@@ -1502,20 +1239,6 @@ public sealed class EhlersInverseFisherTransformState : IStreamingIndicatorState
         _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
     }
 
-    public EhlersInverseFisherTransformState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _rsi = new RsiState(maType, resolvedLength1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersInverseFisherTransform;
 
     public void Reset()
@@ -1569,19 +1292,6 @@ public sealed class EhlersKaufmanAdaptiveMovingAverageState : IStreamingIndicato
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _diffSum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
-    public EhlersKaufmanAdaptiveMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _diffSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length);
     }

--- a/src/Streaming/StatefulIndicators.Batch11.cs
+++ b/src/Streaming/StatefulIndicators.Batch11.cs
@@ -16,10 +16,10 @@ public sealed class EhlersLaguerreFilterState : IStreamingIndicatorState, IDispo
     private double _prevL3;
     private bool _hasPrev;
 
-    public EhlersLaguerreFilterState(double alpha = 0.2, InputName inputName = InputName.Close)
+    public EhlersLaguerreFilterState(double alpha = 0.2)
     {
         _alpha = alpha;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -89,7 +89,7 @@ public sealed class EhlersReflexIndicatorState : IStreamingIndicatorState, IDisp
     private readonly PooledRingBuffer<double> _filterValues;
     private double _prevMs;
 
-    public EhlersReflexIndicatorState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersReflexIndicatorState(int length = 20)
     {
         _length = Math.Max(1, length);
         var period = 0.5 * _length;
@@ -98,7 +98,7 @@ public sealed class EhlersReflexIndicatorState : IStreamingIndicatorState, IDisp
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(1);
         _filterValues = new PooledRingBuffer<double>(_length);
     }
@@ -167,12 +167,11 @@ public sealed class EhlersRelativeStrengthIndexInverseFisherTransformState : ISt
     private readonly StreamingInputResolver _input;
 
     public EhlersRelativeStrengthIndexInverseFisherTransformState(
-        MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14, int signalLength = 9,
-        InputName inputName = InputName.Close)
+        MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14, int signalLength = 9)
     {
         _rsi = new RsiState(maType, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRelativeStrengthIndexInverseFisherTransform;
@@ -218,11 +217,11 @@ public sealed class EhlersRelativeVigorIndexState : IStreamingIndicatorState, ID
     private readonly StreamingInputResolver _input;
 
     public EhlersRelativeVigorIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10,
-        int signalLength = 4, InputName inputName = InputName.Close)
+        int signalLength = 4)
     {
         _rviSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRelativeVigorIndex;
@@ -270,13 +269,13 @@ public sealed class EhlersRestoringPullIndicatorState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public EhlersRestoringPullIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int minLength = 8, int maxLength = 50, int length1 = 40, int length2 = 10, InputName inputName = InputName.Close)
+        int minLength = 8, int maxLength = 50, int length1 = 40, int length2 = 10)
     {
         var resolvedMin = Math.Max(1, minLength);
         var resolvedMax = Math.Max(maxLength, resolvedMin);
         _sdfb = new EhlersSpectrumDerivedFilterBankEngine(resolvedMin, resolvedMax, length1, length2);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedMin);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRestoringPullIndicator;
@@ -319,10 +318,10 @@ public sealed class EhlersReverseExponentialMovingAverageIndicatorV1State : IStr
     private readonly ReverseEmaEngine _engine;
     private readonly StreamingInputResolver _input;
 
-    public EhlersReverseExponentialMovingAverageIndicatorV1State(double alpha = 0.1, InputName inputName = InputName.Close)
+    public EhlersReverseExponentialMovingAverageIndicatorV1State(double alpha = 0.1)
     {
         _engine = new ReverseEmaEngine(alpha);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersReverseExponentialMovingAverageIndicatorV1;
@@ -356,12 +355,11 @@ public sealed class EhlersReverseExponentialMovingAverageIndicatorV2State : IStr
     private readonly ReverseEmaEngine _cycleEngine;
     private readonly StreamingInputResolver _input;
 
-    public EhlersReverseExponentialMovingAverageIndicatorV2State(double trendAlpha = 0.05, double cycleAlpha = 0.3,
-        InputName inputName = InputName.Close)
+    public EhlersReverseExponentialMovingAverageIndicatorV2State(double trendAlpha = 0.05, double cycleAlpha = 0.3)
     {
         _trendEngine = new ReverseEmaEngine(trendAlpha);
         _cycleEngine = new ReverseEmaEngine(cycleAlpha);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersReverseExponentialMovingAverageIndicatorV2;
@@ -407,7 +405,7 @@ public sealed class EhlersRocketRelativeStrengthIndexState : IStreamingIndicator
     private double _prevTmp;
 
     public EhlersRocketRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV2,
-        int length1 = 10, int length2 = 8, double obosLevel = 2, double mult = 1, InputName inputName = InputName.Close)
+        int length1 = 10, int length2 = 8, double obosLevel = 2, double mult = 1)
     {
         _length1 = Math.Max(1, length1);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
@@ -415,7 +413,7 @@ public sealed class EhlersRocketRelativeStrengthIndexState : IStreamingIndicator
         _upSum = new RollingWindowSum(_length1);
         _downSum = new RollingWindowSum(_length1);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRocketRelativeStrengthIndex;
@@ -494,7 +492,7 @@ public sealed class EhlersRoofingFilterIndicatorState : IStreamingIndicatorState
     private double _prevFilter1;
     private double _prevFilter2;
 
-    public EhlersRoofingFilterIndicatorState(int length1 = 80, int length2 = 40, InputName inputName = InputName.Close)
+    public EhlersRoofingFilterIndicatorState(int length1 = 80, int length2 = 40)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -506,7 +504,7 @@ public sealed class EhlersRoofingFilterIndicatorState : IStreamingIndicatorState
         _c2 = b1;
         _c3 = -a2 * a2;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
     }
 
@@ -566,13 +564,13 @@ public sealed class EhlersRoofingFilterV1State : IStreamingIndicatorState, IDisp
     private double _prevHp;
 
     public EhlersRoofingFilterV1State(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV1,
-        int length1 = 48, int length2 = 10, InputName inputName = InputName.Close)
+        int length1 = 48, int length2 = 10)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
         _hp = new HighPassFilterV1Engine(resolved1, 1);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRoofingFilterV1;
@@ -623,13 +621,12 @@ public sealed class EhlersSignalToNoiseRatioV1State : IStreamingIndicatorState, 
     private double _prevRange;
     private double _prevAmp;
 
-    public EhlersSignalToNoiseRatioV1State(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 7,
-        InputName inputName = InputName.Close)
+    public EhlersSignalToNoiseRatioV1State(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 7)
     {
         var resolved = Math.Max(1, length);
         _engine = new EhlersHilbertTransformIndicatorEngine(resolved, 0.635, 0.338);
         _ema = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersSignalToNoiseRatioV1;
@@ -690,11 +687,11 @@ public sealed class EhlersSignalToNoiseRatioV2State : IStreamingIndicatorState, 
     private double _prevRange;
     private double _prevSnr;
 
-    public EhlersSignalToNoiseRatioV2State(int length = 6, InputName inputName = InputName.Close)
+    public EhlersSignalToNoiseRatioV2State(int length = 6)
     {
         _length = Math.Max(1, length);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersSignalToNoiseRatioV2;
@@ -750,10 +747,10 @@ public sealed class EhlersLaguerreRelativeStrengthIndexState : IStreamingIndicat
     private double _prevL3;
     private bool _hasPrev;
 
-    public EhlersLaguerreRelativeStrengthIndexState(double gamma = 0.5, InputName inputName = InputName.Close)
+    public EhlersLaguerreRelativeStrengthIndexState(double gamma = 0.5)
     {
         _gamma = gamma;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersLaguerreRelativeStrengthIndex;
@@ -820,10 +817,10 @@ public sealed class EhlersLaguerreRelativeStrengthIndexWithSelfAdjustingAlphaSta
     private double _prevValue;
     private bool _hasPrev;
 
-    public EhlersLaguerreRelativeStrengthIndexWithSelfAdjustingAlphaState(int length = 13, InputName inputName = InputName.Close)
+    public EhlersLaguerreRelativeStrengthIndexWithSelfAdjustingAlphaState(int length = 13)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _highMax = new RollingWindowMax(_length);
         _lowMin = new RollingWindowMin(_length);
         _ratioSum = new RollingWindowSum(_length);
@@ -915,11 +912,11 @@ public sealed class EhlersLeadingIndicatorState : IStreamingIndicatorState
     private double _prevValue;
     private bool _hasPrev;
 
-    public EhlersLeadingIndicatorState(double alpha1 = 0.25, double alpha2 = 0.33, InputName inputName = InputName.Close)
+    public EhlersLeadingIndicatorState(double alpha1 = 0.25, double alpha2 = 0.33)
     {
         _alpha1 = alpha1;
         _alpha2 = alpha2;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersLeadingIndicator;
@@ -1029,11 +1026,11 @@ public sealed class EhlersMedianAverageAdaptiveFilterState : IStreamingIndicator
     private double _prevValue2;
     private double _prevFilter;
 
-    public EhlersMedianAverageAdaptiveFilterState(int length = 39, double threshold = 0.002, InputName inputName = InputName.Close)
+    public EhlersMedianAverageAdaptiveFilterState(int length = 39, double threshold = 0.002)
     {
         _length = Math.Max(1, length);
         _threshold = threshold;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(3);
         _smthValues = new PooledRingBuffer<double>(_length);
         _windowScratch = new double[_length];
@@ -1206,14 +1203,14 @@ public sealed class EhlersMesaPredictIndicatorV1State : IStreamingIndicatorState
     private int _index;
 
     public EhlersMesaPredictIndicatorV1State(int length1 = 5, int length2 = 4, int length3 = 10,
-        int lowerLength = 12, int upperLength = 54, InputName inputName = InputName.Close)
+        int lowerLength = 12, int upperLength = 54)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
         _length3 = Math.Max(1, length3);
         _lowerLength = Math.Max(1, lowerLength);
         _upperLength = Math.Max(1, upperLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
 
         var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / _upperLength, -0.01, -0.99));
         var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / _upperLength, 0.99, 0.01));
@@ -1440,13 +1437,13 @@ public sealed class EhlersMesaPredictIndicatorV2State : IStreamingIndicatorState
     private int _index;
 
     public EhlersMesaPredictIndicatorV2State(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length1 = 5, int length2 = 135, int length3 = 12, int length4 = 4, InputName inputName = InputName.Close)
+        int length1 = 5, int length2 = 135, int length3 = 12, int length4 = 4)
     {
         _length1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         var resolvedLength3 = Math.Max(1, length3);
         _length4 = Math.Max(1, length4);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
 
         _coefArray = new[] { 4.525, -8.45, 8.145, -4.045, 0.825 };
 
@@ -1574,9 +1571,9 @@ public sealed class EhlersModifiedOptimumEllipticFilterState : IStreamingIndicat
     private double _prevMoef2;
     private int _index;
 
-    public EhlersModifiedOptimumEllipticFilterState(InputName inputName = InputName.Close)
+    public EhlersModifiedOptimumEllipticFilterState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersModifiedOptimumEllipticFilter;
@@ -1732,7 +1729,7 @@ public sealed class EhlersModifiedStochasticIndicatorState : IStreamingIndicator
     private double _prevModStoc2;
 
     public EhlersModifiedStochasticIndicatorState(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV1,
-        int length1 = 48, int length2 = 10, int length3 = 20, InputName inputName = InputName.Close)
+        int length1 = 48, int length2 = 10, int length3 = 20)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1742,7 +1739,7 @@ public sealed class EhlersModifiedStochasticIndicatorState : IStreamingIndicator
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV1State(maType, resolved1, resolved2, inputName);
+        _roofingFilter = new EhlersRoofingFilterV1State(maType, resolved1, resolved2);
         _maxWindow = new RollingWindowMax(resolved3);
         _minWindow = new RollingWindowMin(resolved3);
     }
@@ -1802,11 +1799,11 @@ public sealed class EhlersMovingAverageDifferenceIndicatorState : IStreamingIndi
     private readonly StreamingInputResolver _input;
 
     public EhlersMovingAverageDifferenceIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int fastLength = 8, int slowLength = 23, InputName inputName = InputName.Close)
+        int fastLength = 8, int slowLength = 23)
     {
         _shortSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _longSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersMovingAverageDifferenceIndicator;
@@ -1851,11 +1848,11 @@ public sealed class EhlersNoiseEliminationTechnologyState : IStreamingIndicatorS
     private readonly PooledRingBuffer<double> _values;
     private readonly double[] _scratch;
 
-    public EhlersNoiseEliminationTechnologyState(int length = 14, InputName inputName = InputName.Close)
+    public EhlersNoiseEliminationTechnologyState(int length = 14)
     {
         _length = Math.Max(1, length);
         _denom = 0.5 * _length * (_length - 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
         _scratch = new double[_length + 1];
     }
@@ -1919,9 +1916,9 @@ public sealed class EhlersOptimumEllipticFilterState : IStreamingIndicatorState
     private double _prevOef2;
     private int _index;
 
-    public EhlersOptimumEllipticFilterState(InputName inputName = InputName.Close)
+    public EhlersOptimumEllipticFilterState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersOptimumEllipticFilter;
@@ -1985,7 +1982,7 @@ public sealed class EhlersPhaseAccumulationDominantCycleState : IStreamingIndica
     private int _index;
 
     public EhlersPhaseAccumulationDominantCycleState(int length1 = 48, int length2 = 20, int length3 = 10,
-        int length4 = 40, InputName inputName = InputName.Close)
+        int length4 = 40)
     {
         _length1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1996,7 +1993,7 @@ public sealed class EhlersPhaseAccumulationDominantCycleState : IStreamingIndica
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _hilbert = new EhlersHilbertTransformerEngine(_length1, resolved2, inputName);
+        _hilbert = new EhlersHilbertTransformerEngine(_length1, resolved2, InputName.Close);
         _dPhaseValues = new PooledRingBuffer<double>(_length4);
     }
 
@@ -2081,11 +2078,10 @@ public sealed class EhlersPhaseCalculationState : IStreamingIndicatorState, IDis
     private readonly IMovingAverageSmoother _smoother;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersPhaseCalculationState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 15,
-        InputName inputName = InputName.Close)
+    public EhlersPhaseCalculationState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 15)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _values = new PooledRingBuffer<double>(_length);
     }
@@ -2152,14 +2148,14 @@ public sealed class EhlersRecursiveMedianFilterState : IStreamingIndicatorState,
     private readonly double[] _medianScratch;
     private double _prevRmf;
 
-    public EhlersRecursiveMedianFilterState(int length1 = 5, int length2 = 12, InputName inputName = InputName.Close)
+    public EhlersRecursiveMedianFilterState(int length1 = 5, int length2 = 12)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
         var alphaArg = MathHelper.MinOrMax(2 * Math.PI / resolved2, 0.99, 0.01);
         var alphaArgCos = Math.Cos(alphaArg);
         _alpha = alphaArgCos != 0 ? (alphaArgCos + Math.Sin(alphaArg) - 1) / alphaArgCos : 0;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(resolved1);
         _medianScratch = new double[resolved1];
     }
@@ -2214,8 +2210,7 @@ public sealed class EhlersRecursiveMedianOscillatorState : IStreamingIndicatorSt
     private double _prevRmo1;
     private double _prevRmo2;
 
-    public EhlersRecursiveMedianOscillatorState(int length1 = 5, int length2 = 12, int length3 = 30,
-        InputName inputName = InputName.Close)
+    public EhlersRecursiveMedianOscillatorState(int length1 = 5, int length2 = 12, int length3 = 30)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -2226,7 +2221,7 @@ public sealed class EhlersRecursiveMedianOscillatorState : IStreamingIndicatorSt
         var alpha2ArgCos = Math.Cos(alpha2Arg);
         _alpha1 = alpha1ArgCos != 0 ? (alpha1ArgCos + Math.Sin(alpha1Arg) - 1) / alpha1ArgCos : 0;
         _alpha2 = alpha2ArgCos != 0 ? (alpha2ArgCos + Math.Sin(alpha2Arg) - 1) / alpha2ArgCos : 0;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(resolved1);
         _medianScratch = new double[resolved1];
     }
@@ -2288,12 +2283,11 @@ public sealed class EhlersSimpleClipIndicatorState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _clipValues;
 
     public EhlersSimpleClipIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 2, int length2 = 10, int length3 = 50, int signalLength = 22,
-        InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 10, int length3 = 50, int signalLength = 22)
     {
         _length1 = Math.Max(1, length1);
         _length3 = Math.Max(1, length3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length1);
         _derivValues = new PooledRingBuffer<double>(_length3);
@@ -2368,10 +2362,10 @@ public sealed class EhlersSimpleCycleIndicatorState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _cycleValues;
     private int _index;
 
-    public EhlersSimpleCycleIndicatorState(double alpha = 0.07, InputName inputName = InputName.Close)
+    public EhlersSimpleCycleIndicatorState(double alpha = 0.07)
     {
         _alpha = alpha;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(4);
         _smoothValues = new PooledRingBuffer<double>(3);
         _cycleValues = new PooledRingBuffer<double>(3);
@@ -2438,12 +2432,11 @@ public sealed class EhlersSimpleDecyclerState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
     private readonly HighPassFilterV1Engine _hp;
 
-    public EhlersSimpleDecyclerState(int length = 125, double upperPct = 0.5, double lowerPct = 0.5,
-        InputName inputName = InputName.Close)
+    public EhlersSimpleDecyclerState(int length = 125, double upperPct = 0.5, double lowerPct = 0.5)
     {
         _upperPct = upperPct;
         _lowerPct = lowerPct;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _hp = new HighPassFilterV1Engine(Math.Max(1, length), 1);
     }
 
@@ -2490,10 +2483,10 @@ public sealed class EhlersSimpleDerivIndicatorState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _derivValues;
 
     public EhlersSimpleDerivIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 2,
-        int signalLength = 8, InputName inputName = InputName.Close)
+        int signalLength = 8)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length);
         _derivValues = new PooledRingBuffer<double>(3);
@@ -2555,11 +2548,10 @@ public sealed class EhlersSimpleWindowIndicatorState : IStreamingIndicatorState,
     private readonly IMovingAverageSmoother _thirdSmoother;
     private double _prevFilt;
 
-    public EhlersSimpleWindowIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public EhlersSimpleWindowIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _firstSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _secondSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _thirdSmoother = MovingAverageSmootherFactory.Create(maType, _length);
@@ -2616,10 +2608,10 @@ public sealed class EhlersSineWaveIndicatorV1State : IStreamingIndicatorState, I
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _smoothValues;
 
-    public EhlersSineWaveIndicatorV1State(InputName inputName = InputName.Close)
+    public EhlersSineWaveIndicatorV1State()
     {
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoothValues = new PooledRingBuffer<double>(64);
     }
 
@@ -2690,12 +2682,12 @@ public sealed class EhlersSineWaveIndicatorV2State : IStreamingIndicatorState, I
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _cycleValues;
 
-    public EhlersSineWaveIndicatorV2State(int length = 5, double alpha = 0.07, InputName inputName = InputName.Close)
+    public EhlersSineWaveIndicatorV2State(int length = 5, double alpha = 0.07)
     {
         var resolved = Math.Max(1, length);
         _periodState = new AdaptiveCyberCyclePeriodState(resolved, alpha);
-        _cycleState = new EhlersCyberCycleState(0.07, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _cycleState = new EhlersCyberCycleState(0.07);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _cycleValues = new PooledRingBuffer<double>(64);
     }
 
@@ -2771,7 +2763,7 @@ public sealed class EhlersSmoothedAdaptiveMomentumIndicatorState : IStreamingInd
     private readonly PooledRingBuffer<double> _f3Values;
 
     public EhlersSmoothedAdaptiveMomentumIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 5, int length2 = 8, InputName inputName = InputName.Close)
+        int length1 = 5, int length2 = 8)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -2783,7 +2775,7 @@ public sealed class EhlersSmoothedAdaptiveMomentumIndicatorState : IStreamingInd
         _coef4 = c1 * c1;
         _coef1 = 1 - _coef2 - _coef3 - _coef4;
         _periodState = new AdaptiveCyberCyclePeriodState(resolved1, 0.07);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
         _values = new PooledRingBuffer<double>(Math.Max(64, resolved1 * 2));
         _f3Values = new PooledRingBuffer<double>(3);
@@ -2854,7 +2846,7 @@ public sealed class EhlersSnakeUniversalTradingFilterState : IStreamingIndicator
     private int _index;
 
     public EhlersSnakeUniversalTradingFilterState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length1 = 23, int length2 = 50, double bw = 1.4, InputName inputName = InputName.Close)
+        int length1 = 23, int length2 = 50, double bw = 1.4)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -2862,7 +2854,7 @@ public sealed class EhlersSnakeUniversalTradingFilterState : IStreamingIndicator
         var g1 = Math.Cos(MathHelper.MinOrMax(bw * 2 * Math.PI / (2 * _length1), 0.99, 0.01));
         _s1 = (1 / g1) - MathHelper.Sqrt(1 / MathHelper.Pow(g1, 2) - 1);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
         _bpValues = new PooledRingBuffer<double>(2);
         _powerSum = new RollingWindowSum(_length2);
@@ -2931,10 +2923,10 @@ public sealed class EhlersSpearmanRankIndicatorState : IStreamingIndicatorState,
     private readonly double[] _priceArray;
     private readonly double[] _rankArray;
 
-    public EhlersSpearmanRankIndicatorState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersSpearmanRankIndicatorState(int length = 20)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
         var arrayLength = Math.Max(50, _length + 1);
         _priceArray = new double[arrayLength];
@@ -3012,11 +3004,10 @@ public sealed class EhlersSpectrumDerivedFilterBankState : IStreamingIndicatorSt
     private readonly EhlersSpectrumDerivedFilterBankEngine _engine;
     private readonly StreamingInputResolver _input;
 
-    public EhlersSpectrumDerivedFilterBankState(int minLength = 8, int maxLength = 50, int length1 = 40, int length2 = 10,
-        InputName inputName = InputName.Close)
+    public EhlersSpectrumDerivedFilterBankState(int minLength = 8, int maxLength = 50, int length1 = 40, int length2 = 10)
     {
         _engine = new EhlersSpectrumDerivedFilterBankEngine(minLength, maxLength, length1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersSpectrumDerivedFilterBank;
@@ -3063,13 +3054,12 @@ public sealed class EhlersSquelchIndicatorState : IStreamingIndicatorState, IDis
     private double _prevPhase;
     private double _prevDcPeriod;
 
-    public EhlersSquelchIndicatorState(int length1 = 6, int length2 = 20, int length3 = 40,
-        InputName inputName = InputName.Close)
+    public EhlersSquelchIndicatorState(int length1 = 6, int length2 = 20, int length3 = 40)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
         _length3 = Math.Max(1, length3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length1);
         _v1Values = new PooledRingBuffer<double>(Math.Max(_length1, 4));
         _dPhaseValues = new PooledRingBuffer<double>(_length3);
@@ -3164,11 +3154,11 @@ public sealed class EhlersStochasticCenterOfGravityOscillatorState : IStreamingI
     private readonly PooledRingBuffer<double> _v1Values;
     private readonly PooledRingBuffer<double> _v2Values;
 
-    public EhlersStochasticCenterOfGravityOscillatorState(int length = 8, InputName inputName = InputName.Close)
+    public EhlersStochasticCenterOfGravityOscillatorState(int length = 8)
     {
         _length = Math.Max(1, length);
         _windowLength = Math.Max(_length, 2);
-        _cogState = new EhlersCenterofGravityOscillatorState(_length, inputName);
+        _cogState = new EhlersCenterofGravityOscillatorState(_length);
         _cgValues = new PooledRingBuffer<double>(_windowLength);
         _v1Values = new PooledRingBuffer<double>(3);
         _v2Values = new PooledRingBuffer<double>(1);
@@ -3250,14 +3240,14 @@ public sealed class EhlersZeroMeanRoofingFilterState : IStreamingIndicatorState
     private double _prevZmr;
     private bool _hasPrev;
 
-    public EhlersZeroMeanRoofingFilterState(int length1 = 48, int length2 = 10, InputName inputName = InputName.Close)
+    public EhlersZeroMeanRoofingFilterState(int length1 = 48, int length2 = 10)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         var alphaArg = Math.Min(2 * Math.PI / resolvedLength1, 0.99);
         var alphaCos = Math.Cos(alphaArg);
         _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        _roofingFilter = new EhlersHpLpRoofingFilterState(resolvedLength1, resolvedLength2, inputName);
+        _roofingFilter = new EhlersHpLpRoofingFilterState(resolvedLength1, resolvedLength2);
     }
 
     public IndicatorName Name => IndicatorName.EhlersZeroMeanRoofingFilter;
@@ -3309,7 +3299,7 @@ public sealed class EhlersTrendflexIndicatorState : IStreamingIndicatorState, ID
     private double _prevMs;
     private bool _hasPrev;
 
-    public EhlersTrendflexIndicatorState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersTrendflexIndicatorState(int length = 20)
     {
         _length = Math.Max(1, length);
         var period = 0.5 * _length;
@@ -3318,7 +3308,7 @@ public sealed class EhlersTrendflexIndicatorState : IStreamingIndicatorState, ID
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _filterValues = new PooledRingBuffer<double>(_length);
     }
 
@@ -3390,14 +3380,14 @@ public sealed class EhlersTrendExtractionState : IStreamingIndicatorState, IDisp
     private int _index;
 
     public EhlersTrendExtractionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 20, double delta = 0.1, InputName inputName = InputName.Close)
+        int length = 20, double delta = 0.1)
     {
         _length = Math.Max(1, length);
         _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / _length, 0.99, 0.01));
         var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / _length, 0.99, 0.01));
         _alpha = MathHelper.MinOrMax(gamma - MathHelper.Sqrt((gamma * gamma) - 1), 0.99, 0.01);
         _trendSmoother = MovingAverageSmootherFactory.Create(maType, _length * 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
         _bpValues = new PooledRingBuffer<double>(2);
     }
@@ -3460,13 +3450,13 @@ public sealed class EhlersUniversalTradingFilterState : IStreamingIndicatorState
     private readonly RollingWindowSum _powerSum;
 
     public EhlersUniversalTradingFilterState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length1 = 16, int length2 = 50, double mult = 2, InputName inputName = InputName.Close)
+        int length1 = 16, int length2 = 50, double mult = 2)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         _hannLength = (int)Math.Ceiling(mult * resolvedLength1);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_hannLength);
         _powerSum = new RollingWindowSum(resolvedLength2);
     }
@@ -3527,8 +3517,7 @@ public sealed class EhlersSuperPassbandFilterState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _espfValues;
     private readonly RollingWindowSum _powerSum;
 
-    public EhlersSuperPassbandFilterState(int fastLength = 40, int slowLength = 60, int length1 = 5, int length2 = 50,
-        InputName inputName = InputName.Close)
+    public EhlersSuperPassbandFilterState(int fastLength = 40, int slowLength = 60, int length1 = 5, int length2 = 50)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -3536,7 +3525,7 @@ public sealed class EhlersSuperPassbandFilterState : IStreamingIndicatorState, I
         var resolvedLength2 = Math.Max(1, length2);
         _a1 = MathHelper.MinOrMax((double)resolvedLength1 / resolvedFast, 0.99, 0.01);
         _a2 = MathHelper.MinOrMax((double)resolvedLength1 / resolvedSlow, 0.99, 0.01);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(1);
         _espfValues = new PooledRingBuffer<double>(2);
         _powerSum = new RollingWindowSum(resolvedLength2);
@@ -3601,10 +3590,10 @@ public sealed class EhlersSuperSmootherFilterState : IStreamingIndicatorState
     private readonly EhlersSuperSmootherFilterEngine _engine;
     private readonly StreamingInputResolver _input;
 
-    public EhlersSuperSmootherFilterState(int length = 10, InputName inputName = InputName.Close)
+    public EhlersSuperSmootherFilterState(int length = 10)
     {
         _engine = new EhlersSuperSmootherFilterEngine(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersSuperSmootherFilter;
@@ -3637,10 +3626,10 @@ public sealed class EhlersTriangleMovingAverageState : IStreamingIndicatorState,
     private readonly EhlersTriangleMovingAverageSmoother _smoother;
     private readonly StreamingInputResolver _input;
 
-    public EhlersTriangleMovingAverageState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersTriangleMovingAverageState(int length = 20)
     {
         _smoother = new EhlersTriangleMovingAverageSmoother(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersTriangleMovingAverage;
@@ -3681,10 +3670,10 @@ public sealed class EhlersTriangleWindowIndicatorState : IStreamingIndicatorStat
     private double _prevFilt;
 
     public EhlersTriangleWindowIndicatorState(MovingAvgType maType = MovingAvgType.EhlersTriangleMovingAverage,
-        int length = 20, InputName inputName = InputName.Close)
+        int length = 20)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
     }
 
@@ -3736,15 +3725,14 @@ public sealed class EhlersTruncatedBandPassFilterState : IStreamingIndicatorStat
     private readonly PooledRingBuffer<double> _values;
     private readonly double[] _scratch;
 
-    public EhlersTruncatedBandPassFilterState(int length1 = 20, int length2 = 10, double bw = 0.1,
-        InputName inputName = InputName.Close)
+    public EhlersTruncatedBandPassFilterState(int length1 = 20, int length2 = 10, double bw = 0.1)
     {
         var resolvedLength1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
         _l1 = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01));
         var g1 = Math.Cos(bw * 2 * Math.PI / resolvedLength1);
         _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length2 + 2);
         _scratch = new double[_length2 + 3];
     }
@@ -3808,7 +3796,7 @@ public sealed class EhlersUniversalOscillatorState : IStreamingIndicatorState, I
     private double _prevEuo;
 
     public EhlersUniversalOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 20, int signalLength = 9, InputName inputName = InputName.Close)
+        int length = 20, int signalLength = 9)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedSignal = Math.Max(1, signalLength);
@@ -3818,7 +3806,7 @@ public sealed class EhlersUniversalOscillatorState : IStreamingIndicatorState, I
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSignal);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
     }
 
@@ -3883,9 +3871,9 @@ public sealed class EhlersZeroCrossingsDominantCycleState : IStreamingIndicatorS
     private int _counter;
     private int _index;
 
-    public EhlersZeroCrossingsDominantCycleState(int length = 20, double bw = 0.7, InputName inputName = InputName.Close)
+    public EhlersZeroCrossingsDominantCycleState(int length = 20, double bw = 0.7)
     {
-        _bandPass = new EhlersBandPassFilterV1State(length, bw, inputName);
+        _bandPass = new EhlersBandPassFilterV1State(length, bw);
     }
 
     public IndicatorName Name => IndicatorName.EhlersZeroCrossingsDominantCycle;
@@ -3943,11 +3931,11 @@ public sealed class EhlersStochasticCyberCycleState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _stochValues;
     private double _prevStochCc;
 
-    public EhlersStochasticCyberCycleState(int length = 14, double alpha = 0.7, InputName inputName = InputName.Close)
+    public EhlersStochasticCyberCycleState(int length = 14, double alpha = 0.7)
     {
         _length = Math.Max(1, length);
         _windowLength = Math.Max(_length, 2);
-        _cycleState = new EhlersCyberCycleState(alpha, inputName);
+        _cycleState = new EhlersCyberCycleState(alpha);
         _cycleValues = new PooledRingBuffer<double>(_windowLength);
         _stochValues = new PooledRingBuffer<double>(3);
     }
@@ -4028,11 +4016,11 @@ public sealed class EhlersStochasticState : IStreamingIndicatorState, IDisposabl
     private double _prevStoch;
 
     public EhlersStochasticState(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV1,
-        int length1 = 48, int length2 = 20, int length3 = 10, InputName inputName = InputName.Close)
+        int length1 = 48, int length2 = 20, int length3 = 10)
     {
         _length2 = Math.Max(1, length2);
         _windowLength = Math.Max(_length2, 2);
-        _roofingFilter = new EhlersRoofingFilterV1State(maType, Math.Max(1, length1), Math.Max(1, length3), inputName);
+        _roofingFilter = new EhlersRoofingFilterV1State(maType, Math.Max(1, length1), Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length2);
         _rfValues = new PooledRingBuffer<double>(_windowLength);
     }
@@ -4107,12 +4095,12 @@ public sealed class EhlersTripleDelayLineDetrenderState : IStreamingIndicatorSta
     private readonly PooledRingBuffer<double> _tmp2Values;
 
     public EhlersTripleDelayLineDetrenderState(MovingAvgType maType = MovingAvgType.EhlersModifiedOptimumEllipticFilter,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _tmp1Values = new PooledRingBuffer<double>(6);
         _tmp2Values = new PooledRingBuffer<double>(12);
     }
@@ -4180,7 +4168,7 @@ public sealed class EhlersVariableIndexDynamicAverageState : IStreamingIndicator
     private bool _hasPrev;
 
     public EhlersVariableIndexDynamicAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int fastLength = 9, int slowLength = 30, InputName inputName = InputName.Close)
+        int fastLength = 9, int slowLength = 30)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -4188,7 +4176,7 @@ public sealed class EhlersVariableIndexDynamicAverageState : IStreamingIndicator
         _longSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _shortPowSum = new RollingWindowSum(resolvedFast);
         _longPowSum = new RollingWindowSum(resolvedSlow);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersVariableIndexDynamicAverage;
@@ -4258,11 +4246,11 @@ public sealed class EhlersZeroLagExponentialMovingAverageState : IStreamingIndic
     private readonly PooledRingBuffer<double> _values;
 
     public EhlersZeroLagExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _lag = MathHelper.MinOrMax((int)Math.Floor((double)(resolved - 1) / 2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _values = new PooledRingBuffer<double>(_lag);
     }
@@ -4317,15 +4305,14 @@ public sealed class EhlersVossPredictiveFilterState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _vossValues;
     private int _index;
 
-    public EhlersVossPredictiveFilterState(int length = 20, double predict = 3, double bw = 0.25,
-        InputName inputName = InputName.Close)
+    public EhlersVossPredictiveFilterState(int length = 20, double predict = 3, double bw = 0.25)
     {
         var resolved = Math.Max(1, length);
         _order = MathHelper.MinOrMax((int)Math.Ceiling(3 * predict));
         _f1 = Math.Cos(2 * Math.PI / resolved);
         var g1 = Math.Cos(bw * 2 * Math.PI / resolved);
         _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
         _filterValues = new PooledRingBuffer<double>(2);
         _vossValues = new PooledRingBuffer<double>(_order);
@@ -4416,12 +4403,12 @@ public sealed class EhlersSwissArmyKnifeIndicatorState : IStreamingIndicatorStat
     private double _prevBs2;
     private int _index;
 
-    public EhlersSwissArmyKnifeIndicatorState(int length = 20, double delta = 0.1, InputName inputName = InputName.Close)
+    public EhlersSwissArmyKnifeIndicatorState(int length = 20, double delta = 0.1)
     {
         _length = Math.Max(1, length);
         _twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / _length, 0.99, 0.01);
         _deltaPrd = MathHelper.MinOrMax(2 * Math.PI * 2 * delta / _length, 0.99, 0.01);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length + 2);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch11.cs
+++ b/src/Streaming/StatefulIndicators.Batch11.cs
@@ -23,18 +23,6 @@ public sealed class EhlersLaguerreFilterState : IStreamingIndicatorState, IDispo
         _values = new PooledRingBuffer<double>(3);
     }
 
-    public EhlersLaguerreFilterState(double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = alpha;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(3);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersLaguerreFilter;
 
     public void Reset()
@@ -115,25 +103,6 @@ public sealed class EhlersReflexIndicatorState : IStreamingIndicatorState, IDisp
         _filterValues = new PooledRingBuffer<double>(_length);
     }
 
-    public EhlersReflexIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var period = 0.5 * _length;
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / period);
-        var b1 = 2 * a1 * Math.Cos(MathHelper.Sqrt2 * Math.PI / period);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(1);
-        _filterValues = new PooledRingBuffer<double>(_length);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersReflexIndicator;
 
     public void Reset()
@@ -206,19 +175,6 @@ public sealed class EhlersRelativeStrengthIndexInverseFisherTransformState : ISt
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersRelativeStrengthIndexInverseFisherTransformState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rsi = new RsiState(maType, length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRelativeStrengthIndexInverseFisherTransform;
 
     public void Reset()
@@ -267,19 +223,6 @@ public sealed class EhlersRelativeVigorIndexState : IStreamingIndicatorState, ID
         _rviSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersRelativeVigorIndexState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rviSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRelativeVigorIndex;
@@ -336,21 +279,6 @@ public sealed class EhlersRestoringPullIndicatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersRestoringPullIndicatorState(MovingAvgType maType, int minLength, int maxLength, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedMin = Math.Max(1, minLength);
-        var resolvedMax = Math.Max(maxLength, resolvedMin);
-        _sdfb = new EhlersSpectrumDerivedFilterBankEngine(resolvedMin, resolvedMax, length1, length2);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedMin);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRestoringPullIndicator;
 
     public void Reset()
@@ -397,17 +325,6 @@ public sealed class EhlersReverseExponentialMovingAverageIndicatorV1State : IStr
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersReverseExponentialMovingAverageIndicatorV1State(double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new ReverseEmaEngine(alpha);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersReverseExponentialMovingAverageIndicatorV1;
 
     public void Reset()
@@ -445,19 +362,6 @@ public sealed class EhlersReverseExponentialMovingAverageIndicatorV2State : IStr
         _trendEngine = new ReverseEmaEngine(trendAlpha);
         _cycleEngine = new ReverseEmaEngine(cycleAlpha);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersReverseExponentialMovingAverageIndicatorV2State(double trendAlpha, double cycleAlpha,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _trendEngine = new ReverseEmaEngine(trendAlpha);
-        _cycleEngine = new ReverseEmaEngine(cycleAlpha);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersReverseExponentialMovingAverageIndicatorV2;
@@ -512,23 +416,6 @@ public sealed class EhlersRocketRelativeStrengthIndexState : IStreamingIndicator
         _downSum = new RollingWindowSum(_length1);
         _mult = mult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersRocketRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, double obosLevel,
-        double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _values = new PooledRingBuffer<double>(_length1);
-        _upSum = new RollingWindowSum(_length1);
-        _downSum = new RollingWindowSum(_length1);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersRocketRelativeStrengthIndex;
@@ -623,27 +510,6 @@ public sealed class EhlersRoofingFilterIndicatorState : IStreamingIndicatorState
         _values = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersRoofingFilterIndicatorState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var alphaArg = Math.Min(MathHelper.Sqrt2 * Math.PI / resolved1, 0.99);
-        var alphaCos = Math.Cos(alphaArg);
-        _a1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        var a2 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / resolved2);
-        var b1 = 2 * a2 * Math.Cos(Math.Min(MathHelper.Sqrt2 * Math.PI / resolved2, 0.99));
-        _c2 = b1;
-        _c3 = -a2 * a2;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRoofingFilterIndicator;
 
     public void Reset()
@@ -709,20 +575,6 @@ public sealed class EhlersRoofingFilterV1State : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersRoofingFilterV1State(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _hp = new HighPassFilterV1Engine(resolved1, 1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRoofingFilterV1;
 
     public void Reset()
@@ -778,19 +630,6 @@ public sealed class EhlersSignalToNoiseRatioV1State : IStreamingIndicatorState, 
         _engine = new EhlersHilbertTransformIndicatorEngine(resolved, 0.635, 0.338);
         _ema = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersSignalToNoiseRatioV1State(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _engine = new EhlersHilbertTransformIndicatorEngine(resolved, 0.635, 0.338);
-        _ema = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersSignalToNoiseRatioV1;
@@ -858,18 +697,6 @@ public sealed class EhlersSignalToNoiseRatioV2State : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersSignalToNoiseRatioV2State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSignalToNoiseRatioV2;
 
     public void Reset()
@@ -927,17 +754,6 @@ public sealed class EhlersLaguerreRelativeStrengthIndexState : IStreamingIndicat
     {
         _gamma = gamma;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersLaguerreRelativeStrengthIndexState(double gamma, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _gamma = gamma;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersLaguerreRelativeStrengthIndex;
@@ -1008,20 +824,6 @@ public sealed class EhlersLaguerreRelativeStrengthIndexWithSelfAdjustingAlphaSta
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _highMax = new RollingWindowMax(_length);
-        _lowMin = new RollingWindowMin(_length);
-        _ratioSum = new RollingWindowSum(_length);
-    }
-
-    public EhlersLaguerreRelativeStrengthIndexWithSelfAdjustingAlphaState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _highMax = new RollingWindowMax(_length);
         _lowMin = new RollingWindowMin(_length);
         _ratioSum = new RollingWindowSum(_length);
@@ -1118,18 +920,6 @@ public sealed class EhlersLeadingIndicatorState : IStreamingIndicatorState
         _alpha1 = alpha1;
         _alpha2 = alpha2;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersLeadingIndicatorState(double alpha1, double alpha2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha1 = alpha1;
-        _alpha2 = alpha2;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersLeadingIndicator;
@@ -1244,22 +1034,6 @@ public sealed class EhlersMedianAverageAdaptiveFilterState : IStreamingIndicator
         _length = Math.Max(1, length);
         _threshold = threshold;
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(3);
-        _smthValues = new PooledRingBuffer<double>(_length);
-        _windowScratch = new double[_length];
-        _medianScratch = new double[_length];
-    }
-
-    public EhlersMedianAverageAdaptiveFilterState(int length, double threshold, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _threshold = threshold;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(3);
         _smthValues = new PooledRingBuffer<double>(_length);
         _windowScratch = new double[_length];
@@ -1440,45 +1214,6 @@ public sealed class EhlersMesaPredictIndicatorV1State : IStreamingIndicatorState
         _lowerLength = Math.Max(1, lowerLength);
         _upperLength = Math.Max(1, upperLength);
         _input = new StreamingInputResolver(inputName, null);
-
-        var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / _upperLength, -0.01, -0.99));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / _upperLength, 0.99, 0.01));
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = (1 + _c2 - _c3) / 4;
-
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / _lowerLength, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / _lowerLength, 0.99, 0.01));
-        _coef2 = b;
-        _coef3 = -a * a;
-        _coef1 = 1 - _coef2 - _coef3;
-
-        _pwrSum = new RollingWindowSum(_upperLength);
-        _ssfValues = new PooledRingBuffer<double>(_upperLength);
-        _bb1Array = new double[_upperLength + 2];
-        _bb2Array = new double[_upperLength + 2];
-        _coefArray = new double[_length2 + 2];
-        _coefAArray = new double[_length2 + 2];
-        _pArray = new double[_length2 + 2];
-        _coef1Array = new double[_lowerLength + 2];
-        _hCoefArray = new double[_length2 + 2];
-        _xxArray = new double[_upperLength + Math.Max(_length1, _length3) + 2];
-    }
-
-    public EhlersMesaPredictIndicatorV1State(int length1, int length2, int length3, int lowerLength, int upperLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _length3 = Math.Max(1, length3);
-        _lowerLength = Math.Max(1, lowerLength);
-        _upperLength = Math.Max(1, upperLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
 
         var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / _upperLength, -0.01, -0.99));
         var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / _upperLength, 0.99, 0.01));
@@ -1734,41 +1469,6 @@ public sealed class EhlersMesaPredictIndicatorV2State : IStreamingIndicatorState
         _yyArray = new double[bufferLength];
     }
 
-    public EhlersMesaPredictIndicatorV2State(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var resolvedLength3 = Math.Max(1, length3);
-        _length4 = Math.Max(1, length4);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-
-        _coefArray = new[] { 4.525, -8.45, 8.145, -4.045, 0.825 };
-
-        var a1 = MathHelper.Exp(MathHelper.MinOrMax(-1.414 * Math.PI / resolvedLength2, -0.01, -0.99));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(1.414 * Math.PI / resolvedLength2, 0.99, 0.01));
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = (1 + _c2 - _c3) / 4;
-
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-1.414 * Math.PI / resolvedLength3, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(1.414 * Math.PI / resolvedLength3, 0.99, 0.01));
-        _coef2 = b;
-        _coef3 = -a * a;
-        _coef1 = 1 - _coef2 - _coef3;
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength3);
-        _filtValues = new PooledRingBuffer<double>(_length1);
-        var bufferLength = Math.Max((2 * _length1) + 2, _length1 + _length4 + 2);
-        _xxArray = new double[bufferLength];
-        _yyArray = new double[bufferLength];
-    }
-
     public IndicatorName Name => IndicatorName.EhlersMesaPredictIndicatorV2;
 
     public void Reset()
@@ -1877,16 +1577,6 @@ public sealed class EhlersModifiedOptimumEllipticFilterState : IStreamingIndicat
     public EhlersModifiedOptimumEllipticFilterState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersModifiedOptimumEllipticFilterState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersModifiedOptimumEllipticFilter;
@@ -2057,27 +1747,6 @@ public sealed class EhlersModifiedStochasticIndicatorState : IStreamingIndicator
         _minWindow = new RollingWindowMin(resolved3);
     }
 
-    public EhlersModifiedStochasticIndicatorState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / resolved1);
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / resolved1, 0.99, 0.01));
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV1State(maType, resolved1, resolved2, selector);
-        _maxWindow = new RollingWindowMax(resolved3);
-        _minWindow = new RollingWindowMin(resolved3);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersModifiedStochasticIndicator;
 
     public void Reset()
@@ -2140,19 +1809,6 @@ public sealed class EhlersMovingAverageDifferenceIndicatorState : IStreamingIndi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersMovingAverageDifferenceIndicatorState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _shortSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _longSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersMovingAverageDifferenceIndicator;
 
     public void Reset()
@@ -2200,20 +1856,6 @@ public sealed class EhlersNoiseEliminationTechnologyState : IStreamingIndicatorS
         _length = Math.Max(1, length);
         _denom = 0.5 * _length * (_length - 1);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length);
-        _scratch = new double[_length + 1];
-    }
-
-    public EhlersNoiseEliminationTechnologyState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _denom = 0.5 * _length * (_length - 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length);
         _scratch = new double[_length + 1];
     }
@@ -2280,16 +1922,6 @@ public sealed class EhlersOptimumEllipticFilterState : IStreamingIndicatorState
     public EhlersOptimumEllipticFilterState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersOptimumEllipticFilterState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersOptimumEllipticFilter;
@@ -2365,27 +1997,6 @@ public sealed class EhlersPhaseAccumulationDominantCycleState : IStreamingIndica
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _hilbert = new EhlersHilbertTransformerEngine(_length1, resolved2, inputName);
-        _dPhaseValues = new PooledRingBuffer<double>(_length4);
-    }
-
-    public EhlersPhaseAccumulationDominantCycleState(int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _length3 = Math.Max(1, length3);
-        _length4 = Math.Max(1, length4);
-        var a1 = MathHelper.Exp(-1.414 * Math.PI / resolved2);
-        var b1 = 2 * a1 * Math.Cos(1.414 * Math.PI / resolved2);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _hilbert = new EhlersHilbertTransformerEngine(_length1, resolved2, selector);
         _dPhaseValues = new PooledRingBuffer<double>(_length4);
     }
 
@@ -2479,19 +2090,6 @@ public sealed class EhlersPhaseCalculationState : IStreamingIndicatorState, IDis
         _values = new PooledRingBuffer<double>(_length);
     }
 
-    public EhlersPhaseCalculationState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersPhaseCalculation;
 
     public void Reset()
@@ -2566,23 +2164,6 @@ public sealed class EhlersRecursiveMedianFilterState : IStreamingIndicatorState,
         _medianScratch = new double[resolved1];
     }
 
-    public EhlersRecursiveMedianFilterState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var alphaArg = MathHelper.MinOrMax(2 * Math.PI / resolved2, 0.99, 0.01);
-        var alphaArgCos = Math.Cos(alphaArg);
-        _alpha = alphaArgCos != 0 ? (alphaArgCos + Math.Sin(alphaArg) - 1) / alphaArgCos : 0;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(resolved1);
-        _medianScratch = new double[resolved1];
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRecursiveMedianFilter;
 
     public void Reset()
@@ -2650,27 +2231,6 @@ public sealed class EhlersRecursiveMedianOscillatorState : IStreamingIndicatorSt
         _medianScratch = new double[resolved1];
     }
 
-    public EhlersRecursiveMedianOscillatorState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        var alpha1Arg = MathHelper.MinOrMax(2 * Math.PI / resolved2, 0.99, 0.01);
-        var alpha1ArgCos = Math.Cos(alpha1Arg);
-        var alpha2Arg = MathHelper.MinOrMax((1 / MathHelper.Sqrt2) * 2 * Math.PI / resolved3, 0.99, 0.01);
-        var alpha2ArgCos = Math.Cos(alpha2Arg);
-        _alpha1 = alpha1ArgCos != 0 ? (alpha1ArgCos + Math.Sin(alpha1Arg) - 1) / alpha1ArgCos : 0;
-        _alpha2 = alpha2ArgCos != 0 ? (alpha2ArgCos + Math.Sin(alpha2Arg) - 1) / alpha2ArgCos : 0;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(resolved1);
-        _medianScratch = new double[resolved1];
-    }
-
     public IndicatorName Name => IndicatorName.EhlersRecursiveMedianOscillator;
 
     public void Reset()
@@ -2734,23 +2294,6 @@ public sealed class EhlersSimpleClipIndicatorState : IStreamingIndicatorState, I
         _length1 = Math.Max(1, length1);
         _length3 = Math.Max(1, length3);
         _input = new StreamingInputResolver(inputName, null);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _values = new PooledRingBuffer<double>(_length1);
-        _derivValues = new PooledRingBuffer<double>(_length3);
-        _clipValues = new PooledRingBuffer<double>(3);
-    }
-
-    public EhlersSimpleClipIndicatorState(MovingAvgType maType, int length1, int length2, int length3,
-        int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length3 = Math.Max(1, length3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length1);
         _derivValues = new PooledRingBuffer<double>(_length3);
@@ -2834,20 +2377,6 @@ public sealed class EhlersSimpleCycleIndicatorState : IStreamingIndicatorState, 
         _cycleValues = new PooledRingBuffer<double>(3);
     }
 
-    public EhlersSimpleCycleIndicatorState(double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = alpha;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(4);
-        _smoothValues = new PooledRingBuffer<double>(3);
-        _cycleValues = new PooledRingBuffer<double>(3);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSimpleCycleIndicator;
 
     public void Reset()
@@ -2918,19 +2447,6 @@ public sealed class EhlersSimpleDecyclerState : IStreamingIndicatorState, IDispo
         _hp = new HighPassFilterV1Engine(Math.Max(1, length), 1);
     }
 
-    public EhlersSimpleDecyclerState(int length, double upperPct, double lowerPct, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _upperPct = upperPct;
-        _lowerPct = lowerPct;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _hp = new HighPassFilterV1Engine(Math.Max(1, length), 1);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSimpleDecycler;
 
     public void Reset()
@@ -2978,20 +2494,6 @@ public sealed class EhlersSimpleDerivIndicatorState : IStreamingIndicatorState, 
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _values = new PooledRingBuffer<double>(_length);
-        _derivValues = new PooledRingBuffer<double>(3);
-    }
-
-    public EhlersSimpleDerivIndicatorState(MovingAvgType maType, int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length);
         _derivValues = new PooledRingBuffer<double>(3);
@@ -3063,20 +2565,6 @@ public sealed class EhlersSimpleWindowIndicatorState : IStreamingIndicatorState,
         _thirdSmoother = MovingAverageSmootherFactory.Create(maType, _length);
     }
 
-    public EhlersSimpleWindowIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _firstSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _secondSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _thirdSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSimpleWindowIndicator;
 
     public void Reset()
@@ -3132,18 +2620,6 @@ public sealed class EhlersSineWaveIndicatorV1State : IStreamingIndicatorState, I
     {
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _input = new StreamingInputResolver(inputName, null);
-        _smoothValues = new PooledRingBuffer<double>(64);
-    }
-
-    public EhlersSineWaveIndicatorV1State(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _smoothValues = new PooledRingBuffer<double>(64);
     }
 
@@ -3220,20 +2696,6 @@ public sealed class EhlersSineWaveIndicatorV2State : IStreamingIndicatorState, I
         _periodState = new AdaptiveCyberCyclePeriodState(resolved, alpha);
         _cycleState = new EhlersCyberCycleState(0.07, inputName);
         _input = new StreamingInputResolver(inputName, null);
-        _cycleValues = new PooledRingBuffer<double>(64);
-    }
-
-    public EhlersSineWaveIndicatorV2State(int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _periodState = new AdaptiveCyberCyclePeriodState(resolved, alpha);
-        _cycleState = new EhlersCyberCycleState(0.07, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _cycleValues = new PooledRingBuffer<double>(64);
     }
 
@@ -3327,30 +2789,6 @@ public sealed class EhlersSmoothedAdaptiveMomentumIndicatorState : IStreamingInd
         _f3Values = new PooledRingBuffer<double>(3);
     }
 
-    public EhlersSmoothedAdaptiveMomentumIndicatorState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var a1 = MathHelper.Exp(-Math.PI / resolved2);
-        var b1 = 2 * a1 * Math.Cos(1.738 * Math.PI / resolved2);
-        var c1 = MathHelper.Pow(a1, 2);
-        _coef2 = b1 + c1;
-        _coef3 = -1 * (c1 + (b1 * c1));
-        _coef4 = c1 * c1;
-        _coef1 = 1 - _coef2 - _coef3 - _coef4;
-        _periodState = new AdaptiveCyberCyclePeriodState(resolved1, 0.07);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _values = new PooledRingBuffer<double>(Math.Max(64, resolved1 * 2));
-        _f3Values = new PooledRingBuffer<double>(3);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSmoothedAdaptiveMomentumIndicator;
 
     public void Reset()
@@ -3430,26 +2868,6 @@ public sealed class EhlersSnakeUniversalTradingFilterState : IStreamingIndicator
         _powerSum = new RollingWindowSum(_length2);
     }
 
-    public EhlersSnakeUniversalTradingFilterState(MovingAvgType maType, int length1, int length2, double bw,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _l1 = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / (2 * _length1), 0.99, 0.01));
-        var g1 = Math.Cos(MathHelper.MinOrMax(bw * 2 * Math.PI / (2 * _length1), 0.99, 0.01));
-        _s1 = (1 / g1) - MathHelper.Sqrt(1 / MathHelper.Pow(g1, 2) - 1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(2);
-        _bpValues = new PooledRingBuffer<double>(2);
-        _powerSum = new RollingWindowSum(_length2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSnakeUniversalTradingFilter;
 
     public void Reset()
@@ -3517,21 +2935,6 @@ public sealed class EhlersSpearmanRankIndicatorState : IStreamingIndicatorState,
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length);
-        var arrayLength = Math.Max(50, _length + 1);
-        _priceArray = new double[arrayLength];
-        _rankArray = new double[arrayLength];
-    }
-
-    public EhlersSpearmanRankIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length);
         var arrayLength = Math.Max(50, _length + 1);
         _priceArray = new double[arrayLength];
@@ -3616,18 +3019,6 @@ public sealed class EhlersSpectrumDerivedFilterBankState : IStreamingIndicatorSt
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersSpectrumDerivedFilterBankState(int minLength, int maxLength, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new EhlersSpectrumDerivedFilterBankEngine(minLength, maxLength, length1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSpectrumDerivedFilterBank;
 
     public void Reset()
@@ -3679,22 +3070,6 @@ public sealed class EhlersSquelchIndicatorState : IStreamingIndicatorState, IDis
         _length2 = Math.Max(1, length2);
         _length3 = Math.Max(1, length3);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length1);
-        _v1Values = new PooledRingBuffer<double>(Math.Max(_length1, 4));
-        _dPhaseValues = new PooledRingBuffer<double>(_length3);
-    }
-
-    public EhlersSquelchIndicatorState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _length3 = Math.Max(1, length3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length1);
         _v1Values = new PooledRingBuffer<double>(Math.Max(_length1, 4));
         _dPhaseValues = new PooledRingBuffer<double>(_length3);
@@ -3799,21 +3174,6 @@ public sealed class EhlersStochasticCenterOfGravityOscillatorState : IStreamingI
         _v2Values = new PooledRingBuffer<double>(1);
     }
 
-    public EhlersStochasticCenterOfGravityOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _windowLength = Math.Max(_length, 2);
-        _cogState = new EhlersCenterofGravityOscillatorState(_length, selector);
-        _cgValues = new PooledRingBuffer<double>(_windowLength);
-        _v1Values = new PooledRingBuffer<double>(3);
-        _v2Values = new PooledRingBuffer<double>(1);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersStochasticCenterOfGravityOscillator;
 
     public void Reset()
@@ -3900,21 +3260,6 @@ public sealed class EhlersZeroMeanRoofingFilterState : IStreamingIndicatorState
         _roofingFilter = new EhlersHpLpRoofingFilterState(resolvedLength1, resolvedLength2, inputName);
     }
 
-    public EhlersZeroMeanRoofingFilterState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var alphaArg = Math.Min(2 * Math.PI / resolvedLength1, 0.99);
-        var alphaCos = Math.Cos(alphaArg);
-        _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        _roofingFilter = new EhlersHpLpRoofingFilterState(resolvedLength1, resolvedLength2, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersZeroMeanRoofingFilter;
 
     public void Reset()
@@ -3974,24 +3319,6 @@ public sealed class EhlersTrendflexIndicatorState : IStreamingIndicatorState, ID
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
-        _filterValues = new PooledRingBuffer<double>(_length);
-    }
-
-    public EhlersTrendflexIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var period = 0.5 * _length;
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / period);
-        var b1 = 2 * a1 * Math.Cos(MathHelper.Sqrt2 * Math.PI / period);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _filterValues = new PooledRingBuffer<double>(_length);
     }
 
@@ -4075,24 +3402,6 @@ public sealed class EhlersTrendExtractionState : IStreamingIndicatorState, IDisp
         _bpValues = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersTrendExtractionState(MovingAvgType maType, int length, double delta,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / _length, 0.99, 0.01));
-        var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / _length, 0.99, 0.01));
-        _alpha = MathHelper.MinOrMax(gamma - MathHelper.Sqrt((gamma * gamma) - 1), 0.99, 0.01);
-        _trendSmoother = MovingAverageSmootherFactory.Create(maType, _length * 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(2);
-        _bpValues = new PooledRingBuffer<double>(2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersTrendExtraction;
 
     public void Reset()
@@ -4158,23 +3467,6 @@ public sealed class EhlersUniversalTradingFilterState : IStreamingIndicatorState
         _hannLength = (int)Math.Ceiling(mult * resolvedLength1);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_hannLength);
-        _powerSum = new RollingWindowSum(resolvedLength2);
-    }
-
-    public EhlersUniversalTradingFilterState(MovingAvgType maType, int length1, int length2, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _hannLength = (int)Math.Ceiling(mult * resolvedLength1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_hannLength);
         _powerSum = new RollingWindowSum(resolvedLength2);
     }
@@ -4250,26 +3542,6 @@ public sealed class EhlersSuperPassbandFilterState : IStreamingIndicatorState, I
         _powerSum = new RollingWindowSum(resolvedLength2);
     }
 
-    public EhlersSuperPassbandFilterState(int fastLength, int slowLength, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _a1 = MathHelper.MinOrMax((double)resolvedLength1 / resolvedFast, 0.99, 0.01);
-        _a2 = MathHelper.MinOrMax((double)resolvedLength1 / resolvedSlow, 0.99, 0.01);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(1);
-        _espfValues = new PooledRingBuffer<double>(2);
-        _powerSum = new RollingWindowSum(resolvedLength2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSuperPassbandFilter;
 
     public void Reset()
@@ -4335,17 +3607,6 @@ public sealed class EhlersSuperSmootherFilterState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersSuperSmootherFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new EhlersSuperSmootherFilterEngine(Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersSuperSmootherFilter;
 
     public void Reset()
@@ -4380,17 +3641,6 @@ public sealed class EhlersTriangleMovingAverageState : IStreamingIndicatorState,
     {
         _smoother = new EhlersTriangleMovingAverageSmoother(length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersTriangleMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = new EhlersTriangleMovingAverageSmoother(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersTriangleMovingAverage;
@@ -4435,18 +3685,6 @@ public sealed class EhlersTriangleWindowIndicatorState : IStreamingIndicatorStat
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-    }
-
-    public EhlersTriangleWindowIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
     }
 
@@ -4507,24 +3745,6 @@ public sealed class EhlersTruncatedBandPassFilterState : IStreamingIndicatorStat
         var g1 = Math.Cos(bw * 2 * Math.PI / resolvedLength1);
         _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length2 + 2);
-        _scratch = new double[_length2 + 3];
-    }
-
-    public EhlersTruncatedBandPassFilterState(int length1, int length2, double bw,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _l1 = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01));
-        var g1 = Math.Cos(bw * 2 * Math.PI / resolvedLength1);
-        _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length2 + 2);
         _scratch = new double[_length2 + 3];
     }
@@ -4602,26 +3822,6 @@ public sealed class EhlersUniversalOscillatorState : IStreamingIndicatorState, I
         _values = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersUniversalOscillatorState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedSignal = Math.Max(1, signalLength);
-        var a1 = MathHelper.Exp(-MathHelper.MinOrMax(1.414 * Math.PI / resolvedLength, 0.99, 0.01));
-        var b1 = 2 * a1 * Math.Cos(1.414 * Math.PI / resolvedLength);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSignal);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersUniversalOscillator;
 
     public void Reset()
@@ -4688,16 +3888,6 @@ public sealed class EhlersZeroCrossingsDominantCycleState : IStreamingIndicatorS
         _bandPass = new EhlersBandPassFilterV1State(length, bw, inputName);
     }
 
-    public EhlersZeroCrossingsDominantCycleState(int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _bandPass = new EhlersBandPassFilterV1State(length, bw, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersZeroCrossingsDominantCycle;
 
     public void Reset()
@@ -4758,20 +3948,6 @@ public sealed class EhlersStochasticCyberCycleState : IStreamingIndicatorState, 
         _length = Math.Max(1, length);
         _windowLength = Math.Max(_length, 2);
         _cycleState = new EhlersCyberCycleState(alpha, inputName);
-        _cycleValues = new PooledRingBuffer<double>(_windowLength);
-        _stochValues = new PooledRingBuffer<double>(3);
-    }
-
-    public EhlersStochasticCyberCycleState(int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _windowLength = Math.Max(_length, 2);
-        _cycleState = new EhlersCyberCycleState(alpha, selector);
         _cycleValues = new PooledRingBuffer<double>(_windowLength);
         _stochValues = new PooledRingBuffer<double>(3);
     }
@@ -4861,21 +4037,6 @@ public sealed class EhlersStochasticState : IStreamingIndicatorState, IDisposabl
         _rfValues = new PooledRingBuffer<double>(_windowLength);
     }
 
-    public EhlersStochasticState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _windowLength = Math.Max(_length2, 2);
-        _roofingFilter = new EhlersRoofingFilterV1State(maType, Math.Max(1, length1), Math.Max(1, length3), selector);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length2);
-        _rfValues = new PooledRingBuffer<double>(_windowLength);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersStochastic;
 
     public void Reset()
@@ -4956,21 +4117,6 @@ public sealed class EhlersTripleDelayLineDetrenderState : IStreamingIndicatorSta
         _tmp2Values = new PooledRingBuffer<double>(12);
     }
 
-    public EhlersTripleDelayLineDetrenderState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _tmp1Values = new PooledRingBuffer<double>(6);
-        _tmp2Values = new PooledRingBuffer<double>(12);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersTripleDelayLineDetrender;
 
     public void Reset()
@@ -5043,23 +4189,6 @@ public sealed class EhlersVariableIndexDynamicAverageState : IStreamingIndicator
         _shortPowSum = new RollingWindowSum(resolvedFast);
         _longPowSum = new RollingWindowSum(resolvedSlow);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersVariableIndexDynamicAverageState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _shortSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _longSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _shortPowSum = new RollingWindowSum(resolvedFast);
-        _longPowSum = new RollingWindowSum(resolvedSlow);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersVariableIndexDynamicAverage;
@@ -5138,21 +4267,6 @@ public sealed class EhlersZeroLagExponentialMovingAverageState : IStreamingIndic
         _values = new PooledRingBuffer<double>(_lag);
     }
 
-    public EhlersZeroLagExponentialMovingAverageState(MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _lag = MathHelper.MinOrMax((int)Math.Floor((double)(resolved - 1) / 2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _values = new PooledRingBuffer<double>(_lag);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersZeroLagExponentialMovingAverage;
 
     public void Reset()
@@ -5212,25 +4326,6 @@ public sealed class EhlersVossPredictiveFilterState : IStreamingIndicatorState, 
         var g1 = Math.Cos(bw * 2 * Math.PI / resolved);
         _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(2);
-        _filterValues = new PooledRingBuffer<double>(2);
-        _vossValues = new PooledRingBuffer<double>(_order);
-    }
-
-    public EhlersVossPredictiveFilterState(int length, double predict, double bw,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _order = MathHelper.MinOrMax((int)Math.Ceiling(3 * predict));
-        _f1 = Math.Cos(2 * Math.PI / resolved);
-        var g1 = Math.Cos(bw * 2 * Math.PI / resolved);
-        _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(2);
         _filterValues = new PooledRingBuffer<double>(2);
         _vossValues = new PooledRingBuffer<double>(_order);
@@ -5327,20 +4422,6 @@ public sealed class EhlersSwissArmyKnifeIndicatorState : IStreamingIndicatorStat
         _twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / _length, 0.99, 0.01);
         _deltaPrd = MathHelper.MinOrMax(2 * Math.PI * 2 * delta / _length, 0.99, 0.01);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length + 2);
-    }
-
-    public EhlersSwissArmyKnifeIndicatorState(int length, double delta, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / _length, 0.99, 0.01);
-        _deltaPrd = MathHelper.MinOrMax(2 * Math.PI * 2 * delta / _length, 0.99, 0.01);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length + 2);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch11.cs
+++ b/src/Streaming/StatefulIndicators.Batch11.cs
@@ -2705,7 +2705,7 @@ public sealed class EhlersSineWaveIndicatorV2State : IStreamingIndicatorState, I
         var value = _input.GetValue(bar);
         var period = _periodState.Next(value, isFinal);
         var cycle = _cycleState.Update(bar, isFinal, includeOutputs: false).Value;
-        var dcPeriod = Math.Max(1, (int)Math.Ceiling(period));
+        var dcPeriod = Math.Max(1, MathHelper.CeilingCycle(period));
 
         double realPart = 0;
         double imagPart = 0;

--- a/src/Streaming/StatefulIndicators.Batch12.cs
+++ b/src/Streaming/StatefulIndicators.Batch12.cs
@@ -21,19 +21,6 @@ public sealed class ElasticVolumeWeightedMovingAverageV1State : IStreamingIndica
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ElasticVolumeWeightedMovingAverageV1State(MovingAvgType maType, int length, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _mult = mult;
-        _volumeSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ElasticVolumeWeightedMovingAverageV1;
 
     public void Reset()
@@ -86,17 +73,6 @@ public sealed class ElasticVolumeWeightedMovingAverageV2State : IStreamingIndica
     {
         _volumeSum = new RollingWindowSum(Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ElasticVolumeWeightedMovingAverageV2State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _volumeSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ElasticVolumeWeightedMovingAverageV2;
@@ -230,25 +206,6 @@ public sealed class ElderSafeZoneStopsState : IStreamingIndicatorState, IDisposa
         _factor = factor;
     }
 
-    public ElderSafeZoneStopsState(MovingAvgType maType, int length1, int length2, int length3, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _dmMinusSum = new RollingWindowSum(Math.Max(1, length2));
-        _dmMinusCountSum = new RollingWindowSum(Math.Max(1, length2));
-        _dmPlusSum = new RollingWindowSum(Math.Max(1, length2));
-        _dmPlusCountSum = new RollingWindowSum(Math.Max(1, length2));
-        _safeZMinusMax = new RollingWindowMax(Math.Max(1, length3));
-        _safeZPlusMin = new RollingWindowMin(Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _factor = factor;
-    }
-
     public IndicatorName Name => IndicatorName.ElderSafeZoneStops;
 
     public void Reset()
@@ -339,20 +296,6 @@ public sealed class ElliottWaveOscillatorState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ElliottWaveOscillatorState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ElliottWaveOscillator;
 
     public void Reset()
@@ -414,24 +357,6 @@ public sealed class EmaWaveIndicatorState : IStreamingIndicatorState, IDisposabl
         _wbSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
         _wcSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EmaWaveIndicatorState(int length1, int length2, int length3, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _emaA = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length1));
-        _emaB = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length2));
-        _emaC = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length3));
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _waSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
-        _wbSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
-        _wcSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EmaWaveIndicator;
@@ -508,28 +433,6 @@ public sealed class EndPointMovingAverageState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EndPointMovingAverageState(int length, int offset, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _weights = new double[resolved];
-        double weightSum = 0;
-        for (var j = 0; j < resolved; j++)
-        {
-            var weight = resolved - j - offset;
-            _weights[j] = weight;
-            weightSum += weight;
-        }
-
-        _weightSum = weightSum;
-        _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EndPointMovingAverage;
 
     public void Reset()
@@ -590,22 +493,6 @@ public sealed class EnhancedIndexState : IStreamingIndicatorState, IDisposable
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, smaLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EnhancedIndexState(MovingAvgType maType, int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var smaLength = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, smaLength);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EnhancedIndex;
@@ -678,27 +565,6 @@ public sealed class EnhancedWilliamsRState : IStreamingIndicatorState, IDisposab
         _volSma = MovingAverageSmootherFactory.Create(maType, smaLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EnhancedWilliamsRState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(2, length);
-        _srcMax = new RollingWindowMax(resolved);
-        _srcMin = new RollingWindowMin(resolved);
-        _volMax = new RollingWindowMax(resolved);
-        _volMin = new RollingWindowMin(resolved);
-        _af = length < 10 ? 0.25 : ((double)length / 32) - 0.0625;
-        var smaLength = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
-        _srcSma = MovingAverageSmootherFactory.Create(maType, smaLength);
-        _volSma = MovingAverageSmootherFactory.Create(maType, smaLength);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EnhancedWilliamsR;
@@ -790,19 +656,6 @@ public sealed class EquityMovingAverageState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EquityMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _chgXSum = new RollingWindowSum(resolved);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EquityMovingAverage;
 
     public void Reset()
@@ -881,22 +734,6 @@ public sealed class ErgodicCandlestickOscillatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ErgodicCandlestickOscillatorState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _xcoEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _xcoEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _xhlEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _xhlEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ErgodicCandlestickOscillator;
 
     public void Reset()
@@ -970,24 +807,6 @@ public sealed class ErgodicCommoditySelectionIndexState : IStreamingIndicatorSta
         _adx = MovingAverageSmootherFactory.Create(maType, _length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ErgodicCommoditySelectionIndexState(MovingAvgType maType, int length, int smoothLength, double pointValue,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _k = 100 * (pointValue / MathHelper.Sqrt(_length) / (150 + smoothLength));
-        _dmPlus = MovingAverageSmootherFactory.Create(maType, _length);
-        _dmMinus = MovingAverageSmootherFactory.Create(maType, _length);
-        _tr = MovingAverageSmootherFactory.Create(maType, _length);
-        _adx = MovingAverageSmootherFactory.Create(maType, _length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicCommoditySelectionIndex;
@@ -1088,21 +907,6 @@ public sealed class ErgodicMeanDeviationIndicatorState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ErgodicMeanDeviationIndicatorState(MovingAvgType maType, int length1, int length2, int length3,
-        int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ma1Ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _emdi = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ErgodicMeanDeviationIndicator;
 
     public void Reset()
@@ -1161,20 +965,6 @@ public sealed class ErgodicMovingAverageConvergenceDivergenceState : IStreamingI
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ErgodicMovingAverageConvergenceDivergenceState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ErgodicMovingAverageConvergenceDivergence;
 
     public void Reset()
@@ -1230,20 +1020,6 @@ public sealed class ErgodicPercentagePriceOscillatorState : IStreamingIndicatorS
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ErgodicPercentagePriceOscillatorState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicPercentagePriceOscillator;
@@ -1312,24 +1088,6 @@ public sealed class ErgodicTrueStrengthIndexV1State : IStreamingIndicatorState, 
         _absDiffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ErgodicTrueStrengthIndexV1State(MovingAvgType maType, int length1, int length2, int length3,
-        int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _diffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _absDiffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _diffEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _absDiffEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _diffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _absDiffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicTrueStrengthIndexV1;
@@ -1431,30 +1189,6 @@ public sealed class ErgodicTrueStrengthIndexV2State : IStreamingIndicatorState, 
         _absDiffEma6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ErgodicTrueStrengthIndexV2State(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int length6, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _diffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _absDiffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _diffEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _absDiffEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _diffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _absDiffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _diffEma4 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _absDiffEma4 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _diffEma5 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _absDiffEma5 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _diffEma6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
-        _absDiffEma6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicTrueStrengthIndexV2;
@@ -1559,20 +1293,6 @@ public sealed class FallingRisingFilterState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FallingRisingFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = (double)2 / (resolved + 1);
-        _tempMax = new RollingWindowMax(resolved);
-        _tempMin = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FallingRisingFilter;
 
     public void Reset()
@@ -1666,46 +1386,6 @@ public sealed class FareySequenceWeightedMovingAverageState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FareySequenceWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var array = new double[4] { 0, 1, 1, resolved };
-        List<double> resList = new();
-
-        while (array[2] <= resolved)
-        {
-            var a = array[0];
-            var b = array[1];
-            var c = array[2];
-            var d = array[3];
-            var k = Math.Floor((resolved + b) / array[3]);
-
-            array[0] = c;
-            array[1] = d;
-            array[2] = (k * c) - a;
-            array[3] = (k * d) - b;
-
-            var res = array[1] != 0 ? Math.Round(array[0] / array[1], 3) : 0;
-            resList.Insert(0, res);
-        }
-
-        _weights = resList.ToArray();
-        double weightSum = 0;
-        for (var i = 0; i < _weights.Length; i++)
-        {
-            weightSum += _weights[i];
-        }
-
-        _weightSum = weightSum;
-        _values = new PooledRingBuffer<double>(_weights.Length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FareySequenceWeightedMovingAverage;
 
     public void Reset()
@@ -1766,21 +1446,6 @@ public sealed class FastandSlowKurtosisOscillatorState : IStreamingIndicatorStat
         _values = new PooledRingBuffer<double>(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FastandSlowKurtosisOscillatorState(MovingAvgType maType, int length, double ratio,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _ratio = ratio;
-        _values = new PooledRingBuffer<double>(_length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FastandSlowKurtosisOscillator;

--- a/src/Streaming/StatefulIndicators.Batch12.cs
+++ b/src/Streaming/StatefulIndicators.Batch12.cs
@@ -14,11 +14,11 @@ public sealed class ElasticVolumeWeightedMovingAverageV1State : IStreamingIndica
     private bool _hasPrev;
 
     public ElasticVolumeWeightedMovingAverageV1State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 40, double mult = 20, InputName inputName = InputName.Close)
+        int length = 40, double mult = 20)
     {
         _mult = mult;
         _volumeSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ElasticVolumeWeightedMovingAverageV1;
@@ -69,10 +69,10 @@ public sealed class ElasticVolumeWeightedMovingAverageV2State : IStreamingIndica
     private double _prevEvwma;
     private bool _hasPrev;
 
-    public ElasticVolumeWeightedMovingAverageV2State(int length = 14, InputName inputName = InputName.Close)
+    public ElasticVolumeWeightedMovingAverageV2State(int length = 14)
     {
         _volumeSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ElasticVolumeWeightedMovingAverageV2;
@@ -193,7 +193,7 @@ public sealed class ElderSafeZoneStopsState : IStreamingIndicatorState, IDisposa
     private bool _hasPrev;
 
     public ElderSafeZoneStopsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 63,
-        int length2 = 22, int length3 = 3, double factor = 2.5, InputName inputName = InputName.Close)
+        int length2 = 22, int length3 = 3, double factor = 2.5)
     {
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _dmMinusSum = new RollingWindowSum(Math.Max(1, length2));
@@ -202,7 +202,7 @@ public sealed class ElderSafeZoneStopsState : IStreamingIndicatorState, IDisposa
         _dmPlusCountSum = new RollingWindowSum(Math.Max(1, length2));
         _safeZMinusMax = new RollingWindowMax(Math.Max(1, length3));
         _safeZPlusMin = new RollingWindowMin(Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _factor = factor;
     }
 
@@ -288,12 +288,12 @@ public sealed class ElliottWaveOscillatorState : IStreamingIndicatorState, IDisp
     private readonly StreamingInputResolver _input;
 
     public ElliottWaveOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5,
-        int slowLength = 34, InputName inputName = InputName.Close)
+        int slowLength = 34)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ElliottWaveOscillator;
@@ -346,8 +346,7 @@ public sealed class EmaWaveIndicatorState : IStreamingIndicatorState, IDisposabl
     private readonly IMovingAverageSmoother _wcSmoother;
     private readonly StreamingInputResolver _input;
 
-    public EmaWaveIndicatorState(int length1 = 5, int length2 = 25, int length3 = 50, int smoothLength = 4,
-        InputName inputName = InputName.Close)
+    public EmaWaveIndicatorState(int length1 = 5, int length2 = 25, int length3 = 50, int smoothLength = 4)
     {
         _emaA = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length1));
         _emaB = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length2));
@@ -356,7 +355,7 @@ public sealed class EmaWaveIndicatorState : IStreamingIndicatorState, IDisposabl
         _waSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
         _wbSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
         _wcSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSmooth);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EmaWaveIndicator;
@@ -416,7 +415,7 @@ public sealed class EndPointMovingAverageState : IStreamingIndicatorState, IDisp
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public EndPointMovingAverageState(int length = 11, int offset = 4, InputName inputName = InputName.Close)
+    public EndPointMovingAverageState(int length = 11, int offset = 4)
     {
         var resolved = Math.Max(1, length);
         _weights = new double[resolved];
@@ -430,7 +429,7 @@ public sealed class EndPointMovingAverageState : IStreamingIndicatorState, IDisp
 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EndPointMovingAverage;
@@ -484,7 +483,7 @@ public sealed class EnhancedIndexState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public EnhancedIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int signalLength = 8, InputName inputName = InputName.Close)
+        int signalLength = 8)
     {
         var resolved = Math.Max(1, length);
         var smaLength = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
@@ -492,7 +491,7 @@ public sealed class EnhancedIndexState : IStreamingIndicatorState, IDisposable
         _lowWindow = new RollingWindowMin(resolved);
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, smaLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EnhancedIndex;
@@ -552,7 +551,7 @@ public sealed class EnhancedWilliamsRState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public EnhancedWilliamsRState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int signalLength = 5, InputName inputName = InputName.Close)
+        int signalLength = 5)
     {
         var resolved = Math.Max(2, length);
         _srcMax = new RollingWindowMax(resolved);
@@ -564,7 +563,7 @@ public sealed class EnhancedWilliamsRState : IStreamingIndicatorState, IDisposab
         _srcSma = MovingAverageSmootherFactory.Create(maType, smaLength);
         _volSma = MovingAverageSmootherFactory.Create(maType, smaLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EnhancedWilliamsR;
@@ -647,13 +646,12 @@ public sealed class EquityMovingAverageState : IStreamingIndicatorState, IDispos
     private double _chgXCumSum;
     private bool _hasPrev;
 
-    public EquityMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public EquityMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _chgXSum = new RollingWindowSum(resolved);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EquityMovingAverage;
@@ -724,14 +722,14 @@ public sealed class ErgodicCandlestickOscillatorState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public ErgodicCandlestickOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 32, int length2 = 12, InputName inputName = InputName.Close)
+        int length1 = 32, int length2 = 12)
     {
         _xcoEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _xcoEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _xhlEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _xhlEma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicCandlestickOscillator;
@@ -797,7 +795,7 @@ public sealed class ErgodicCommoditySelectionIndexState : IStreamingIndicatorSta
     private bool _hasPrev;
 
     public ErgodicCommoditySelectionIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length = 32, int smoothLength = 5, double pointValue = 1, InputName inputName = InputName.Close)
+        int length = 32, int smoothLength = 5, double pointValue = 1)
     {
         _length = Math.Max(1, length);
         _k = 100 * (pointValue / MathHelper.Sqrt(_length) / (150 + smoothLength));
@@ -806,7 +804,7 @@ public sealed class ErgodicCommoditySelectionIndexState : IStreamingIndicatorSta
         _tr = MovingAverageSmootherFactory.Create(maType, _length);
         _adx = MovingAverageSmootherFactory.Create(maType, _length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicCommoditySelectionIndex;
@@ -897,14 +895,13 @@ public sealed class ErgodicMeanDeviationIndicatorState : IStreamingIndicatorStat
     private readonly StreamingInputResolver _input;
 
     public ErgodicMeanDeviationIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 32, int length2 = 5, int length3 = 5, int signalLength = 5,
-        InputName inputName = InputName.Close)
+        int length1 = 32, int length2 = 5, int length3 = 5, int signalLength = 5)
     {
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ma1Ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _emdi = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicMeanDeviationIndicator;
@@ -957,12 +954,12 @@ public sealed class ErgodicMovingAverageConvergenceDivergenceState : IStreamingI
 
     public ErgodicMovingAverageConvergenceDivergenceState(
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 32, int length2 = 5,
-        int length3 = 5, InputName inputName = InputName.Close)
+        int length3 = 5)
     {
         _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicMovingAverageConvergenceDivergence;
@@ -1014,12 +1011,12 @@ public sealed class ErgodicPercentagePriceOscillatorState : IStreamingIndicatorS
 
     public ErgodicPercentagePriceOscillatorState(
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 32, int length2 = 5,
-        int length3 = 5, InputName inputName = InputName.Close)
+        int length3 = 5)
     {
         _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicPercentagePriceOscillator;
@@ -1077,8 +1074,7 @@ public sealed class ErgodicTrueStrengthIndexV1State : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public ErgodicTrueStrengthIndexV1State(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 4, int length2 = 8, int length3 = 6, int signalLength = 3,
-        InputName inputName = InputName.Close)
+        int length1 = 4, int length2 = 8, int length3 = 6, int signalLength = 3)
     {
         _diffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _absDiffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
@@ -1087,7 +1083,7 @@ public sealed class ErgodicTrueStrengthIndexV1State : IStreamingIndicatorState, 
         _diffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _absDiffEma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicTrueStrengthIndexV1;
@@ -1173,7 +1169,7 @@ public sealed class ErgodicTrueStrengthIndexV2State : IStreamingIndicatorState, 
 
     public ErgodicTrueStrengthIndexV2State(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length1 = 21, int length2 = 9, int length3 = 9, int length4 = 17, int length5 = 6,
-        int length6 = 2, int signalLength = 2, InputName inputName = InputName.Close)
+        int length6 = 2, int signalLength = 2)
     {
         _diffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _absDiffEma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
@@ -1188,7 +1184,7 @@ public sealed class ErgodicTrueStrengthIndexV2State : IStreamingIndicatorState, 
         _diffEma6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
         _absDiffEma6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ErgodicTrueStrengthIndexV2;
@@ -1284,13 +1280,13 @@ public sealed class FallingRisingFilterState : IStreamingIndicatorState, IDispos
     private double _prevError;
     private bool _hasPrev;
 
-    public FallingRisingFilterState(int length = 14, InputName inputName = InputName.Close)
+    public FallingRisingFilterState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _alpha = (double)2 / (resolved + 1);
         _tempMax = new RollingWindowMax(resolved);
         _tempMin = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FallingRisingFilter;
@@ -1351,7 +1347,7 @@ public sealed class FareySequenceWeightedMovingAverageState : IStreamingIndicato
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public FareySequenceWeightedMovingAverageState(int length = 5, InputName inputName = InputName.Close)
+    public FareySequenceWeightedMovingAverageState(int length = 5)
     {
         var resolved = Math.Max(1, length);
         var array = new double[4] { 0, 1, 1, resolved };
@@ -1383,7 +1379,7 @@ public sealed class FareySequenceWeightedMovingAverageState : IStreamingIndicato
 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(_weights.Length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FareySequenceWeightedMovingAverage;
@@ -1439,13 +1435,13 @@ public sealed class FastandSlowKurtosisOscillatorState : IStreamingIndicatorStat
     private double _prevFsk;
 
     public FastandSlowKurtosisOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 3, double ratio = 0.03, InputName inputName = InputName.Close)
+        int length = 3, double ratio = 0.03)
     {
         _length = Math.Max(1, length);
         _ratio = ratio;
         _values = new PooledRingBuffer<double>(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FastandSlowKurtosisOscillator;

--- a/src/Streaming/StatefulIndicators.Batch13.cs
+++ b/src/Streaming/StatefulIndicators.Batch13.cs
@@ -22,14 +22,14 @@ public sealed class FastandSlowRelativeStrengthIndexOscillatorState : IStreaming
     private readonly StreamingInputResolver _input;
 
     public FastandSlowRelativeStrengthIndexOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length1 = 3, int length2 = 6, int length3 = 9, int length4 = 6, InputName inputName = InputName.Close)
+        int length1 = 3, int length2 = 6, int length3 = 9, int length4 = 6)
     {
         _fskLength = Math.Max(1, length1);
         _fskValues = new PooledRingBuffer<double>(_fskLength);
         _rsi = new RsiState(maType, Math.Max(1, length3));
         _fskSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FastandSlowRelativeStrengthIndexOscillator;
@@ -98,13 +98,13 @@ public sealed class FastandSlowStochasticOscillatorState : IStreamingIndicatorSt
     private readonly IMovingAverageSmoother _signalSmoother;
 
     public FastandSlowStochasticOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length1 = 3, int length2 = 6, int length3 = 9, int length4 = 9, InputName inputName = InputName.Close)
+        int length1 = 3, int length2 = 6, int length3 = 9, int length4 = 9)
     {
-        _fsk = new FastandSlowKurtosisOscillatorState(maType, Math.Max(1, length1), 0.03, inputName);
+        _fsk = new FastandSlowKurtosisOscillatorState(maType, Math.Max(1, length1), 0.03);
         _fskSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         // StochasticOscillator operates on stockData (close) in batch, not on FSK values
         // Use length3 for stochastic length, smoothLength1=1 and smoothLength2=1 (no smoothing for raw fastK)
-        _stoch = new StochasticOscillatorState(maType, Math.Max(1, length3), 1, 1, inputName);
+        _stoch = new StochasticOscillatorState(maType, Math.Max(1, length3), 1, 1);
         _slowKSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
     }
@@ -170,8 +170,7 @@ public sealed class FastSlowDegreeOscillatorState : IStreamingIndicatorState, ID
     private int _index;
 
     public FastSlowDegreeOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 100, int fastLength = 3, int slowLength = 2, int signalLength = 14,
-        InputName inputName = InputName.Close)
+        int length = 100, int fastLength = 3, int slowLength = 2, int signalLength = 14)
     {
         _length = Math.Max(1, length);
         var resolvedFast = Math.Max(1, fastLength);
@@ -183,7 +182,7 @@ public sealed class FastSlowDegreeOscillatorState : IStreamingIndicatorState, ID
         _slowF2bSum = new RollingWindowSum(resolvedSlow);
         _slowVWSum = new RollingWindowSum(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FastSlowDegreeOscillator;
@@ -282,14 +281,14 @@ public sealed class FearAndGreedIndicatorState : IStreamingIndicatorState, IDisp
     private bool _hasPrev;
 
     public FearAndGreedIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int fastLength = 10, int slowLength = 30, int smoothLength = 2, InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 30, int smoothLength = 2)
     {
         _fastTrUp = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _fastTrDn = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowTrUp = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _slowTrDn = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FearAndGreedIndicator;
@@ -432,14 +431,14 @@ public sealed class FibonacciRetraceState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
 
     public FibonacciRetraceState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length1 = 15, int length2 = 50, double factor = 0.382, InputName inputName = InputName.Close)
+        int length1 = 15, int length2 = 50, double factor = 0.382)
     {
         _length2 = Math.Max(1, length2);
         _factor = factor;
         _highWindow = new RollingWindowMax(_length2);
         _lowWindow = new RollingWindowMin(_length2);
         _wma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FibonacciRetrace;
@@ -489,7 +488,7 @@ public sealed class FibonacciWeightedMovingAverageState : IStreamingIndicatorSta
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public FibonacciWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public FibonacciWeightedMovingAverageState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         var phi = (1 + Math.Sqrt(5)) / 2;
@@ -505,7 +504,7 @@ public sealed class FibonacciWeightedMovingAverageState : IStreamingIndicatorSta
 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FibonacciWeightedMovingAverage;
@@ -561,12 +560,12 @@ public sealed class FiniteVolumeElementsState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public FiniteVolumeElementsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 22, double factor = 0.3, InputName inputName = InputName.Close)
+        int length = 22, double factor = 0.3)
     {
         _length = Math.Max(1, length);
         _factor = factor;
         _volumeSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FiniteVolumeElements;
@@ -630,7 +629,7 @@ public sealed class FireflyOscillatorState : IStreamingIndicatorState, IDisposab
     private double _v2Value;
 
     public FireflyOscillatorState(MovingAvgType maType = MovingAvgType.ZeroLagExponentialMovingAverage,
-        int length = 10, int smoothLength = 3, InputName inputName = InputName.Close)
+        int length = 10, int smoothLength = 3)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedSmooth = Math.Max(1, smoothLength);
@@ -640,7 +639,7 @@ public sealed class FireflyOscillatorState : IStreamingIndicatorState, IDisposab
         _v7Smoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
         _wwSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _maxWindow = new RollingWindowMax(resolvedSmooth);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FireflyOscillator;
@@ -710,16 +709,16 @@ public sealed class FisherLeastSquaresMovingAverageState : IStreamingIndicatorSt
     private int _index;
 
     public FisherLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 100, InputName inputName = InputName.Close)
+        int length = 100)
     {
         _length = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _indexSma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDevSrc = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDevSrc = new StandardDeviationVolatilityState(maType, _length);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
         _diffSum = new RollingWindowSum(_length);
         _absDiffSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FisherLeastSquaresMovingAverage;
@@ -810,7 +809,7 @@ public sealed class FisherTransformStochasticOscillatorState : IStreamingIndicat
     private readonly StreamingInputResolver _input;
 
     public FisherTransformStochasticOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 2, int stochLength = 30, int smoothLength = 5, InputName inputName = InputName.Close)
+        int length = 2, int stochLength = 30, int smoothLength = 5)
     {
         var resolvedLength = Math.Max(1, length);
         _wma1 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
@@ -827,7 +826,7 @@ public sealed class FisherTransformStochasticOscillatorState : IStreamingIndicat
         _minWindow = new RollingWindowMin(Math.Max(1, stochLength));
         _numSum = new RollingWindowSum(Math.Max(1, smoothLength));
         _denomSum = new RollingWindowSum(Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FisherTransformStochasticOscillator;
@@ -919,13 +918,13 @@ public sealed class FlaggingBandsState : IStreamingIndicatorState, IDisposable
     private double _prevTos;
     private bool _hasPrevTos;
 
-    public FlaggingBandsState(int length = 14, InputName inputName = InputName.Close)
+    public FlaggingBandsState(int length = 14)
     {
         _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length);
         _aValues = new PooledRingBuffer<double>(3);
         _bValues = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FlaggingBands;
@@ -1063,13 +1062,13 @@ public sealed class FoldedRelativeStrengthIndexState : IStreamingIndicatorState,
     private readonly StreamingInputResolver _input;
 
     public FoldedRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _length = Math.Max(1, length);
         _rsi = new RsiState(maType, _length);
         _absSum = new RollingWindowSum(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FoldedRelativeStrengthIndex;
@@ -1118,10 +1117,10 @@ public sealed class ForceIndexState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public ForceIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ForceIndex;
@@ -1172,10 +1171,10 @@ public sealed class ForecastOscillatorState : IStreamingIndicatorState, IDisposa
     private bool _hasPrev;
 
     public ForecastOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 3, InputName inputName = InputName.Close)
+        int length = 3)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ForecastOscillator;
@@ -1374,7 +1373,7 @@ public sealed class FreedomOfMovementState : IStreamingIndicatorState, IDisposab
     private double _vBymValue;
 
     public FreedomOfMovementState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 60, InputName inputName = InputName.Close)
+        int length = 60)
     {
         _length = Math.Max(1, length);
         _volumeSmoother = MovingAverageSmootherFactory.Create(maType, _length);
@@ -1385,7 +1384,7 @@ public sealed class FreedomOfMovementState : IStreamingIndicatorState, IDisposab
         _relVolMin = new RollingWindowMin(_length);
         _vBymSum = new RollingWindowSum(_length);
         _vBymStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _vBymValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FreedomOfMovement;
@@ -1546,10 +1545,9 @@ public sealed class FXSniperIndicatorState : IStreamingIndicatorState, IDisposab
     private double _e6;
 
     public FXSniperIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int cciLength = 14, int t3Length = 5, double b = MathHelper.InversePhi,
-        InputName inputName = InputName.TypicalPrice)
+        int cciLength = 14, int t3Length = 5, double b = MathHelper.InversePhi)
     {
-        _cciState = new CommodityChannelIndexState(inputName, maType, Math.Max(1, cciLength), 0.015);
+        _cciState = new CommodityChannelIndexState(maType, Math.Max(1, cciLength), 0.015);
         var b2 = b * b;
         var b3 = b2 * b;
         _c1 = -b3;
@@ -1630,11 +1628,11 @@ public sealed class GainLossMovingAverageState : IStreamingIndicatorState, IDisp
     private bool _hasPrev;
 
     public GainLossMovingAverageState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length = 14, int signalLength = 7, InputName inputName = InputName.Close)
+        int length = 14, int signalLength = 7)
     {
         _glmaSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GainLossMovingAverage;
@@ -1693,11 +1691,11 @@ public sealed class GannHiLoActivatorState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public GannHiLoActivatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 3, InputName inputName = InputName.Close)
+        int length = 3)
     {
         _highMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _lowMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GannHiLoActivator;

--- a/src/Streaming/StatefulIndicators.Batch13.cs
+++ b/src/Streaming/StatefulIndicators.Batch13.cs
@@ -49,15 +49,16 @@ public sealed class FastandSlowRelativeStrengthIndexOscillatorState : IStreaming
         var value = _input.GetValue(bar);
         var rsi = _rsi.Next(value, isFinal);
 
-        // Compute FSK on RSI values (matching batch chaining behavior where FSK sees RSI via CustomValuesList)
+        // The fast-and-slow kurtosis of the source, beside the RSI of the source. It used to be taken of the RSI,
+        // copying a batch that read the RSI it had just published back as the kurtosis input.
         var hasMomentum = _fskValues.Count >= _fskLength;
-        var prevRsi = hasMomentum ? EhlersStreamingWindow.GetOffsetValue(_fskValues, rsi, _fskLength) : 0;
-        var momentum = hasMomentum ? rsi - prevRsi : 0;
+        var prevValue = hasMomentum ? EhlersStreamingWindow.GetOffsetValue(_fskValues, value, _fskLength) : 0;
+        var momentum = hasMomentum ? value - prevValue : 0;
         var fsk = (FskRatio * (momentum - _fskPrevMomentum)) + ((1 - FskRatio) * _fskPrevFsk);
 
         if (isFinal)
         {
-            _fskValues.TryAdd(rsi, out _);
+            _fskValues.TryAdd(value, out _);
             _fskPrevMomentum = momentum;
             _fskPrevFsk = fsk;
         }

--- a/src/Streaming/StatefulIndicators.Batch13.cs
+++ b/src/Streaming/StatefulIndicators.Batch13.cs
@@ -1782,7 +1782,7 @@ public sealed class FunctionToCandlesState : IStreamingIndicatorState, IDisposab
     }
 }
 
-public sealed class FXSniperIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class FXSniperIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly CommodityChannelIndexState _cciState;
     private readonly double _c1;
@@ -1835,6 +1835,13 @@ public sealed class FXSniperIndicatorState : IStreamingIndicatorState, IDisposab
     }
 
     public IndicatorName Name => IndicatorName.FXSniperIndicator;
+
+    // No resolver of its own: the input was handed to these inner states, so they are the
+    // ones that must switch to reading the close.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_cciState).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch13.cs
+++ b/src/Streaming/StatefulIndicators.Batch13.cs
@@ -32,22 +32,6 @@ public sealed class FastandSlowRelativeStrengthIndexOscillatorState : IStreaming
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FastandSlowRelativeStrengthIndexOscillatorState(MovingAvgType maType, int length1, int length2, int length3,
-        int length4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fskLength = Math.Max(1, length1);
-        _fskValues = new PooledRingBuffer<double>(_fskLength);
-        _rsi = new RsiState(maType, Math.Max(1, length3));
-        _fskSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FastandSlowRelativeStrengthIndexOscillator;
 
     public void Reset()
@@ -121,23 +105,6 @@ public sealed class FastandSlowStochasticOscillatorState : IStreamingIndicatorSt
         // StochasticOscillator operates on stockData (close) in batch, not on FSK values
         // Use length3 for stochastic length, smoothLength1=1 and smoothLength2=1 (no smoothing for raw fastK)
         _stoch = new StochasticOscillatorState(maType, Math.Max(1, length3), 1, 1, inputName);
-        _slowKSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-    }
-
-    public FastandSlowStochasticOscillatorState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fsk = new FastandSlowKurtosisOscillatorState(maType, Math.Max(1, length1), 0.03, selector);
-        _fskSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        // StochasticOscillator operates on stockData (close) in batch, not on FSK values
-        // Use length3 for stochastic length, smoothLength1=1 and smoothLength2=1 (no smoothing for raw fastK)
-        _stoch = new StochasticOscillatorState(maType, Math.Max(1, length3), 1, 1, selector);
         _slowKSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
     }
@@ -217,27 +184,6 @@ public sealed class FastSlowDegreeOscillatorState : IStreamingIndicatorState, ID
         _slowVWSum = new RollingWindowSum(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FastSlowDegreeOscillatorState(MovingAvgType maType, int length, int fastLength, int slowLength,
-        int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastF1bSum = new RollingWindowSum(resolvedFast);
-        _fastF2bSum = new RollingWindowSum(resolvedFast);
-        _fastVWSum = new RollingWindowSum(_length);
-        _slowF1bSum = new RollingWindowSum(resolvedSlow);
-        _slowF2bSum = new RollingWindowSum(resolvedSlow);
-        _slowVWSum = new RollingWindowSum(_length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FastSlowDegreeOscillator;
@@ -344,22 +290,6 @@ public sealed class FearAndGreedIndicatorState : IStreamingIndicatorState, IDisp
         _slowTrDn = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FearAndGreedIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastTrUp = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _fastTrDn = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowTrUp = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _slowTrDn = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FearAndGreedIndicator;
@@ -512,22 +442,6 @@ public sealed class FibonacciRetraceState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FibonacciRetraceState(MovingAvgType maType, int length1, int length2, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _factor = factor;
-        _highWindow = new RollingWindowMax(_length2);
-        _lowWindow = new RollingWindowMin(_length2);
-        _wma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FibonacciRetrace;
 
     public void Reset()
@@ -594,30 +508,6 @@ public sealed class FibonacciWeightedMovingAverageState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FibonacciWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var phi = (1 + Math.Sqrt(5)) / 2;
-        _weights = new double[resolved];
-        double weightSum = 0;
-        for (var j = 0; j < resolved; j++)
-        {
-            var pow = Math.Pow(phi, resolved - j);
-            var weight = (pow - (Math.Pow(-1, j) / pow)) / Math.Sqrt(5);
-            _weights[j] = weight;
-            weightSum += weight;
-        }
-
-        _weightSum = weightSum;
-        _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FibonacciWeightedMovingAverage;
 
     public void Reset()
@@ -677,19 +567,6 @@ public sealed class FiniteVolumeElementsState : IStreamingIndicatorState, IDispo
         _factor = factor;
         _volumeSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FiniteVolumeElementsState(MovingAvgType maType, int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _factor = factor;
-        _volumeSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FiniteVolumeElements;
@@ -764,24 +641,6 @@ public sealed class FireflyOscillatorState : IStreamingIndicatorState, IDisposab
         _wwSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _maxWindow = new RollingWindowMax(resolvedSmooth);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FireflyOscillatorState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _v3Smoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolvedLength, _ => _v2Value);
-        _v6Smoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _v7Smoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _wwSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _maxWindow = new RollingWindowMax(resolvedSmooth);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FireflyOscillator;
@@ -861,23 +720,6 @@ public sealed class FisherLeastSquaresMovingAverageState : IStreamingIndicatorSt
         _diffSum = new RollingWindowSum(_length);
         _absDiffSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FisherLeastSquaresMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _indexSma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDevSrc = new StandardDeviationVolatilityState(maType, _length, selector);
-        _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _diffSum = new RollingWindowSum(_length);
-        _absDiffSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FisherLeastSquaresMovingAverage;
@@ -988,32 +830,6 @@ public sealed class FisherTransformStochasticOscillatorState : IStreamingIndicat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FisherTransformStochasticOscillatorState(MovingAvgType maType, int length, int stochLength, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        _wma1 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma2 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma3 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma4 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma5 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma6 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma7 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma8 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma9 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _wma10 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _maxWindow = new RollingWindowMax(Math.Max(1, stochLength));
-        _minWindow = new RollingWindowMin(Math.Max(1, stochLength));
-        _numSum = new RollingWindowSum(Math.Max(1, smoothLength));
-        _denomSum = new RollingWindowSum(Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FisherTransformStochasticOscillator;
 
     public void Reset()
@@ -1110,20 +926,6 @@ public sealed class FlaggingBandsState : IStreamingIndicatorState, IDisposable
         _aValues = new PooledRingBuffer<double>(3);
         _bValues = new PooledRingBuffer<double>(3);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public FlaggingBandsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, selector);
-        _aValues = new PooledRingBuffer<double>(3);
-        _bValues = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.FlaggingBands;
@@ -1270,20 +1072,6 @@ public sealed class FoldedRelativeStrengthIndexState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FoldedRelativeStrengthIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _rsi = new RsiState(maType, _length);
-        _absSum = new RollingWindowSum(_length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FoldedRelativeStrengthIndex;
 
     public void Reset()
@@ -1334,17 +1122,6 @@ public sealed class ForceIndexState : IStreamingIndicatorState, IDisposable
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ForceIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ForceIndex;
@@ -1399,17 +1176,6 @@ public sealed class ForecastOscillatorState : IStreamingIndicatorState, IDisposa
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ForecastOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ForecastOscillator;
@@ -1622,25 +1388,6 @@ public sealed class FreedomOfMovementState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FreedomOfMovementState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _volumeSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _volumeStdDev = new StandardDeviationVolatilityState(maType, _length, InputName.Volume);
-        _aMoveMax = new RollingWindowMax(_length);
-        _aMoveMin = new RollingWindowMin(_length);
-        _relVolMax = new RollingWindowMax(_length);
-        _relVolMin = new RollingWindowMin(_length);
-        _vBymSum = new RollingWindowSum(_length);
-        _vBymStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _vBymValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FreedomOfMovement;
 
     public void Reset()
@@ -1814,26 +1561,6 @@ public sealed class FXSniperIndicatorState : IStreamingIndicatorState, IDisposab
         _w2 = 1 - _w1;
     }
 
-    public FXSniperIndicatorState(MovingAvgType maType, int cciLength, int t3Length, double b,
-        InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _cciState = new CommodityChannelIndexState(inputName, maType, Math.Max(1, cciLength), 0.015, selector);
-        var b2 = b * b;
-        var b3 = b2 * b;
-        _c1 = -b3;
-        _c2 = 3 * (b2 + b3);
-        _c3 = -3 * ((2 * b2) + b + b3);
-        _c4 = 1 + (3 * b) + b3 + (3 * b2);
-        var nr = 1 + (0.5 * (t3Length - 1));
-        _w1 = 2 / (nr + 1);
-        _w2 = 1 - _w1;
-    }
-
     public IndicatorName Name => IndicatorName.FXSniperIndicator;
 
     // No resolver of its own: the input was handed to these inner states, so they are the
@@ -1910,18 +1637,6 @@ public sealed class GainLossMovingAverageState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GainLossMovingAverageState(MovingAvgType maType, int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _glmaSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GainLossMovingAverage;
 
     public void Reset()
@@ -1983,18 +1698,6 @@ public sealed class GannHiLoActivatorState : IStreamingIndicatorState, IDisposab
         _highMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _lowMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GannHiLoActivatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _highMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _lowMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GannHiLoActivator;

--- a/src/Streaming/StatefulIndicators.Batch14.cs
+++ b/src/Streaming/StatefulIndicators.Batch14.cs
@@ -19,8 +19,7 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _lipsWindow;
     private StreamingInputResolver _input;
 
-    public GatorOscillatorState(InputName inputName = InputName.MedianPrice,
-        MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
+    public GatorOscillatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
         int jawOffset = 8, int teethLength = 8, int teethOffset = 5, int lipsLength = 5, int lipsOffset = 3)
     {
         _jawOffset = Math.Max(0, jawOffset);
@@ -32,7 +31,7 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
         _jawWindow = new PooledRingBuffer<double>(_jawOffset + 1);
         _teethWindow = new PooledRingBuffer<double>(_teethOffset + 1);
         _lipsWindow = new PooledRingBuffer<double>(_lipsOffset + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.GatorOscillator;
@@ -104,8 +103,7 @@ public sealed class GeneralFilterEstimatorState : IStreamingIndicatorState, IDis
     private readonly PooledRingBuffer<double> _dValues;
     private readonly StreamingInputResolver _input;
 
-    public GeneralFilterEstimatorState(int length = 100, double beta = 5.25, double gamma = 1, double zeta = 1,
-        InputName inputName = InputName.Close)
+    public GeneralFilterEstimatorState(int length = 100, double beta = 5.25, double gamma = 1, double zeta = 1)
     {
         _length = Math.Max(1, length);
         _p = beta != 0 ? (int)Math.Ceiling(_length / beta) : 0;
@@ -114,7 +112,7 @@ public sealed class GeneralFilterEstimatorState : IStreamingIndicatorState, IDis
         var windowLength = Math.Max(1, _p);
         _bValues = new PooledRingBuffer<double>(windowLength);
         _dValues = new PooledRingBuffer<double>(windowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GeneralFilterEstimator;
@@ -170,13 +168,13 @@ public sealed class GeneralizedDoubleExponentialMovingAverageState : IStreamingI
     private readonly StreamingInputResolver _input;
 
     public GeneralizedDoubleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 5, double factor = 0.7, InputName inputName = InputName.Close)
+        int length = 5, double factor = 0.7)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GeneralizedDoubleExponentialMovingAverage;
@@ -221,11 +219,11 @@ public sealed class GOscillatorState : IStreamingIndicatorState, IDisposable
     private double _prevValue;
     private bool _hasPrev;
 
-    public GOscillatorState(int length = 14, InputName inputName = InputName.Close)
+    public GOscillatorState(int length = 14)
     {
         _length = Math.Max(1, length);
         _bSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GOscillator;
@@ -280,8 +278,7 @@ public sealed class GrandTrendForecastingState : IStreamingIndicatorState, IDisp
     private readonly PooledRingBuffer<double> _chgValues;
     private readonly StreamingInputResolver _input;
 
-    public GrandTrendForecastingState(int length = 100, int forecastLength = 200, double mult = 2,
-        InputName inputName = InputName.Close)
+    public GrandTrendForecastingState(int length = 100, int forecastLength = 200, double mult = 2)
     {
         _length = Math.Max(1, length);
         _forecastLength = Math.Max(1, forecastLength);
@@ -292,7 +289,7 @@ public sealed class GrandTrendForecastingState : IStreamingIndicatorState, IDisp
         _tValues = new PooledRingBuffer<double>(bufferLength);
         _fcastValues = new PooledRingBuffer<double>(bufferLength);
         _chgValues = new PooledRingBuffer<double>(bufferLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GrandTrendForecasting;
@@ -369,11 +366,11 @@ public sealed class GroverLlorensActivatorState : IStreamingIndicatorState, IDis
     private bool _hasPrev;
 
     public GroverLlorensActivatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length = 100, double mult = 5, InputName inputName = InputName.Close)
+        int length = 100, double mult = 5)
     {
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GroverLlorensActivator;
@@ -439,13 +436,13 @@ public sealed class GroverLlorensCycleOscillatorState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public GroverLlorensCycleOscillatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length = 100, int smoothLength = 20, double mult = 10, InputName inputName = InputName.Close)
+        int length = 100, int smoothLength = 20, double mult = 10)
     {
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _oscSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _rsi = new RsiState(maType, Math.Max(1, smoothLength));
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GroverLlorensCycleOscillator;
@@ -509,14 +506,14 @@ public sealed class GuppyCountBackLineState : IStreamingIndicatorState, IDisposa
     private readonly PooledRingBuffer<double> _lows;
     private readonly StreamingInputResolver _input;
 
-    public GuppyCountBackLineState(int length = 21, InputName inputName = InputName.Close)
+    public GuppyCountBackLineState(int length = 21)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
         _highs = new PooledRingBuffer<double>((_length * 2) + 1);
         _lows = new PooledRingBuffer<double>((_length * 2) + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GuppyCountBackLine;
@@ -618,7 +615,7 @@ public sealed class GuppyDistanceIndicatorState : IStreamingIndicatorState, IDis
     public GuppyDistanceIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length1 = 3, int length2 = 5, int length3 = 8, int length4 = 10, int length5 = 12, int length6 = 15,
         int length7 = 30, int length8 = 35, int length9 = 40, int length10 = 45, int length11 = 11,
-        int length12 = 60, InputName inputName = InputName.Close)
+        int length12 = 60)
     {
         _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
@@ -632,7 +629,7 @@ public sealed class GuppyDistanceIndicatorState : IStreamingIndicatorState, IDis
         _ema10 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length10));
         _ema11 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length11));
         _ema12 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length12));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GuppyDistanceIndicator;
@@ -753,8 +750,7 @@ public sealed class GuppyMultipleMovingAverageState : IStreamingIndicatorState, 
         int length15 = 25, int length16 = 28, int length17 = 30, int length18 = 31, int length19 = 34, int length20 = 35,
         int length21 = 37, int length22 = 40, int length23 = 43, int length24 = 45, int length25 = 46, int length26 = 49,
         int length27 = 50, int length28 = 52, int length29 = 55, int length30 = 58, int length31 = 60, int length32 = 61,
-        int length33 = 64, int length34 = 67, int length35 = 70, int smoothLength = 1, int signalLength = 13,
-        InputName inputName = InputName.Close)
+        int length33 = 64, int length34 = 67, int length35 = 70, int smoothLength = 1, int signalLength = 13)
     {
         _ema3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ema5 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
@@ -786,7 +782,7 @@ public sealed class GuppyMultipleMovingAverageState : IStreamingIndicatorState, 
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _smoothLength = Math.Max(1, smoothLength);
         _oscRawSum = new RollingWindowSum(_smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GuppyMultipleMovingAverage;
@@ -929,7 +925,7 @@ public sealed class HalfTrendState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public HalfTrendState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 2,
-        int atrLength = 100, InputName inputName = InputName.Close)
+        int atrLength = 100)
     {
         _length = Math.Max(1, length);
         var resolvedAtr = Math.Max(1, atrLength);
@@ -938,7 +934,7 @@ public sealed class HalfTrendState : IStreamingIndicatorState, IDisposable
         _lowMa = MovingAverageSmootherFactory.Create(maType, _length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HalfTrend;
@@ -1079,7 +1075,7 @@ public sealed class HampelFilterState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private double _prevHfEma;
 
-    public HampelFilterState(int length = 14, double scalingFactor = 3, InputName inputName = InputName.Close)
+    public HampelFilterState(int length = 14, double scalingFactor = 3)
     {
         _length = Math.Max(1, length);
         _alpha = (double)2 / (_length + 1);
@@ -1088,7 +1084,7 @@ public sealed class HampelFilterState : IStreamingIndicatorState, IDisposable
         _absDiffs = new PooledRingBuffer<double>(_length);
         _medianScratch = new double[_length];
         _absMedianScratch = new double[_length];
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HampelFilter;
@@ -1144,11 +1140,11 @@ public sealed class HawkeyeVolumeIndicatorState : IStreamingIndicatorState, ICus
     private double _prevMidpoint;
     private bool _hasPrev;
 
-    public HawkeyeVolumeIndicatorState(InputName inputName = InputName.MedianPrice, int length = 200,
+    public HawkeyeVolumeIndicatorState(int length = 200,
         double divisor = 3.6)
     {
         _divisor = divisor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.HawkeyeVolumeIndicator;
@@ -1203,7 +1199,7 @@ public sealed class HendersonWeightedMovingAverageState : IStreamingIndicatorSta
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public HendersonWeightedMovingAverageState(int length = 7, InputName inputName = InputName.Close)
+    public HendersonWeightedMovingAverageState(int length = 7)
     {
         var resolved = Math.Max(1, length);
         var termMult = MathHelper.MinOrMax((int)Math.Floor((double)(resolved - 1) / 2));
@@ -1227,7 +1223,7 @@ public sealed class HendersonWeightedMovingAverageState : IStreamingIndicatorSta
 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HendersonWeightedMovingAverage;
@@ -1282,10 +1278,10 @@ public sealed class HerrickPayoffIndexState : IStreamingIndicatorState, ICustomI
     private double _prevK;
     private bool _hasPrev;
 
-    public HerrickPayoffIndexState(InputName inputName = InputName.MedianPrice, double pointValue = 100)
+    public HerrickPayoffIndexState(double pointValue = 100)
     {
         _pointValue = pointValue;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.HerrickPayoffIndex;
@@ -1351,8 +1347,7 @@ public sealed class HighLowIndexState : IStreamingIndicatorState, IDisposable
     private double _prevLowest;
     private bool _hasPrev;
 
-    public HighLowIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 10,
-        InputName inputName = InputName.Close)
+    public HighLowIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 10)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
@@ -1360,7 +1355,7 @@ public sealed class HighLowIndexState : IStreamingIndicatorState, IDisposable
         _advSum = new RollingWindowSum(_length);
         _loSum = new RollingWindowSum(_length);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HighLowIndex;
@@ -1434,15 +1429,14 @@ public sealed class HirashimaSugitaRSState : IStreamingIndicatorState, IDisposab
     private double _prevS2;
     private bool _hasPrev;
 
-    public HirashimaSugitaRSState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 1000,
-        InputName inputName = InputName.Close)
+    public HirashimaSugitaRSState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 1000)
     {
         var resolved = Math.Max(1, length);
         _ema = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved);
         _wma = MovingAverageSmootherFactory.Create(maType, resolved);
         _s1Regression = new LinearRegressionState(resolved, _ => _d1Value);
         _s2Regression = new LinearRegressionState(resolved, _ => _d2Value);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HirashimaSugitaRS;
@@ -1517,14 +1511,13 @@ public sealed class HoltExponentialMovingAverageState : IStreamingIndicatorState
     private double _prevHema;
     private bool _hasPrev;
 
-    public HoltExponentialMovingAverageState(int alphaLength = 20, int gammaLength = 20,
-        InputName inputName = InputName.Close)
+    public HoltExponentialMovingAverageState(int alphaLength = 20, int gammaLength = 20)
     {
         var resolvedAlpha = Math.Max(1, alphaLength);
         var resolvedGamma = Math.Max(1, gammaLength);
         _alpha = (double)2 / (resolvedAlpha + 1);
         _gamma = (double)2 / (resolvedGamma + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HoltExponentialMovingAverage;
@@ -1570,12 +1563,12 @@ public sealed class HullEstimateState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _ema;
     private readonly StreamingInputResolver _input;
 
-    public HullEstimateState(int length = 50, InputName inputName = InputName.Close)
+    public HullEstimateState(int length = 50)
     {
         var maLength = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
         _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, maLength);
         _ema = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, maLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HullEstimate;
@@ -1626,7 +1619,7 @@ public sealed class HurstBandsState : IStreamingIndicatorState, IDisposable
     private double _prevCma2;
 
     public HurstBandsState(int length = 10, double innerMult = 1.6, double outerMult = 2.6,
-        double extremeMult = 4.2, InputName inputName = InputName.Close)
+        double extremeMult = 4.2)
     {
         _length = Math.Max(1, length);
         _displacement = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2) + 1);
@@ -1635,7 +1628,7 @@ public sealed class HurstBandsState : IStreamingIndicatorState, IDisposable
         _extremeMult = extremeMult;
         _dPriceSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_displacement);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HurstBands;
@@ -1714,8 +1707,7 @@ public sealed class HurstCycleChannelState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public HurstCycleChannelState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int fastLength = 10, int slowLength = 30, double fastMult = 1, double slowMult = 3,
-        InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 30, double fastMult = 1, double slowMult = 3)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1731,7 +1723,7 @@ public sealed class HurstCycleChannelState : IStreamingIndicatorState, IDisposab
         _mclRmaValues = new PooledRingBuffer<double>(Math.Max(1, _mclOffset));
         _fastMult = fastMult;
         _slowMult = slowMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HurstCycleChannel;
@@ -1818,11 +1810,11 @@ public sealed class HybridConvolutionFilterState : IStreamingIndicatorState, IDi
     private double _prevOutput;
     private bool _hasPrev;
 
-    public HybridConvolutionFilterState(int length = 14, InputName inputName = InputName.Close)
+    public HybridConvolutionFilterState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HybridConvolutionFilter;
@@ -1882,8 +1874,7 @@ public sealed class IchimokuCloudState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowMin _senkouLow;
     private readonly StreamingInputResolver _input;
 
-    public IchimokuCloudState(int tenkanLength = 9, int kijunLength = 26, int senkouLength = 52,
-        InputName inputName = InputName.Close)
+    public IchimokuCloudState(int tenkanLength = 9, int kijunLength = 26, int senkouLength = 52)
     {
         _tenkanHigh = new RollingWindowMax(Math.Max(1, tenkanLength));
         _tenkanLow = new RollingWindowMin(Math.Max(1, tenkanLength));
@@ -1891,7 +1882,7 @@ public sealed class IchimokuCloudState : IStreamingIndicatorState, IDisposable
         _kijunLow = new RollingWindowMin(Math.Max(1, kijunLength));
         _senkouHigh = new RollingWindowMax(Math.Max(1, senkouLength));
         _senkouLow = new RollingWindowMin(Math.Max(1, senkouLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.IchimokuCloud;
@@ -1955,12 +1946,12 @@ public sealed class IIRLeastSquaresEstimateState : IStreamingIndicatorState
     private double _prevSEma;
     private bool _hasPrev;
 
-    public IIRLeastSquaresEstimateState(int length = 100, InputName inputName = InputName.Close)
+    public IIRLeastSquaresEstimateState(int length = 100)
     {
         var resolved = Math.Max(1, length);
         _a = (double)4 / (resolved + 2);
         _halfLength = MathHelper.MinOrMax((int)Math.Ceiling((double)resolved / 2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.IIRLeastSquaresEstimate;
@@ -2013,8 +2004,7 @@ public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingI
     private readonly RollingWindowSum _signalSum;
     private StreamingInputResolver _input;
 
-    public ImpulseMovingAverageConvergenceDivergenceState(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
+    public ImpulseMovingAverageConvergenceDivergenceState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
     {
         var resolved = Math.Max(1, length);
         _signalLength = Math.Max(1, signalLength);
@@ -2023,7 +2013,7 @@ public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingI
         _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.ImpulseMovingAverageConvergenceDivergence;

--- a/src/Streaming/StatefulIndicators.Batch14.cs
+++ b/src/Streaming/StatefulIndicators.Batch14.cs
@@ -35,26 +35,6 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GatorOscillatorState(InputName inputName, MovingAvgType maType, int jawLength, int jawOffset, int teethLength, int teethOffset,
-        int lipsLength, int lipsOffset, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _jawOffset = Math.Max(0, jawOffset);
-        _teethOffset = Math.Max(0, teethOffset);
-        _lipsOffset = Math.Max(0, lipsOffset);
-        _jawSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, jawLength));
-        _teethSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, teethLength));
-        _lipsSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, lipsLength));
-        _jawWindow = new PooledRingBuffer<double>(_jawOffset + 1);
-        _teethWindow = new PooledRingBuffer<double>(_teethOffset + 1);
-        _lipsWindow = new PooledRingBuffer<double>(_lipsOffset + 1);
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GatorOscillator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -137,24 +117,6 @@ public sealed class GeneralFilterEstimatorState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GeneralFilterEstimatorState(int length, double beta, double gamma, double zeta,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _p = beta != 0 ? (int)Math.Ceiling(_length / beta) : 0;
-        _gamma = gamma;
-        _zeta = zeta;
-        var windowLength = Math.Max(1, _p);
-        _bValues = new PooledRingBuffer<double>(windowLength);
-        _dValues = new PooledRingBuffer<double>(windowLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GeneralFilterEstimator;
 
     public void Reset()
@@ -217,21 +179,6 @@ public sealed class GeneralizedDoubleExponentialMovingAverageState : IStreamingI
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GeneralizedDoubleExponentialMovingAverageState(MovingAvgType maType, int length, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GeneralizedDoubleExponentialMovingAverage;
 
     public void Reset()
@@ -279,18 +226,6 @@ public sealed class GOscillatorState : IStreamingIndicatorState, IDisposable
         _length = Math.Max(1, length);
         _bSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _bSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GOscillator;
@@ -358,25 +293,6 @@ public sealed class GrandTrendForecastingState : IStreamingIndicatorState, IDisp
         _fcastValues = new PooledRingBuffer<double>(bufferLength);
         _chgValues = new PooledRingBuffer<double>(bufferLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GrandTrendForecastingState(int length, int forecastLength, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _forecastLength = Math.Max(1, forecastLength);
-        _mult = mult;
-        _tSum = new RollingWindowSum(_length);
-        _diffSum = new RollingWindowSum(_forecastLength);
-        var bufferLength = Math.Max(_length, _forecastLength);
-        _tValues = new PooledRingBuffer<double>(bufferLength);
-        _fcastValues = new PooledRingBuffer<double>(bufferLength);
-        _chgValues = new PooledRingBuffer<double>(bufferLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GrandTrendForecasting;
@@ -460,18 +376,6 @@ public sealed class GroverLlorensActivatorState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GroverLlorensActivatorState(MovingAvgType maType, int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GroverLlorensActivator;
 
     public void Reset()
@@ -544,21 +448,6 @@ public sealed class GroverLlorensCycleOscillatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GroverLlorensCycleOscillatorState(MovingAvgType maType, int length, int smoothLength, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _oscSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _rsi = new RsiState(maType, Math.Max(1, smoothLength));
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GroverLlorensCycleOscillator;
 
     public void Reset()
@@ -628,21 +517,6 @@ public sealed class GuppyCountBackLineState : IStreamingIndicatorState, IDisposa
         _highs = new PooledRingBuffer<double>((_length * 2) + 1);
         _lows = new PooledRingBuffer<double>((_length * 2) + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GuppyCountBackLineState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _highs = new PooledRingBuffer<double>((_length * 2) + 1);
-        _lows = new PooledRingBuffer<double>((_length * 2) + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GuppyCountBackLine;
@@ -759,30 +633,6 @@ public sealed class GuppyDistanceIndicatorState : IStreamingIndicatorState, IDis
         _ema11 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length11));
         _ema12 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length12));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GuppyDistanceIndicatorState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int length6, int length7, int length8, int length9, int length10, int length11, int length12,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ema3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _ema4 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _ema5 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _ema6 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
-        _ema7 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length7));
-        _ema8 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length8));
-        _ema9 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length9));
-        _ema10 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length10));
-        _ema11 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length11));
-        _ema12 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length12));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GuppyDistanceIndicator;
@@ -939,50 +789,6 @@ public sealed class GuppyMultipleMovingAverageState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GuppyMultipleMovingAverageState(MovingAvgType maType, int length1, int length2, int length3, int length4, int length5, int length6,
-        int length7, int length8, int length9, int length10, int length11, int length12, int length13, int length14, int length15, int length16,
-        int length17, int length18, int length19, int length20, int length21, int length22, int length23, int length24, int length25, int length26,
-        int length27, int length28, int length29, int length30, int length31, int length32, int length33, int length34, int length35,
-        int smoothLength, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ema5 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ema7 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _ema9 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _ema11 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length7));
-        _ema13 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length9));
-        _ema15 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length10));
-        _ema17 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length11));
-        _ema19 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length12));
-        _ema21 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length13));
-        _ema23 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length14));
-        _ema25 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length15));
-        _ema28 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length16));
-        _ema31 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length18));
-        _ema34 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length19));
-        _ema37 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length21));
-        _ema40 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length22));
-        _ema43 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length23));
-        _ema46 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length25));
-        _ema49 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length26));
-        _ema52 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length28));
-        _ema55 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length29));
-        _ema58 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length30));
-        _ema61 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length32));
-        _ema64 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length33));
-        _ema67 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length34));
-        _ema70 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length35));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _smoothLength = Math.Max(1, smoothLength);
-        _oscRawSum = new RollingWindowSum(_smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GuppyMultipleMovingAverage;
 
     public void Reset()
@@ -1135,24 +941,6 @@ public sealed class HalfTrendState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HalfTrendState(MovingAvgType maType, int length, int atrLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var resolvedAtr = Math.Max(1, atrLength);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolvedAtr);
-        _highMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _lowMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HalfTrend;
 
     public void Reset()
@@ -1303,23 +1091,6 @@ public sealed class HampelFilterState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HampelFilterState(int length, double scalingFactor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = (double)2 / (_length + 1);
-        _scalingFactor = scalingFactor;
-        _values = new PooledRingBuffer<double>(_length);
-        _absDiffs = new PooledRingBuffer<double>(_length);
-        _medianScratch = new double[_length];
-        _absMedianScratch = new double[_length];
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HampelFilter;
 
     public void Reset()
@@ -1378,17 +1149,6 @@ public sealed class HawkeyeVolumeIndicatorState : IStreamingIndicatorState, ICus
     {
         _divisor = divisor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HawkeyeVolumeIndicatorState(int length, double divisor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _divisor = divisor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HawkeyeVolumeIndicator;
@@ -1470,38 +1230,6 @@ public sealed class HendersonWeightedMovingAverageState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HendersonWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var termMult = MathHelper.MinOrMax((int)Math.Floor((double)(resolved - 1) / 2));
-        _weights = new double[resolved];
-        double weightSum = 0;
-        for (var j = 0; j < resolved; j++)
-        {
-            var m = termMult;
-            var n = j - termMult;
-            var numerator = 315 * (MathHelper.Pow(m + 1, 2) - MathHelper.Pow(n, 2)) *
-                (MathHelper.Pow(m + 2, 2) - MathHelper.Pow(n, 2)) *
-                (MathHelper.Pow(m + 3, 2) - MathHelper.Pow(n, 2)) *
-                ((3 * MathHelper.Pow(m + 2, 2)) - (11 * MathHelper.Pow(n, 2)) - 16);
-            var denominator = 8 * (m + 2) * (MathHelper.Pow(m + 2, 2) - 1) *
-                ((4 * MathHelper.Pow(m + 2, 2)) - 1) * ((4 * MathHelper.Pow(m + 2, 2)) - 9) *
-                ((4 * MathHelper.Pow(m + 2, 2)) - 25);
-            var weight = denominator != 0 ? numerator / denominator : 0;
-            _weights[j] = weight;
-            weightSum += weight;
-        }
-
-        _weightSum = weightSum;
-        _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HendersonWeightedMovingAverage;
 
     public void Reset()
@@ -1558,17 +1286,6 @@ public sealed class HerrickPayoffIndexState : IStreamingIndicatorState, ICustomI
     {
         _pointValue = pointValue;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HerrickPayoffIndexState(double pointValue, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _pointValue = pointValue;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HerrickPayoffIndex;
@@ -1644,22 +1361,6 @@ public sealed class HighLowIndexState : IStreamingIndicatorState, IDisposable
         _loSum = new RollingWindowSum(_length);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HighLowIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _advSum = new RollingWindowSum(_length);
-        _loSum = new RollingWindowSum(_length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HighLowIndex;
@@ -1744,21 +1445,6 @@ public sealed class HirashimaSugitaRSState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HirashimaSugitaRSState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved);
-        _wma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _s1Regression = new LinearRegressionState(resolved, _ => _d1Value);
-        _s2Regression = new LinearRegressionState(resolved, _ => _d2Value);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HirashimaSugitaRS;
 
     public void Reset()
@@ -1841,20 +1527,6 @@ public sealed class HoltExponentialMovingAverageState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HoltExponentialMovingAverageState(int alphaLength, int gammaLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedAlpha = Math.Max(1, alphaLength);
-        var resolvedGamma = Math.Max(1, gammaLength);
-        _alpha = (double)2 / (resolvedAlpha + 1);
-        _gamma = (double)2 / (resolvedGamma + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HoltExponentialMovingAverage;
 
     public void Reset()
@@ -1904,19 +1576,6 @@ public sealed class HullEstimateState : IStreamingIndicatorState, IDisposable
         _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, maLength);
         _ema = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, maLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HullEstimateState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var maLength = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
-        _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, maLength);
-        _ema = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, maLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HullEstimate;
@@ -1977,24 +1636,6 @@ public sealed class HurstBandsState : IStreamingIndicatorState, IDisposable
         _dPriceSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_displacement);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HurstBandsState(int length, double innerMult, double outerMult, double extremeMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _displacement = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2) + 1);
-        _innerMult = innerMult;
-        _outerMult = outerMult;
-        _extremeMult = extremeMult;
-        _dPriceSum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(_displacement);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HurstBands;
@@ -2093,31 +1734,6 @@ public sealed class HurstCycleChannelState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HurstCycleChannelState(MovingAvgType maType, int fastLength, int slowLength, double fastMult,
-        double slowMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var scl = MathHelper.MinOrMax((int)Math.Ceiling((double)resolvedFast / 2));
-        var mcl = MathHelper.MinOrMax((int)Math.Ceiling((double)resolvedSlow / 2));
-        _sclOffset = MathHelper.MinOrMax((int)Math.Ceiling((double)scl / 2));
-        _mclOffset = MathHelper.MinOrMax((int)Math.Ceiling((double)mcl / 2));
-        _sclAtrSmoother = MovingAverageSmootherFactory.Create(maType, scl);
-        _mclAtrSmoother = MovingAverageSmootherFactory.Create(maType, mcl);
-        _sclRmaSmoother = MovingAverageSmootherFactory.Create(maType, scl);
-        _mclRmaSmoother = MovingAverageSmootherFactory.Create(maType, mcl);
-        _sclRmaValues = new PooledRingBuffer<double>(Math.Max(1, _sclOffset));
-        _mclRmaValues = new PooledRingBuffer<double>(Math.Max(1, _mclOffset));
-        _fastMult = fastMult;
-        _slowMult = slowMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HurstCycleChannel;
 
     public void Reset()
@@ -2209,18 +1825,6 @@ public sealed class HybridConvolutionFilterState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HybridConvolutionFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HybridConvolutionFilter;
 
     public void Reset()
@@ -2288,23 +1892,6 @@ public sealed class IchimokuCloudState : IStreamingIndicatorState, IDisposable
         _senkouHigh = new RollingWindowMax(Math.Max(1, senkouLength));
         _senkouLow = new RollingWindowMin(Math.Max(1, senkouLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public IchimokuCloudState(int tenkanLength, int kijunLength, int senkouLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _tenkanHigh = new RollingWindowMax(Math.Max(1, tenkanLength));
-        _tenkanLow = new RollingWindowMin(Math.Max(1, tenkanLength));
-        _kijunHigh = new RollingWindowMax(Math.Max(1, kijunLength));
-        _kijunLow = new RollingWindowMin(Math.Max(1, kijunLength));
-        _senkouHigh = new RollingWindowMax(Math.Max(1, senkouLength));
-        _senkouLow = new RollingWindowMin(Math.Max(1, senkouLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.IchimokuCloud;
@@ -2376,19 +1963,6 @@ public sealed class IIRLeastSquaresEstimateState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public IIRLeastSquaresEstimateState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _a = (double)4 / (resolved + 2);
-        _halfLength = MathHelper.MinOrMax((int)Math.Ceiling((double)resolved / 2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.IIRLeastSquaresEstimate;
 
     public void Reset()
@@ -2450,24 +2024,6 @@ public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingI
         _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSum = new RollingWindowSum(_signalLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ImpulseMovingAverageConvergenceDivergenceState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _signalLength = Math.Max(1, signalLength);
-        _ema1 = new EmaState(resolved);
-        _ema2 = new EmaState(resolved);
-        _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ImpulseMovingAverageConvergenceDivergence;

--- a/src/Streaming/StatefulIndicators.Batch14.cs
+++ b/src/Streaming/StatefulIndicators.Batch14.cs
@@ -56,6 +56,12 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
         var teeth = _teethSmoother.Next(value, isFinal);
         var lips = _lipsSmoother.Next(value, isFinal);
 
+        // Read an offset of bars back, counting this bar, before this bar is committed, as AlligatorIndexState
+        // does; reading after the commit made a preview a bar late once the window was full.
+        var displacedJaw = EhlersStreamingWindow.GetOffsetValue(_jawWindow, jaw, _jawOffset);
+        var displacedTeeth = EhlersStreamingWindow.GetOffsetValue(_teethWindow, teeth, _teethOffset);
+        var displacedLips = EhlersStreamingWindow.GetOffsetValue(_lipsWindow, lips, _lipsOffset);
+
         if (isFinal)
         {
             _jawWindow.TryAdd(jaw, out _);
@@ -63,9 +69,6 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
             _lipsWindow.TryAdd(lips, out _);
         }
 
-        var displacedJaw = _jawOffset == 0 ? jaw : _jawWindow.Count > _jawOffset ? _jawWindow[0] : 0;
-        var displacedTeeth = _teethOffset == 0 ? teeth : _teethWindow.Count > _teethOffset ? _teethWindow[0] : 0;
-        var displacedLips = _lipsOffset == 0 ? lips : _lipsWindow.Count > _lipsOffset ? _lipsWindow[0] : 0;
         var top = Math.Abs(displacedJaw - displacedTeeth);
         var bottom = -Math.Abs(displacedTeeth - displacedLips);
 

--- a/src/Streaming/StatefulIndicators.Batch14.cs
+++ b/src/Streaming/StatefulIndicators.Batch14.cs
@@ -460,7 +460,9 @@ public sealed class GroverLlorensCycleOscillatorState : IStreamingIndicatorState
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
         var value = _input.GetValue(bar);
-        var prevValue = _hasPrev ? _prevValue : 0;
+        // The first bar has no previous close, so it stands in for itself (TR = High - Low), as the batch's
+        // true range and AverageTrueRangeState both do. A zero there made the first TR the whole high.
+        var prevValue = _hasPrev ? _prevValue : value;
         var tr = CalculationsHelper.CalculateTrueRange(bar.High, bar.Low, prevValue);
         var atr = _atrSmoother.Next(tr, isFinal);
         var prevTs = _hasPrev ? _prevTs : value;

--- a/src/Streaming/StatefulIndicators.Batch14.cs
+++ b/src/Streaming/StatefulIndicators.Batch14.cs
@@ -6,7 +6,7 @@ using OoplesFinance.StockIndicators.Helpers;
 
 namespace OoplesFinance.StockIndicators.Streaming;
 
-public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _jawOffset;
     private readonly int _teethOffset;
@@ -17,7 +17,7 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _jawWindow;
     private readonly PooledRingBuffer<double> _teethWindow;
     private readonly PooledRingBuffer<double> _lipsWindow;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public GatorOscillatorState(InputName inputName = InputName.MedianPrice,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
@@ -56,6 +56,9 @@ public sealed class GatorOscillatorState : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.GatorOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1361,10 +1364,10 @@ public sealed class HampelFilterState : IStreamingIndicatorState, IDisposable
     }
 }
 
-public sealed class HawkeyeVolumeIndicatorState : IStreamingIndicatorState
+public sealed class HawkeyeVolumeIndicatorState : IStreamingIndicatorState, ICustomInputConsumer
 {
     private readonly double _divisor;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevHigh;
     private double _prevLow;
     private double _prevMidpoint;
@@ -1389,6 +1392,9 @@ public sealed class HawkeyeVolumeIndicatorState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.HawkeyeVolumeIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1538,10 +1544,10 @@ public sealed class HendersonWeightedMovingAverageState : IStreamingIndicatorSta
     }
 }
 
-public sealed class HerrickPayoffIndexState : IStreamingIndicatorState
+public sealed class HerrickPayoffIndexState : IStreamingIndicatorState, ICustomInputConsumer
 {
     private readonly double _pointValue;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevValue;
     private double _prevOpen;
     private double _prevClose;
@@ -1566,6 +1572,9 @@ public sealed class HerrickPayoffIndexState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.HerrickPayoffIndex;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -2420,7 +2429,7 @@ public sealed class IIRLeastSquaresEstimateState : IStreamingIndicatorState
     }
 }
 
-public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingIndicatorState, IDisposable
+public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _signalLength;
     private readonly EmaState _ema1;
@@ -2428,7 +2437,7 @@ public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingI
     private readonly IMovingAverageSmoother _highSmoother;
     private readonly IMovingAverageSmoother _lowSmoother;
     private readonly RollingWindowSum _signalSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public ImpulseMovingAverageConvergenceDivergenceState(InputName inputName = InputName.TypicalPrice,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
@@ -2462,6 +2471,9 @@ public sealed class ImpulseMovingAverageConvergenceDivergenceState : IStreamingI
     }
 
     public IndicatorName Name => IndicatorName.ImpulseMovingAverageConvergenceDivergence;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch15.cs
+++ b/src/Streaming/StatefulIndicators.Batch15.cs
@@ -455,8 +455,8 @@ public sealed class InterquartileRangeBandsState : IStreamingIndicatorState, IDi
             _order.Add(value);
         }
 
-        var q1 = _order.PercentileNearestRank(25);
-        var q3 = _order.PercentileNearestRank(75);
+        var q1 = isFinal ? _order.PercentileNearestRank(25) : _order.PercentileNearestRank(25, value);
+        var q3 = isFinal ? _order.PercentileNearestRank(75) : _order.PercentileNearestRank(75, value);
         var iqr = q3 - q1;
         var upper = q3 + (_mult * iqr);
         var lower = q1 - (_mult * iqr);

--- a/src/Streaming/StatefulIndicators.Batch15.cs
+++ b/src/Streaming/StatefulIndicators.Batch15.cs
@@ -6,7 +6,7 @@ using OoplesFinance.StockIndicators.Helpers;
 
 namespace OoplesFinance.StockIndicators.Streaming;
 
-public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _signalLength;
     private readonly EmaState _ema1;
@@ -14,7 +14,7 @@ public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorS
     private readonly IMovingAverageSmoother _highSmoother;
     private readonly IMovingAverageSmoother _lowSmoother;
     private readonly RollingWindowSum _signalSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public ImpulsePercentagePriceOscillatorState(InputName inputName = InputName.TypicalPrice,
         MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
@@ -48,6 +48,9 @@ public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorS
     }
 
     public IndicatorName Name => IndicatorName.ImpulsePercentagePriceOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1428,7 +1431,7 @@ public sealed class KaseConvergenceDivergenceState : IStreamingIndicatorState, I
     }
 }
 
-public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable
+public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _fastSmoother;
     private readonly IMovingAverageSmoother _slowSmoother;
@@ -1436,7 +1439,7 @@ public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable
     private readonly StandardDeviationVolatilityState _dtrStd;
     private readonly PooledRingBuffer<double> _lowValues;
     private readonly PooledRingBuffer<double> _closeValues;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly double _stdDev1;
     private readonly double _stdDev2;
     private readonly double _stdDev3;
@@ -1488,6 +1491,9 @@ public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.KaseDevStopV1;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch15.cs
+++ b/src/Streaming/StatefulIndicators.Batch15.cs
@@ -194,7 +194,7 @@ public sealed class InformationRatioState : IStreamingIndicatorState, IDisposabl
     }
 }
 
-public sealed class InsyncIndexState : IStreamingIndicatorState, IDisposable
+public sealed class InsyncIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _smaLength;
     private readonly RelativeStrengthIndexState _rsi;
@@ -244,6 +244,14 @@ public sealed class InsyncIndexState : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.InsyncIndex;
+
+    // No resolver of its own: the inner states that default to a typical or median price are the
+    // ones that must switch to reading the close when this state is wrapped.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_cci).ReadCloseAsInput();
+        ((ICustomInputConsumer)_mfi).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch15.cs
+++ b/src/Streaming/StatefulIndicators.Batch15.cs
@@ -29,24 +29,6 @@ public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ImpulsePercentagePriceOscillatorState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _signalLength = Math.Max(1, signalLength);
-        _ema1 = new EmaState(resolved);
-        _ema2 = new EmaState(resolved);
-        _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ImpulsePercentagePriceOscillator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -167,21 +149,6 @@ public sealed class InformationRatioState : IStreamingIndicatorState, IDisposabl
         _stdDev = new StandardDeviationVolatilityState(maType, _length, _ => _retValue);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public InformationRatioState(MovingAvgType maType, int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _bench = MathHelper.Pow(1 + bmk, _length / 360d) - 1;
-        _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, _ => _retValue);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.InformationRatio;
@@ -409,19 +376,6 @@ public sealed class InternalBarStrengthIndicatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public InternalBarStrengthIndicatorState(int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoothLength = Math.Max(1, smoothLength);
-        _ibsSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.InternalBarStrengthIndicator;
 
     public void Reset()
@@ -479,19 +433,6 @@ public sealed class InterquartileRangeBandsState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public InterquartileRangeBandsState(int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mult = mult;
-        _order = new RollingOrderStatistic(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.InterquartileRangeBands;
 
     public void Reset()
@@ -546,18 +487,6 @@ public sealed class InverseDistanceWeightedMovingAverageState : IStreamingIndica
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public InverseDistanceWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.InverseDistanceWeightedMovingAverage;
@@ -620,16 +549,6 @@ public sealed class InverseFisherFastZScoreState : IStreamingIndicatorState, IDi
         _fastZScore = new FastZScoreState(maType, length, inputName);
     }
 
-    public InverseFisherFastZScoreState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastZScore = new FastZScoreState(maType, length, selector);
-    }
-
     public IndicatorName Name => IndicatorName.InverseFisherFastZScore;
 
     public void Reset()
@@ -674,19 +593,6 @@ public sealed class InverseFisherZScoreState : IStreamingIndicatorState, IDispos
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public InverseFisherZScoreState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _varianceMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.InverseFisherZScore;
@@ -752,24 +658,6 @@ public sealed class JapaneseCorrelationCoefficientState : IStreamingIndicatorSta
         _lowest = new RollingWindowMin(_length1);
         _closeValues = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public JapaneseCorrelationCoefficientState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _length1 = MathHelper.MinOrMax((int)Math.Ceiling(_length / 2d));
-        _highSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _lowSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _closeSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _highest = new RollingWindowMax(_length1);
-        _lowest = new RollingWindowMin(_length1);
-        _closeValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.JapaneseCorrelationCoefficient;
@@ -850,19 +738,6 @@ public sealed class JmaRsxCloneState : IStreamingIndicatorState
         _f18 = 3d / (_length + 2);
         _f20 = 1 - _f18;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public JmaRsxCloneState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _f18 = 3d / (_length + 2);
-        _f20 = 1 - _f18;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.JmaRsxClone;
@@ -994,31 +869,6 @@ public sealed class JrcFractalDimensionState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public JrcFractalDimensionState(MovingAvgType maType, int length1, int length2, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _smoothLength = Math.Max(1, smoothLength);
-        _wind1 = MathHelper.MinOrMax((_length2 - 1) * _length1);
-        _wind2 = MathHelper.MinOrMax(_length2 * _length1);
-        _nLog = Math.Log(_length2);
-        _highest1 = new RollingWindowMax(_length1);
-        _lowest1 = new RollingWindowMin(_length1);
-        _highest2 = new RollingWindowMax(_wind2);
-        _lowest2 = new RollingWindowMin(_wind2);
-        var capacity = Math.Max(_wind2, _length1);
-        _values = new PooledRingBuffer<double>(capacity);
-        _smallRanges = new PooledRingBuffer<double>(_wind1);
-        _fdSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.JrcFractalDimension;
 
     public void Reset()
@@ -1107,18 +957,6 @@ public sealed class JsaMovingAverageState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public JsaMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.JsaMovingAverage;
 
     public void Reset()
@@ -1175,21 +1013,6 @@ public sealed class JurikMovingAverageState : IStreamingIndicatorState
         _beta = ratio / (ratio + 2);
         _alpha = MathHelper.Pow(_beta, power);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public JurikMovingAverageState(int length, double phase, double power, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _phaseRatio = phase < -100 ? 0.5 : phase > 100 ? 2.5 : (phase / 100) + 1.5;
-        var ratio = 0.45 * (resolved - 1);
-        _beta = ratio / (ratio + 2);
-        _alpha = MathHelper.Pow(_beta, power);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.JurikMovingAverage;
@@ -1250,19 +1073,6 @@ public sealed class KalmanSmootherState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KalmanSmootherState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoothFactor = MathHelper.Sqrt((resolved / 10000d) * 2);
-        _veloFactor = resolved / 10000d;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KalmanSmoother;
 
     public void Reset()
@@ -1318,20 +1128,6 @@ public sealed class KarobeinOscillatorState : IStreamingIndicatorState, IDisposa
         _aSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _bSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KarobeinOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema = MovingAverageSmootherFactory.Create(maType, resolved);
-        _aSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _bSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KarobeinOscillator;
@@ -1466,30 +1262,6 @@ public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable, 
         _stdDev4 = stdDev4;
     }
 
-    public KaseDevStopV1State(MovingAvgType maType, int fastLength, int slowLength, int length,
-        double stdDev1, double stdDev2, double stdDev3, double stdDev4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var resolved = Math.Max(1, length);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _dtrAvg = MovingAverageSmootherFactory.Create(maType, resolved);
-        _dtrStd = new StandardDeviationVolatilityState(maType, resolved, _ => _dtrValue);
-        _lowValues = new PooledRingBuffer<double>(2);
-        _closeValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _stdDev1 = stdDev1;
-        _stdDev2 = stdDev2;
-        _stdDev3 = stdDev3;
-        _stdDev4 = stdDev4;
-    }
-
     public IndicatorName Name => IndicatorName.KaseDevStopV1;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1594,31 +1366,6 @@ public sealed class KaseDevStopV2State : IStreamingIndicatorState, IDisposable
         _lowValues = new PooledRingBuffer<double>(2);
         _inputValues = new PooledRingBuffer<double>(2);
         _input = new StreamingInputResolver(inputName, null);
-        _stdDev1 = stdDev1;
-        _stdDev2 = stdDev2;
-        _stdDev3 = stdDev3;
-        _stdDev4 = stdDev4;
-    }
-
-    public KaseDevStopV2State(MovingAvgType maType, int fastLength, int slowLength, int length, double stdDev1,
-        double stdDev2, double stdDev3, double stdDev4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var resolved = Math.Max(1, length);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _rangeAvg = MovingAverageSmootherFactory.Create(maType, resolved);
-        _rangeStd = new StandardDeviationVolatilityState(maType, resolved, _ => _rangeValue);
-        _highValues = new PooledRingBuffer<double>(2);
-        _lowValues = new PooledRingBuffer<double>(2);
-        _inputValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _stdDev1 = stdDev1;
         _stdDev2 = stdDev2;
         _stdDev3 = stdDev3;
@@ -1860,29 +1607,6 @@ public sealed class KasePeakOscillatorV2State : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KasePeakOscillatorV2State(MovingAvgType maType, int fastLength, int slowLength, int length1, int length2, int length3,
-        int smoothLength, double devFactor, double sensitivity, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _slowLength = Math.Max(1, slowLength);
-        _sensitivity = sensitivity;
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _ccDev = new StandardDeviationVolatilityState(maType, resolvedLength1, _ => _ccLogValue);
-        _ccDevAvg = MovingAverageSmootherFactory.Create(maType, resolvedLength2);
-        _x1Sum = new RollingWindowSum(resolvedSmooth);
-        _x2Sum = new RollingWindowSum(resolvedSmooth);
-        _highValues = new PooledRingBuffer<double>(_slowLength);
-        _lowValues = new PooledRingBuffer<double>(_slowLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KasePeakOscillatorV2;
 
     public void Reset()
@@ -1981,20 +1705,6 @@ public sealed class KaseSerialDependencyIndexState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KaseSerialDependencyIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, _ => _tempLog);
-        _highValues = new PooledRingBuffer<double>(_length);
-        _lowValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KaseSerialDependencyIndex;
 
     public void Reset()
@@ -2066,18 +1776,6 @@ public sealed class KaufmanAdaptiveBandsState : IStreamingIndicatorState, IDispo
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _stdDevFactor = stdDevFactor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KaufmanAdaptiveBandsState(int length, double stdDevFactor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _er = new EfficiencyRatioState(Math.Max(1, length));
-        _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveBands;
@@ -2159,34 +1857,6 @@ public sealed class KaufmanAdaptiveCorrelationOscillatorState : IStreamingIndica
         }
 
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KaufmanAdaptiveCorrelationOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        if (maType == MovingAvgType.KaufmanAdaptiveMovingAverage)
-        {
-            _srcMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
-            _indexMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
-            _indexSrcMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
-            _index2Ma = new KaufmanAdaptiveMovingAverageEngine(resolved);
-            _src2Ma = new KaufmanAdaptiveMovingAverageEngine(resolved);
-        }
-        else
-        {
-            _srcMa = MovingAverageSmootherFactory.Create(maType, resolved);
-            _indexMa = MovingAverageSmootherFactory.Create(maType, resolved);
-            _indexSrcMa = MovingAverageSmootherFactory.Create(maType, resolved);
-            _index2Ma = MovingAverageSmootherFactory.Create(maType, resolved);
-            _src2Ma = MovingAverageSmootherFactory.Create(maType, resolved);
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveCorrelationOscillator;

--- a/src/Streaming/StatefulIndicators.Batch15.cs
+++ b/src/Streaming/StatefulIndicators.Batch15.cs
@@ -16,8 +16,7 @@ public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorS
     private readonly RollingWindowSum _signalSum;
     private StreamingInputResolver _input;
 
-    public ImpulsePercentagePriceOscillatorState(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
+    public ImpulsePercentagePriceOscillatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 34, int signalLength = 9)
     {
         var resolved = Math.Max(1, length);
         _signalLength = Math.Max(1, signalLength);
@@ -26,7 +25,7 @@ public sealed class ImpulsePercentagePriceOscillatorState : IStreamingIndicatorS
         _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.ImpulsePercentagePriceOscillator;
@@ -140,15 +139,14 @@ public sealed class InformationRatioState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
     private double _retValue;
 
-    public InformationRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.05,
-        InputName inputName = InputName.Close)
+    public InformationRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.05)
     {
         _length = Math.Max(1, length);
         _bench = MathHelper.Pow(1 + bmk, _length / 360d) - 1;
         _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _stdDev = new StandardDeviationVolatilityState(maType, _length, _ => _retValue);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.InformationRatio;
@@ -368,12 +366,12 @@ public sealed class InternalBarStrengthIndicatorState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private double _prevIbsiEma;
 
-    public InternalBarStrengthIndicatorState(int length = 14, int smoothLength = 3, InputName inputName = InputName.Close)
+    public InternalBarStrengthIndicatorState(int length = 14, int smoothLength = 3)
     {
         _length = Math.Max(1, length);
         _smoothLength = Math.Max(1, smoothLength);
         _ibsSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.InternalBarStrengthIndicator;
@@ -425,12 +423,12 @@ public sealed class InterquartileRangeBandsState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
     private RollingOrderStatistic _order;
 
-    public InterquartileRangeBandsState(int length = 14, double mult = 1.5, InputName inputName = InputName.Close)
+    public InterquartileRangeBandsState(int length = 14, double mult = 1.5)
     {
         _length = Math.Max(1, length);
         _mult = mult;
         _order = new RollingOrderStatistic(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.InterquartileRangeBands;
@@ -482,11 +480,11 @@ public sealed class InverseDistanceWeightedMovingAverageState : IStreamingIndica
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public InverseDistanceWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public InverseDistanceWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.InverseDistanceWeightedMovingAverage;
@@ -543,10 +541,9 @@ public sealed class InverseFisherFastZScoreState : IStreamingIndicatorState, IDi
 {
     private readonly FastZScoreState _fastZScore;
 
-    public InverseFisherFastZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50,
-        InputName inputName = InputName.Close)
+    public InverseFisherFastZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50)
     {
-        _fastZScore = new FastZScoreState(maType, length, inputName);
+        _fastZScore = new FastZScoreState(maType, length);
     }
 
     public IndicatorName Name => IndicatorName.InverseFisherFastZScore;
@@ -586,13 +583,12 @@ public sealed class InverseFisherZScoreState : IStreamingIndicatorState, IDispos
     private readonly IMovingAverageSmoother _varianceMa;
     private readonly StreamingInputResolver _input;
 
-    public InverseFisherZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public InverseFisherZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.InverseFisherZScore;
@@ -647,7 +643,7 @@ public sealed class JapaneseCorrelationCoefficientState : IStreamingIndicatorSta
     private readonly StreamingInputResolver _input;
 
     public JapaneseCorrelationCoefficientState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 50, InputName inputName = InputName.Close)
+        int length = 50)
     {
         _length = Math.Max(1, length);
         _length1 = MathHelper.MinOrMax((int)Math.Ceiling(_length / 2d));
@@ -657,7 +653,7 @@ public sealed class JapaneseCorrelationCoefficientState : IStreamingIndicatorSta
         _highest = new RollingWindowMax(_length1);
         _lowest = new RollingWindowMin(_length1);
         _closeValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.JapaneseCorrelationCoefficient;
@@ -732,12 +728,12 @@ public sealed class JmaRsxCloneState : IStreamingIndicatorState
     private double _f80;
     private double _f90;
 
-    public JmaRsxCloneState(int length = 14, InputName inputName = InputName.Close)
+    public JmaRsxCloneState(int length = 14)
     {
         _length = Math.Max(1, length);
         _f18 = 3d / (_length + 2);
         _f20 = 1 - _f18;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.JmaRsxClone;
@@ -849,7 +845,7 @@ public sealed class JrcFractalDimensionState : IStreamingIndicatorState, IDispos
     private int _index;
 
     public JrcFractalDimensionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 20, int length2 = 5, int smoothLength = 5, InputName inputName = InputName.Close)
+        int length1 = 20, int length2 = 5, int smoothLength = 5)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -866,7 +862,7 @@ public sealed class JrcFractalDimensionState : IStreamingIndicatorState, IDispos
         _smallRanges = new PooledRingBuffer<double>(_wind1);
         _fdSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.JrcFractalDimension;
@@ -950,11 +946,11 @@ public sealed class JsaMovingAverageState : IStreamingIndicatorState, IDisposabl
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public JsaMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public JsaMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.JsaMovingAverage;
@@ -1004,15 +1000,14 @@ public sealed class JurikMovingAverageState : IStreamingIndicatorState
     private double _e2;
     private double _jma;
 
-    public JurikMovingAverageState(int length = 7, double phase = 50, double power = 2,
-        InputName inputName = InputName.Close)
+    public JurikMovingAverageState(int length = 7, double phase = 50, double power = 2)
     {
         var resolved = Math.Max(1, length);
         _phaseRatio = phase < -100 ? 0.5 : phase > 100 ? 2.5 : (phase / 100) + 1.5;
         var ratio = 0.45 * (resolved - 1);
         _beta = ratio / (ratio + 2);
         _alpha = MathHelper.Pow(_beta, power);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.JurikMovingAverage;
@@ -1065,12 +1060,12 @@ public sealed class KalmanSmootherState : IStreamingIndicatorState
     private double _prevKf;
     private bool _hasPrev;
 
-    public KalmanSmootherState(int length = 200, InputName inputName = InputName.Close)
+    public KalmanSmootherState(int length = 200)
     {
         var resolved = Math.Max(1, length);
         _smoothFactor = MathHelper.Sqrt((resolved / 10000d) * 2);
         _veloFactor = resolved / 10000d;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KalmanSmoother;
@@ -1121,13 +1116,13 @@ public sealed class KarobeinOscillatorState : IStreamingIndicatorState, IDisposa
     private bool _hasPrev;
 
     public KarobeinOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 50, InputName inputName = InputName.Close)
+        int length = 50)
     {
         var resolved = Math.Max(1, length);
         _ema = MovingAverageSmootherFactory.Create(maType, resolved);
         _aSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _bSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KarobeinOscillator;
@@ -1242,8 +1237,7 @@ public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable, 
     private readonly double _stdDev4;
     private double _dtrValue;
 
-    public KaseDevStopV1State(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5, int slowLength = 21, int length = 20,
+    public KaseDevStopV1State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5, int slowLength = 21, int length = 20,
         double stdDev1 = 0, double stdDev2 = 1, double stdDev3 = 2.2, double stdDev4 = 3.6)
     {
         var resolvedFast = Math.Max(1, fastLength);
@@ -1255,7 +1249,7 @@ public sealed class KaseDevStopV1State : IStreamingIndicatorState, IDisposable, 
         _dtrStd = new StandardDeviationVolatilityState(maType, resolved, _ => _dtrValue);
         _lowValues = new PooledRingBuffer<double>(2);
         _closeValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
         _stdDev1 = stdDev1;
         _stdDev2 = stdDev2;
         _stdDev3 = stdDev3;
@@ -1353,7 +1347,7 @@ public sealed class KaseDevStopV2State : IStreamingIndicatorState, IDisposable
 
     public KaseDevStopV2State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int fastLength = 10, int slowLength = 21, int length = 20, double stdDev1 = 0, double stdDev2 = 1,
-        double stdDev3 = 2.2, double stdDev4 = 3.6, InputName inputName = InputName.Close)
+        double stdDev3 = 2.2, double stdDev4 = 3.6)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1365,7 +1359,7 @@ public sealed class KaseDevStopV2State : IStreamingIndicatorState, IDisposable
         _highValues = new PooledRingBuffer<double>(2);
         _lowValues = new PooledRingBuffer<double>(2);
         _inputValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _stdDev1 = stdDev1;
         _stdDev2 = stdDev2;
         _stdDev3 = stdDev3;
@@ -1590,7 +1584,7 @@ public sealed class KasePeakOscillatorV2State : IStreamingIndicatorState, IDispo
 
     public KasePeakOscillatorV2State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int fastLength = 8, int slowLength = 65, int length1 = 9, int length2 = 30, int length3 = 50, int smoothLength = 3,
-        double devFactor = 2, double sensitivity = 40, InputName inputName = InputName.Close)
+        double devFactor = 2, double sensitivity = 40)
     {
         _fastLength = Math.Max(1, fastLength);
         _slowLength = Math.Max(1, slowLength);
@@ -1604,7 +1598,7 @@ public sealed class KasePeakOscillatorV2State : IStreamingIndicatorState, IDispo
         _x2Sum = new RollingWindowSum(resolvedSmooth);
         _highValues = new PooledRingBuffer<double>(_slowLength);
         _lowValues = new PooledRingBuffer<double>(_slowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KasePeakOscillatorV2;
@@ -1696,13 +1690,13 @@ public sealed class KaseSerialDependencyIndexState : IStreamingIndicatorState, I
     private double _prevValue;
     private bool _hasPrev;
 
-    public KaseSerialDependencyIndexState(int length = 14, InputName inputName = InputName.Close)
+    public KaseSerialDependencyIndexState(int length = 14)
     {
         _length = Math.Max(1, length);
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, _ => _tempLog);
         _highValues = new PooledRingBuffer<double>(_length);
         _lowValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaseSerialDependencyIndex;
@@ -1771,11 +1765,11 @@ public sealed class KaufmanAdaptiveBandsState : IStreamingIndicatorState, IDispo
     private double _prevMiddle;
     private double _prevPowMa;
 
-    public KaufmanAdaptiveBandsState(int length = 100, double stdDevFactor = 3, InputName inputName = InputName.Close)
+    public KaufmanAdaptiveBandsState(int length = 100, double stdDevFactor = 3)
     {
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveBands;
@@ -1836,7 +1830,7 @@ public sealed class KaufmanAdaptiveCorrelationOscillatorState : IStreamingIndica
     private int _index;
 
     public KaufmanAdaptiveCorrelationOscillatorState(MovingAvgType maType = MovingAvgType.KaufmanAdaptiveMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         if (maType == MovingAvgType.KaufmanAdaptiveMovingAverage)
@@ -1856,7 +1850,7 @@ public sealed class KaufmanAdaptiveCorrelationOscillatorState : IStreamingIndica
             _src2Ma = MovingAverageSmootherFactory.Create(maType, resolved);
         }
 
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveCorrelationOscillator;

--- a/src/Streaming/StatefulIndicators.Batch16.cs
+++ b/src/Streaming/StatefulIndicators.Batch16.cs
@@ -15,10 +15,10 @@ public sealed class KaufmanAdaptiveLeastSquaresMovingAverageState : IStreamingIn
     private int _index;
 
     public KaufmanAdaptiveLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.KaufmanAdaptiveMovingAverage,
-        int length = 100, InputName inputName = InputName.Close)
+        int length = 100)
     {
         var resolved = Math.Max(1, length);
-        _kaco = new KaufmanAdaptiveCorrelationOscillatorState(maType, resolved, inputName);
+        _kaco = new KaufmanAdaptiveCorrelationOscillatorState(maType, resolved);
         if (maType == MovingAvgType.KaufmanAdaptiveMovingAverage)
         {
             _srcMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
@@ -29,7 +29,7 @@ public sealed class KaufmanAdaptiveLeastSquaresMovingAverageState : IStreamingIn
             _srcMa = MovingAverageSmootherFactory.Create(maType, resolved);
             _indexMa = MovingAverageSmootherFactory.Create(maType, resolved);
         }
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveLeastSquaresMovingAverage;
@@ -91,14 +91,13 @@ public sealed class KaufmanAdaptiveMovingAverageState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private double _prevKama;
 
-    public KaufmanAdaptiveMovingAverageState(int length = 10, int fastLength = 2, int slowLength = 30,
-        InputName inputName = InputName.Close)
+    public KaufmanAdaptiveMovingAverageState(int length = 10, int fastLength = 2, int slowLength = 30)
     {
         var resolved = Math.Max(1, length);
         _er = new EfficiencyRatioState(resolved);
         _fastAlpha = 2d / (Math.Max(1, fastLength) + 1);
         _slowAlpha = 2d / (Math.Max(1, slowLength) + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveMovingAverage;
@@ -155,7 +154,7 @@ public sealed class KaufmanBinaryWaveState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public KaufmanBinaryWaveState(int length = 20, double fastSc = 0.6022, double slowSc = 0.0645,
-        double filterPct = 10, InputName inputName = InputName.Close)
+        double filterPct = 10)
     {
         var resolved = Math.Max(1, length);
         _er = new EfficiencyRatioState(resolved);
@@ -163,7 +162,7 @@ public sealed class KaufmanBinaryWaveState : IStreamingIndicatorState, IDisposab
         _fastSc = fastSc;
         _slowSc = slowSc;
         _filterPct = filterPct;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanBinaryWave;
@@ -363,14 +362,14 @@ public sealed class KendallRankCorrelationCoefficientState : IStreamingIndicator
     private readonly PooledRingBuffer<double> _linRegValues;
     private readonly StreamingInputResolver _input;
 
-    public KendallRankCorrelationCoefficientState(int length = 20, InputName inputName = InputName.Close)
+    public KendallRankCorrelationCoefficientState(int length = 20)
     {
         _length = Math.Max(1, length);
-        _linReg = new LinearRegressionState(_length, inputName);
+        _linReg = new LinearRegressionState(_length);
         _correlation = new RollingWindowCorrelation(_length);
         _values = new PooledRingBuffer<double>(_length);
         _linRegValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KendallRankCorrelationCoefficient;
@@ -445,14 +444,14 @@ public sealed class KirshenbaumBandsState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
 
     public KirshenbaumBandsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 30, int length2 = 20, double stdDevFactor = 1, InputName inputName = InputName.Close)
+        int length1 = 30, int length2 = 20, double stdDevFactor = 1)
     {
         _length2 = Math.Max(1, length2);
         _stdDevFactor = stdDevFactor;
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _linReg = new LinearRegressionState(_length2, inputName);
+        _linReg = new LinearRegressionState(_length2);
         _errorSum = new RollingWindowSum(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KirshenbaumBands;
@@ -513,12 +512,12 @@ public sealed class KlingerVolumeOscillatorState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public KlingerVolumeOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 34, int slowLength = 55, int signalLength = 13, InputName inputName = InputName.Close)
+        int fastLength = 34, int slowLength = 55, int signalLength = 13)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KlingerVolumeOscillator;
@@ -602,16 +601,16 @@ public sealed class KnowSureThingState : IStreamingIndicatorState, IDisposable
     public KnowSureThingState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 10, int length2 = 10,
         int length3 = 10, int length4 = 15, int rocLength1 = 10, int rocLength2 = 15, int rocLength3 = 20,
         int rocLength4 = 30, int signalLength = 9, double weight1 = 1, double weight2 = 2, double weight3 = 3,
-        double weight4 = 4, InputName inputName = InputName.Close)
+        double weight4 = 4)
     {
         _weight1 = weight1;
         _weight2 = weight2;
         _weight3 = weight3;
         _weight4 = weight4;
-        _roc1 = new RateOfChangeState(Math.Max(1, rocLength1), inputName);
-        _roc2 = new RateOfChangeState(Math.Max(1, rocLength2), inputName);
-        _roc3 = new RateOfChangeState(Math.Max(1, rocLength3), inputName);
-        _roc4 = new RateOfChangeState(Math.Max(1, rocLength4), inputName);
+        _roc1 = new RateOfChangeState(Math.Max(1, rocLength1));
+        _roc2 = new RateOfChangeState(Math.Max(1, rocLength2));
+        _roc3 = new RateOfChangeState(Math.Max(1, rocLength3));
+        _roc4 = new RateOfChangeState(Math.Max(1, rocLength4));
         _roc1Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _roc2Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _roc3Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
@@ -687,8 +686,7 @@ public sealed class KurtosisIndicatorState : IStreamingIndicatorState, IDisposab
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public KurtosisIndicatorState(int length1 = 3, int length2 = 1, int fastLength = 3, int slowLength = 65,
-        InputName inputName = InputName.Close)
+    public KurtosisIndicatorState(int length1 = 3, int length2 = 1, int fastLength = 3, int slowLength = 65)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -696,7 +694,7 @@ public sealed class KurtosisIndicatorState : IStreamingIndicatorState, IDisposab
         _fastSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, fastLength));
         _values = new PooledRingBuffer<double>(_length1);
         _diffs = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KurtosisIndicator;
@@ -762,7 +760,7 @@ public sealed class KwanIndicatorState : IStreamingIndicatorState, IDisposable
     private double _prevSum;
 
     public KwanIndicatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 9,
-        int smoothLength = 2, InputName inputName = InputName.Close)
+        int smoothLength = 2)
     {
         _length = Math.Max(1, length);
         _smoothLength = Math.Max(1, smoothLength);
@@ -771,7 +769,7 @@ public sealed class KwanIndicatorState : IStreamingIndicatorState, IDisposable
         _lowWindow = new RollingWindowMin(_length);
         _values = new PooledRingBuffer<double>(_length);
         _vrValues = new PooledRingBuffer<double>(_smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.KwanIndicator;
@@ -904,11 +902,11 @@ public sealed class LeastSquaresMovingAverageState : IStreamingIndicatorState, I
     private readonly IMovingAverageSmoother _sma;
     private readonly StreamingInputResolver _input;
 
-    public LeastSquaresMovingAverageState(int length = 25, InputName inputName = InputName.Close)
+    public LeastSquaresMovingAverageState(int length = 25)
     {
         _wma = new WmaState(length);
         _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LeastSquaresMovingAverage;
@@ -952,11 +950,11 @@ public sealed class LeoMovingAverageState : IStreamingIndicatorState, IDisposabl
     private readonly IMovingAverageSmoother _sma;
     private readonly StreamingInputResolver _input;
 
-    public LeoMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public LeoMovingAverageState(int length = 14)
     {
         _wma = new WmaState(length);
         _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LeoMovingAverage;
@@ -1006,17 +1004,16 @@ public sealed class LightLeastSquaresMovingAverageState : IStreamingIndicatorSta
     private double _indexValue;
     private int _index;
 
-    public LightLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 250,
-        InputName inputName = InputName.Close)
+    public LightLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 250)
     {
         _length = Math.Max(1, length);
         var length1 = Math.Max(1, (int)Math.Ceiling(_length / 2d));
         _sma1 = MovingAverageSmootherFactory.Create(maType, _length);
         _sma2 = MovingAverageSmootherFactory.Create(maType, length1);
         _indexMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LightLeastSquaresMovingAverage;
@@ -1084,13 +1081,13 @@ public sealed class LindaRaschke3_10OscillatorState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public LindaRaschke3_10OscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int fastLength = 3, int slowLength = 10, int smoothLength = 16, InputName inputName = InputName.Close)
+        int fastLength = 3, int slowLength = 10, int smoothLength = 16)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _macdSignalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _ppoSignalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LindaRaschke3_10Oscillator;
@@ -1148,11 +1145,11 @@ public sealed class LinearExtrapolationState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public LinearExtrapolationState(int length = 500, InputName inputName = InputName.Close)
+    public LinearExtrapolationState(int length = 500)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(Math.Max(1, _length * 2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LinearExtrapolation;
@@ -1207,10 +1204,10 @@ public sealed class LinearQuadraticConvergenceDivergenceOscillatorState : IStrea
     private double _linRegValue;
 
     public LinearQuadraticConvergenceDivergenceOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 50, int signalLength = 25, InputName inputName = InputName.Close)
+        int length = 50, int signalLength = 25)
     {
         var resolved = Math.Max(1, length);
-        _linReg = new LinearRegressionState(resolved, inputName);
+        _linReg = new LinearRegressionState(resolved);
         // Batch contamination: CalculateLinearRegression sets CustomValuesList to linReg output,
         // then CalculateQuadraticRegression uses those linReg values as input (not original close prices)
         _quadReg = new QuadraticRegressionEngine(maType, resolved, _ => _linRegValue);
@@ -1269,8 +1266,7 @@ public sealed class LinearRegressionLineState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public LinearRegressionLineState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public LinearRegressionLineState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _correlation = new RollingWindowCorrelation(_length);
@@ -1278,7 +1274,7 @@ public sealed class LinearRegressionLineState : IStreamingIndicatorState, IDispo
         _xMa = MovingAverageSmootherFactory.Create(maType, _length);
         _yStdDev = new RollingStandardDeviation(_length);
         _xStdDev = new RollingStandardDeviation(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LinearRegressionLine;
@@ -1352,12 +1348,12 @@ public sealed class LinearTrailingStopState : IStreamingIndicatorState
     private bool _hasPrevA;
     private bool _hasPrevA2;
 
-    public LinearTrailingStopState(int length = 14, double mult = 28, InputName inputName = InputName.Close)
+    public LinearTrailingStopState(int length = 14, double mult = 28)
     {
         var resolved = Math.Max(1, length);
         _s = 1d / resolved;
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LinearTrailingStop;
@@ -1416,10 +1412,10 @@ public sealed class LinearWeightedMovingAverageState : IStreamingIndicatorState,
     private readonly WmaState _wma;
     private readonly StreamingInputResolver _input;
 
-    public LinearWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public LinearWeightedMovingAverageState(int length = 14)
     {
         _wma = new WmaState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LinearWeightedMovingAverage;
@@ -1460,10 +1456,10 @@ public sealed class LiquidRelativeStrengthIndexState : IStreamingIndicatorState
     private double _denEma;
     private bool _hasPrev;
 
-    public LiquidRelativeStrengthIndexState(int length = 14, InputName inputName = InputName.Close)
+    public LiquidRelativeStrengthIndexState(int length = 14)
     {
         _k = 1d / Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LiquidRelativeStrengthIndex;
@@ -1520,12 +1516,12 @@ public sealed class LogisticCorrelationState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public LogisticCorrelationState(int length = 100, double k = 10, InputName inputName = InputName.Close)
+    public LogisticCorrelationState(int length = 100, double k = 10)
     {
         _length = Math.Max(1, length);
         _k = k;
         _correlation = new RollingWindowCorrelation(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LogisticCorrelation;
@@ -1580,16 +1576,15 @@ public sealed class MacZIndicatorState : IStreamingIndicatorState, IDisposable
     private readonly double _mult;
 
     public MacZIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 12,
-        int slowLength = 25, int signalLength = 9, int length = 25, double gamma = 0.02, double mult = 1,
-        InputName inputName = InputName.Close)
+        int slowLength = 25, int signalLength = 9, int length = 25, double gamma = 0.02, double mult = 1)
     {
         var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, resolved);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _wilderSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.WildersSmoothingMethod, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mult = mult;
         _ = gamma;
     }
@@ -1659,9 +1654,8 @@ public sealed class MacZVwapIndicatorState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public MacZVwapIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 12,
-        int slowLength = 25, int signalLength = 9, int length1 = 20, int length2 = 25, double gamma = 0.02,
-        InputName inputName = InputName.Close)
-        : this(maType, fastLength, slowLength, signalLength, length1, length2, gamma, new StreamingInputResolver(inputName, null))
+        int slowLength = 25, int signalLength = 9, int length1 = 20, int length2 = 25, double gamma = 0.02)
+        : this(maType, fastLength, slowLength, signalLength, length1, length2, gamma, new StreamingInputResolver(InputName.Close, null))
     {
     }
 
@@ -1768,12 +1762,12 @@ public sealed class MarketDirectionIndicatorState : IStreamingIndicatorState
     private double _prevValue;
     private bool _hasPrev;
 
-    public MarketDirectionIndicatorState(int fastLength = 13, int slowLength = 55, InputName inputName = InputName.Close)
+    public MarketDirectionIndicatorState(int fastLength = 13, int slowLength = 55)
     {
         _fastLength = Math.Max(1, fastLength);
         _slowLength = Math.Max(1, slowLength);
         _sumWindow = new RollingCumulativeSum();
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MarketDirectionIndicator;

--- a/src/Streaming/StatefulIndicators.Batch16.cs
+++ b/src/Streaming/StatefulIndicators.Batch16.cs
@@ -32,28 +32,6 @@ public sealed class KaufmanAdaptiveLeastSquaresMovingAverageState : IStreamingIn
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KaufmanAdaptiveLeastSquaresMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _kaco = new KaufmanAdaptiveCorrelationOscillatorState(maType, resolved, selector);
-        if (maType == MovingAvgType.KaufmanAdaptiveMovingAverage)
-        {
-            _srcMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
-            _indexMa = new KaufmanAdaptiveMovingAverageEngine(resolved);
-        }
-        else
-        {
-            _srcMa = MovingAverageSmootherFactory.Create(maType, resolved);
-            _indexMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        }
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveLeastSquaresMovingAverage;
 
     public void Reset()
@@ -123,21 +101,6 @@ public sealed class KaufmanAdaptiveMovingAverageState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KaufmanAdaptiveMovingAverageState(int length, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _er = new EfficiencyRatioState(resolved);
-        _fastAlpha = 2d / (Math.Max(1, fastLength) + 1);
-        _slowAlpha = 2d / (Math.Max(1, slowLength) + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KaufmanAdaptiveMovingAverage;
 
     public void Reset()
@@ -201,23 +164,6 @@ public sealed class KaufmanBinaryWaveState : IStreamingIndicatorState, IDisposab
         _slowSc = slowSc;
         _filterPct = filterPct;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KaufmanBinaryWaveState(int length, double fastSc, double slowSc, double filterPct,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _er = new EfficiencyRatioState(resolved);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _diffValue);
-        _fastSc = fastSc;
-        _slowSc = slowSc;
-        _filterPct = filterPct;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KaufmanBinaryWave;
@@ -427,21 +373,6 @@ public sealed class KendallRankCorrelationCoefficientState : IStreamingIndicator
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KendallRankCorrelationCoefficientState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _linReg = new LinearRegressionState(_length, selector);
-        _correlation = new RollingWindowCorrelation(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _linRegValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KendallRankCorrelationCoefficient;
 
     public void Reset()
@@ -524,22 +455,6 @@ public sealed class KirshenbaumBandsState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KirshenbaumBandsState(MovingAvgType maType, int length1, int length2, double stdDevFactor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _stdDevFactor = stdDevFactor;
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _linReg = new LinearRegressionState(_length2, selector);
-        _errorSum = new RollingWindowSum(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KirshenbaumBands;
 
     public void Reset()
@@ -604,20 +519,6 @@ public sealed class KlingerVolumeOscillatorState : IStreamingIndicatorState, IDi
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KlingerVolumeOscillatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KlingerVolumeOscillator;
@@ -718,30 +619,6 @@ public sealed class KnowSureThingState : IStreamingIndicatorState, IDisposable
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
     }
 
-    public KnowSureThingState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int rocLength1, int rocLength2, int rocLength3, int rocLength4, int signalLength, double weight1,
-        double weight2, double weight3, double weight4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _weight1 = weight1;
-        _weight2 = weight2;
-        _weight3 = weight3;
-        _weight4 = weight4;
-        _roc1 = new RateOfChangeState(Math.Max(1, rocLength1), selector);
-        _roc2 = new RateOfChangeState(Math.Max(1, rocLength2), selector);
-        _roc3 = new RateOfChangeState(Math.Max(1, rocLength3), selector);
-        _roc4 = new RateOfChangeState(Math.Max(1, rocLength4), selector);
-        _roc1Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _roc2Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _roc3Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _roc4Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-    }
-
     public IndicatorName Name => IndicatorName.KnowSureThing;
 
     public void Reset()
@@ -822,22 +699,6 @@ public sealed class KurtosisIndicatorState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public KurtosisIndicatorState(int length1, int length2, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _slowSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, slowLength));
-        _fastSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, fastLength));
-        _values = new PooledRingBuffer<double>(_length1);
-        _diffs = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.KurtosisIndicator;
 
     public void Reset()
@@ -911,23 +772,6 @@ public sealed class KwanIndicatorState : IStreamingIndicatorState, IDisposable
         _values = new PooledRingBuffer<double>(_length);
         _vrValues = new PooledRingBuffer<double>(_smoothLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public KwanIndicatorState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoothLength = Math.Max(1, smoothLength);
-        _rsi = new RsiState(maType, _length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _vrValues = new PooledRingBuffer<double>(_smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.KwanIndicator;
@@ -1067,18 +911,6 @@ public sealed class LeastSquaresMovingAverageState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LeastSquaresMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wma = new WmaState(length);
-        _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LeastSquaresMovingAverage;
 
     public void Reset()
@@ -1125,18 +957,6 @@ public sealed class LeoMovingAverageState : IStreamingIndicatorState, IDisposabl
         _wma = new WmaState(length);
         _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public LeoMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wma = new WmaState(length);
-        _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.LeoMovingAverage;
@@ -1197,23 +1017,6 @@ public sealed class LightLeastSquaresMovingAverageState : IStreamingIndicatorSta
         _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public LightLeastSquaresMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var length1 = Math.Max(1, (int)Math.Ceiling(_length / 2d));
-        _sma1 = MovingAverageSmootherFactory.Create(maType, _length);
-        _sma2 = MovingAverageSmootherFactory.Create(maType, length1);
-        _indexMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.LightLeastSquaresMovingAverage;
@@ -1290,21 +1093,6 @@ public sealed class LindaRaschke3_10OscillatorState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LindaRaschke3_10OscillatorState(MovingAvgType maType, int fastLength, int slowLength, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _macdSignalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _ppoSignalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LindaRaschke3_10Oscillator;
 
     public void Reset()
@@ -1367,18 +1155,6 @@ public sealed class LinearExtrapolationState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LinearExtrapolationState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(Math.Max(1, _length * 2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LinearExtrapolation;
 
     public void Reset()
@@ -1437,21 +1213,6 @@ public sealed class LinearQuadraticConvergenceDivergenceOscillatorState : IStrea
         _linReg = new LinearRegressionState(resolved, inputName);
         // Batch contamination: CalculateLinearRegression sets CustomValuesList to linReg output,
         // then CalculateQuadraticRegression uses those linReg values as input (not original close prices)
-        _quadReg = new QuadraticRegressionEngine(maType, resolved, _ => _linRegValue);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-    }
-
-    public LinearQuadraticConvergenceDivergenceOscillatorState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _linReg = new LinearRegressionState(resolved, selector);
-        // Batch contamination: quadReg uses linReg output as input
         _quadReg = new QuadraticRegressionEngine(maType, resolved, _ => _linRegValue);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
     }
@@ -1518,22 +1279,6 @@ public sealed class LinearRegressionLineState : IStreamingIndicatorState, IDispo
         _yStdDev = new RollingStandardDeviation(_length);
         _xStdDev = new RollingStandardDeviation(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public LinearRegressionLineState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _correlation = new RollingWindowCorrelation(_length);
-        _yMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _xMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _yStdDev = new RollingStandardDeviation(_length);
-        _xStdDev = new RollingStandardDeviation(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.LinearRegressionLine;
@@ -1615,19 +1360,6 @@ public sealed class LinearTrailingStopState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LinearTrailingStopState(int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _s = 1d / resolved;
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LinearTrailingStop;
 
     public void Reset()
@@ -1690,17 +1422,6 @@ public sealed class LinearWeightedMovingAverageState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LinearWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wma = new WmaState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LinearWeightedMovingAverage;
 
     public void Reset()
@@ -1743,17 +1464,6 @@ public sealed class LiquidRelativeStrengthIndexState : IStreamingIndicatorState
     {
         _k = 1d / Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public LiquidRelativeStrengthIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _k = 1d / Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.LiquidRelativeStrengthIndex;
@@ -1818,19 +1528,6 @@ public sealed class LogisticCorrelationState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LogisticCorrelationState(int length, double k, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _k = k;
-        _correlation = new RollingWindowCorrelation(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.LogisticCorrelation;
 
     public void Reset()
@@ -1893,25 +1590,6 @@ public sealed class MacZIndicatorState : IStreamingIndicatorState, IDisposable
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _wilderSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.WildersSmoothingMethod, resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _mult = mult;
-        _ = gamma;
-    }
-
-    public MacZIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength, int length,
-        double gamma, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _wilderSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.WildersSmoothingMethod, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _mult = mult;
         _ = gamma;
     }
@@ -1984,13 +1662,6 @@ public sealed class MacZVwapIndicatorState : IStreamingIndicatorState, IDisposab
         int slowLength = 25, int signalLength = 9, int length1 = 20, int length2 = 25, double gamma = 0.02,
         InputName inputName = InputName.Close)
         : this(maType, fastLength, slowLength, signalLength, length1, length2, gamma, new StreamingInputResolver(inputName, null))
-    {
-    }
-
-    public MacZVwapIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength, int length1,
-        int length2, double gamma, Func<OhlcvBar, double> selector)
-        : this(maType, fastLength, slowLength, signalLength, length1, length2, gamma,
-            new StreamingInputResolver(InputName.Close, selector ?? throw new ArgumentNullException(nameof(selector))))
     {
     }
 
@@ -2103,19 +1774,6 @@ public sealed class MarketDirectionIndicatorState : IStreamingIndicatorState
         _slowLength = Math.Max(1, slowLength);
         _sumWindow = new RollingCumulativeSum();
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MarketDirectionIndicatorState(int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _slowLength = Math.Max(1, slowLength);
-        _sumWindow = new RollingCumulativeSum();
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MarketDirectionIndicator;

--- a/src/Streaming/StatefulIndicators.Batch17.cs
+++ b/src/Streaming/StatefulIndicators.Batch17.cs
@@ -57,28 +57,6 @@ public sealed class MarketMeannessIndexState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MarketMeannessIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        if (maType == MovingAvgType.EhlersNoiseEliminationTechnology)
-        {
-            _mmiNet = new NoiseEliminationTechnologyEngine(_length);
-        }
-        else
-        {
-            _mmiSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        }
-
-        _values = new PooledRingBuffer<double>(_length);
-        _medianScratch = new double[_length];
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MarketMeannessIndex;
 
     public void Reset()
@@ -162,24 +140,6 @@ public sealed class MartinRatioState : IStreamingIndicatorState, IDisposable
         _ulcerIndex = new UlcerIndexState(_length, _ => _retValue);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MartinRatioState(MovingAvgType maType, int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var barMin = 60d * 24;
-        var minPerYr = 60d * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = MathHelper.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _ulcerIndex = new UlcerIndexState(_length, _ => _retValue);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MartinRatio;
@@ -307,22 +267,6 @@ public sealed class MassThrustIndicatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MassThrustIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _advSum = new RollingWindowSum(resolved);
-        _decSum = new RollingWindowSum(resolved);
-        _advVolSum = new RollingWindowSum(resolved);
-        _decVolSum = new RollingWindowSum(resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MassThrustIndicator;
 
     public void Reset()
@@ -407,22 +351,6 @@ public sealed class MassThrustOscillatorState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MassThrustOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _advSum = new RollingWindowSum(resolved);
-        _decSum = new RollingWindowSum(resolved);
-        _advVolSum = new RollingWindowSum(resolved);
-        _decVolSum = new RollingWindowSum(resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MassThrustOscillator;
 
     public void Reset()
@@ -499,18 +427,6 @@ public sealed class MayerMultipleState : IStreamingIndicatorState, IDisposable
         _ = threshold;
     }
 
-    public MayerMultipleState(MovingAvgType maType, int length, double threshold, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _ = threshold;
-    }
-
     public IndicatorName Name => IndicatorName.MayerMultiple;
 
     public void Reset()
@@ -561,22 +477,6 @@ public sealed class McClellanOscillatorState : IStreamingIndicatorState, IDispos
         _decSum = new RollingWindowSum(resolvedFast);
         _macd = new MacdEngine(maType, resolvedFast, Math.Max(1, slowLength), Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-        _mult = mult;
-    }
-
-    public McClellanOscillatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        _advSum = new RollingWindowSum(resolvedFast);
-        _decSum = new RollingWindowSum(resolvedFast);
-        _macd = new MacdEngine(maType, resolvedFast, Math.Max(1, slowLength), Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _mult = mult;
     }
 
@@ -649,18 +549,6 @@ public sealed class McGinleyDynamicIndicatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public McGinleyDynamicIndicatorState(int length, double k, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _k = k;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.McGinleyDynamicIndicator;
 
     public void Reset()
@@ -713,20 +601,6 @@ public sealed class McNichollMovingAverageState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public McNichollMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = 2d / (resolved + 1);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.McNichollMovingAverage;
 
     public void Reset()
@@ -772,18 +646,6 @@ public sealed class MiddleHighLowMovingAverageState : IStreamingIndicatorState, 
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _midpoint = new MidpointState(Math.Max(1, length2), inputName);
-    }
-
-    public MiddleHighLowMovingAverageState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _midpoint = new MidpointState(Math.Max(1, length2), selector);
     }
 
     public IndicatorName Name => IndicatorName.MiddleHighLowMovingAverage;
@@ -833,20 +695,6 @@ public sealed class MidpointOscillatorState : IStreamingIndicatorState, IDisposa
         _lowWindow = new RollingWindowMin(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MidpointOscillatorState(MovingAvgType maType, int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MidpointOscillator;
@@ -1048,26 +896,6 @@ public sealed class MobilityOscillatorState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MobilityOscillatorState(MovingAvgType maType, int length1, int length2, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _highWindow = new RollingWindowMax(_length2);
-        _lowWindow = new RollingWindowMin(_length2);
-        _moSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _highValues = new PooledRingBuffer<double>(_length1 + _length2 + 1);
-        _lowValues = new PooledRingBuffer<double>(_length1 + _length2 + 1);
-        _values = new PooledRingBuffer<double>(_length2 + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MobilityOscillator;
 
     public void Reset()
@@ -1224,23 +1052,6 @@ public sealed class ModifiedGannHiloActivatorState : IStreamingIndicatorState, I
         _mult = mult;
     }
 
-    public ModifiedGannHiloActivatorState(MovingAvgType maType, int length, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _cSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _dSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _mult = mult;
-    }
-
     public IndicatorName Name => IndicatorName.ModifiedGannHiloActivator;
 
     public void Reset()
@@ -1315,17 +1126,6 @@ public sealed class ModifiedPriceVolumeTrendState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ModifiedPriceVolumeTrendState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ModifiedPriceVolumeTrend;
 
     public void Reset()
@@ -1387,19 +1187,6 @@ public sealed class ModularFilterState : IStreamingIndicatorState
         _alpha = 2d / (Math.Max(1, length) + 1);
         _beta = beta;
         _input = new StreamingInputResolver(inputName, null);
-        _ = z;
-    }
-
-    public ModularFilterState(int length, double beta, double z, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = 2d / (Math.Max(1, length) + 1);
-        _beta = beta;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _ = z;
     }
 
@@ -1469,21 +1256,6 @@ public sealed class MomentaRelativeStrengthIndexState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MomentaRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _maxWindow = new RollingWindowMax(Math.Max(1, length1));
-        _minWindow = new RollingWindowMin(Math.Max(1, length1));
-        _topSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _botSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MomentaRelativeStrengthIndex;
 
     public void Reset()
@@ -1547,19 +1319,6 @@ public sealed class MomentumOscillatorState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MomentumOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MomentumOscillator;
 
     public void Reset()
@@ -1615,19 +1374,6 @@ public sealed class MorphedSineWaveState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MorphedSineWaveState(int length, double power, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _power = power;
-        _p = resolved / (2 * Math.PI);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MorphedSineWave;
 
     public void Reset()
@@ -1673,19 +1419,6 @@ public sealed class MotionSmoothnessIndexState : IStreamingIndicatorState, IDisp
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, inputName);
         _chgStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _chgValue);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MotionSmoothnessIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, selector);
-        _chgStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _chgValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MotionSmoothnessIndex;
@@ -1749,17 +1482,6 @@ public sealed class MotionToAttractionTrailingStopState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MotionToAttractionTrailingStopState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _channels = new MotionToAttractionChannelsState(length, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MotionToAttractionTrailingStop;
 
     public void Reset()
@@ -1815,16 +1537,6 @@ public sealed class MoveTrackerState : IStreamingIndicatorState
     public MoveTrackerState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MoveTrackerState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MoveTracker;
@@ -1884,23 +1596,6 @@ public sealed class MovingAverageAdaptiveFilterState : IStreamingIndicatorState,
         _er = new EfficiencyRatioState(resolved);
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _amaDiff);
         _input = new StreamingInputResolver(inputName, null);
-        _filter = filter;
-        _fastAlpha = fastAlpha;
-        _slowAlpha = slowAlpha;
-    }
-
-    public MovingAverageAdaptiveFilterState(int length, double filter, double fastAlpha, double slowAlpha,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _er = new EfficiencyRatioState(resolved);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _amaDiff);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _filter = filter;
         _fastAlpha = fastAlpha;
         _slowAlpha = slowAlpha;

--- a/src/Streaming/StatefulIndicators.Batch17.cs
+++ b/src/Streaming/StatefulIndicators.Batch17.cs
@@ -40,7 +40,7 @@ public sealed class MarketMeannessIndexState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
 
     public MarketMeannessIndexState(MovingAvgType maType = MovingAvgType.EhlersNoiseEliminationTechnology,
-        int length = 100, InputName inputName = InputName.Close)
+        int length = 100)
     {
         _length = Math.Max(1, length);
         if (maType == MovingAvgType.EhlersNoiseEliminationTechnology)
@@ -54,7 +54,7 @@ public sealed class MarketMeannessIndexState : IStreamingIndicatorState, IDispos
 
         _values = new PooledRingBuffer<double>(_length);
         _medianScratch = new double[_length];
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MarketMeannessIndex;
@@ -129,7 +129,7 @@ public sealed class MartinRatioState : IStreamingIndicatorState, IDisposable
     private double _retValue;
 
     public MartinRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 30, double bmk = 0.02, InputName inputName = InputName.Close)
+        int length = 30, double bmk = 0.02)
     {
         _length = Math.Max(1, length);
         var barMin = 60d * 24;
@@ -139,7 +139,7 @@ public sealed class MartinRatioState : IStreamingIndicatorState, IDisposable
         _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _ulcerIndex = new UlcerIndexState(_length, _ => _retValue);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MartinRatio;
@@ -256,7 +256,7 @@ public sealed class MassThrustIndicatorState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public MassThrustIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _advSum = new RollingWindowSum(resolved);
@@ -264,7 +264,7 @@ public sealed class MassThrustIndicatorState : IStreamingIndicatorState, IDispos
         _advVolSum = new RollingWindowSum(resolved);
         _decVolSum = new RollingWindowSum(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MassThrustIndicator;
@@ -340,7 +340,7 @@ public sealed class MassThrustOscillatorState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public MassThrustOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _advSum = new RollingWindowSum(resolved);
@@ -348,7 +348,7 @@ public sealed class MassThrustOscillatorState : IStreamingIndicatorState, IDispo
         _advVolSum = new RollingWindowSum(resolved);
         _decVolSum = new RollingWindowSum(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MassThrustOscillator;
@@ -420,10 +420,10 @@ public sealed class MayerMultipleState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public MayerMultipleState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 200, double threshold = 2.4, InputName inputName = InputName.Close)
+        int length = 200, double threshold = 2.4)
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _ = threshold;
     }
 
@@ -469,14 +469,13 @@ public sealed class McClellanOscillatorState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public McClellanOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 19, int slowLength = 39, int signalLength = 9, double mult = 1000,
-        InputName inputName = InputName.Close)
+        int fastLength = 19, int slowLength = 39, int signalLength = 9, double mult = 1000)
     {
         var resolvedFast = Math.Max(1, fastLength);
         _advSum = new RollingWindowSum(resolvedFast);
         _decSum = new RollingWindowSum(resolvedFast);
         _macd = new MacdEngine(maType, resolvedFast, Math.Max(1, slowLength), Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mult = mult;
     }
 
@@ -542,11 +541,11 @@ public sealed class McGinleyDynamicIndicatorState : IStreamingIndicatorState
     private double _prevMdi;
     private bool _hasPrev;
 
-    public McGinleyDynamicIndicatorState(int length = 14, double k = 0.6, InputName inputName = InputName.Close)
+    public McGinleyDynamicIndicatorState(int length = 14, double k = 0.6)
     {
         _length = Math.Max(1, length);
         _k = k;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.McGinleyDynamicIndicator;
@@ -592,13 +591,13 @@ public sealed class McNichollMovingAverageState : IStreamingIndicatorState, IDis
     private readonly StreamingInputResolver _input;
 
     public McNichollMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 20, InputName inputName = InputName.Close)
+        int length = 20)
     {
         var resolved = Math.Max(1, length);
         _alpha = 2d / (resolved + 1);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.McNichollMovingAverage;
@@ -642,10 +641,10 @@ public sealed class MiddleHighLowMovingAverageState : IStreamingIndicatorState, 
     private readonly MidpointState _midpoint;
 
     public MiddleHighLowMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 14, int length2 = 10, InputName inputName = InputName.Close)
+        int length1 = 14, int length2 = 10)
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _midpoint = new MidpointState(Math.Max(1, length2), inputName);
+        _midpoint = new MidpointState(Math.Max(1, length2));
     }
 
     public IndicatorName Name => IndicatorName.MiddleHighLowMovingAverage;
@@ -688,13 +687,13 @@ public sealed class MidpointOscillatorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public MidpointOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 26, int signalLength = 9, InputName inputName = InputName.Close)
+        int length = 26, int signalLength = 9)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MidpointOscillator;
@@ -882,7 +881,7 @@ public sealed class MobilityOscillatorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public MobilityOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length1 = 10, int length2 = 14, int signalLength = 7, InputName inputName = InputName.Close)
+        int length1 = 10, int length2 = 14, int signalLength = 7)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -893,7 +892,7 @@ public sealed class MobilityOscillatorState : IStreamingIndicatorState, IDisposa
         _highValues = new PooledRingBuffer<double>(_length1 + _length2 + 1);
         _lowValues = new PooledRingBuffer<double>(_length1 + _length2 + 1);
         _values = new PooledRingBuffer<double>(_length2 + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MobilityOscillator;
@@ -1041,14 +1040,14 @@ public sealed class ModifiedGannHiloActivatorState : IStreamingIndicatorState, I
     private bool _hasPrev;
 
     public ModifiedGannHiloActivatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 50, double mult = 1, InputName inputName = InputName.Close)
+        int length = 50, double mult = 1)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _cSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _dSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mult = mult;
     }
 
@@ -1120,10 +1119,10 @@ public sealed class ModifiedPriceVolumeTrendState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public ModifiedPriceVolumeTrendState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 23, InputName inputName = InputName.Close)
+        int length = 23)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ModifiedPriceVolumeTrend;
@@ -1181,12 +1180,11 @@ public sealed class ModularFilterState : IStreamingIndicatorState
     private double _prevOs2;
     private bool _hasPrev;
 
-    public ModularFilterState(int length = 200, double beta = 0.8, double z = 0.5,
-        InputName inputName = InputName.Close)
+    public ModularFilterState(int length = 200, double beta = 0.8, double z = 0.5)
     {
         _alpha = 2d / (Math.Max(1, length) + 1);
         _beta = beta;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _ = z;
     }
 
@@ -1246,14 +1244,14 @@ public sealed class MomentaRelativeStrengthIndexState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public MomentaRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 2, int length2 = 14, InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 14)
     {
         _maxWindow = new RollingWindowMax(Math.Max(1, length1));
         _minWindow = new RollingWindowMin(Math.Max(1, length1));
         _topSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _botSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MomentaRelativeStrengthIndex;
@@ -1311,12 +1309,12 @@ public sealed class MomentumOscillatorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public MomentumOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MomentumOscillator;
@@ -1366,12 +1364,12 @@ public sealed class MorphedSineWaveState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public MorphedSineWaveState(int length = 14, double power = 100, InputName inputName = InputName.Close)
+    public MorphedSineWaveState(int length = 14, double power = 100)
     {
         var resolved = Math.Max(1, length);
         _power = power;
         _p = resolved / (2 * Math.PI);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MorphedSineWave;
@@ -1413,12 +1411,12 @@ public sealed class MotionSmoothnessIndexState : IStreamingIndicatorState, IDisp
     private double _chgValue;
     private bool _hasPrev;
 
-    public MotionSmoothnessIndexState(int length = 50, InputName inputName = InputName.Close)
+    public MotionSmoothnessIndexState(int length = 50)
     {
         var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved);
         _chgStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _chgValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MotionSmoothnessIndex;
@@ -1476,10 +1474,10 @@ public sealed class MotionToAttractionTrailingStopState : IStreamingIndicatorSta
     private double _prevOs;
     private bool _hasPrev;
 
-    public MotionToAttractionTrailingStopState(int length = 14, InputName inputName = InputName.Close)
+    public MotionToAttractionTrailingStopState(int length = 14)
     {
-        _channels = new MotionToAttractionChannelsState(length, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _channels = new MotionToAttractionChannelsState(length);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MotionToAttractionTrailingStop;
@@ -1534,9 +1532,9 @@ public sealed class MoveTrackerState : IStreamingIndicatorState
     private double _prevMt;
     private bool _hasPrev;
 
-    public MoveTrackerState(InputName inputName = InputName.Close)
+    public MoveTrackerState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MoveTracker;
@@ -1590,12 +1588,12 @@ public sealed class MovingAverageAdaptiveFilterState : IStreamingIndicatorState,
     private bool _hasPrev;
 
     public MovingAverageAdaptiveFilterState(int length = 10, double filter = 0.15,
-        double fastAlpha = 0.667, double slowAlpha = 0.0645, InputName inputName = InputName.Close)
+        double fastAlpha = 0.667, double slowAlpha = 0.0645)
     {
         var resolved = Math.Max(1, length);
         _er = new EfficiencyRatioState(resolved);
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, _ => _amaDiff);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _filter = filter;
         _fastAlpha = fastAlpha;
         _slowAlpha = slowAlpha;

--- a/src/Streaming/StatefulIndicators.Batch18.cs
+++ b/src/Streaming/StatefulIndicators.Batch18.cs
@@ -14,12 +14,11 @@ public sealed class MovingAverageAdaptiveQState : IStreamingIndicatorState, IDis
     private double _prevMaaq;
     private bool _hasPrev;
 
-    public MovingAverageAdaptiveQState(int length = 10, double fastAlpha = 0.667, double slowAlpha = 0.0645,
-        InputName inputName = InputName.Close)
+    public MovingAverageAdaptiveQState(int length = 10, double fastAlpha = 0.667, double slowAlpha = 0.0645)
     {
         var resolved = Math.Max(1, length);
         _er = new EfficiencyRatioState(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _fastAlpha = fastAlpha;
         _slowAlpha = slowAlpha;
     }
@@ -74,7 +73,7 @@ public sealed class MovingAverageBandWidthState : IStreamingIndicatorState, IDis
     private readonly double _mult;
 
     public MovingAverageBandWidthState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 10,
-        int slowLength = 50, double mult = 1, InputName inputName = InputName.Close)
+        int slowLength = 50, double mult = 1)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -82,7 +81,7 @@ public sealed class MovingAverageBandWidthState : IStreamingIndicatorState, IDis
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _sqSum = new RollingWindowSum(resolvedFast);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageBandWidth;
@@ -138,7 +137,7 @@ public sealed class MovingAverageConvergenceDivergenceLeaderState : IStreamingIn
     private readonly StreamingInputResolver _input;
 
     public MovingAverageConvergenceDivergenceLeaderState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 12, int slowLength = 26, int signalLength = 9, InputName inputName = InputName.Close)
+        int fastLength = 12, int slowLength = 26, int signalLength = 9)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -147,7 +146,7 @@ public sealed class MovingAverageConvergenceDivergenceLeaderState : IStreamingIn
         _diffFastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
         _diffSlowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageConvergenceDivergenceLeader;
@@ -207,13 +206,13 @@ public sealed class MovingAverageV3State : IStreamingIndicatorState, IDisposable
     private readonly double _alpha;
 
     public MovingAverageV3State(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 14,
-        int length2 = 3, InputName inputName = InputName.Close)
+        int length2 = 3)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
         _ma1 = MovingAverageSmootherFactory.Create(maType, resolved1);
         _ma2 = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         var lamdaRatio = (double)resolved1 / resolved2;
         _alpha = resolved1 - lamdaRatio != 0 ? lamdaRatio * (resolved1 - 1) / (resolved1 - lamdaRatio) : 0;
     }
@@ -275,7 +274,7 @@ public sealed class MultiDepthZeroLagExponentialMovingAverageState : IStreamingI
     private double _beta3_3;
     private int _index;
 
-    public MultiDepthZeroLagExponentialMovingAverageState(int length = 50, InputName inputName = InputName.Close)
+    public MultiDepthZeroLagExponentialMovingAverageState(int length = 50)
     {
         var resolved = Math.Max(1, length);
         _a1 = (double)2 / (resolved + 1);
@@ -284,7 +283,7 @@ public sealed class MultiDepthZeroLagExponentialMovingAverageState : IStreamingI
         _b2 = 2 * _a2 * Math.Cos(MathHelper.Sqrt(2) * Math.PI / resolved);
         _b3 = 2 * _a3 * Math.Cos(MathHelper.Sqrt(3) * Math.PI / resolved);
         _c = MathHelper.Exp(-2 * Math.PI / resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MultiDepthZeroLagExponentialMovingAverage;
@@ -381,12 +380,12 @@ public sealed class MultiLevelIndicatorState : IStreamingIndicatorState, IDispos
     private readonly PooledRingBuffer<double> _openValues;
     private readonly StreamingInputResolver _input;
 
-    public MultiLevelIndicatorState(int length = 14, double factor = 10000, InputName inputName = InputName.Close)
+    public MultiLevelIndicatorState(int length = 14, double factor = 10000)
     {
         _length = Math.Max(1, length);
         _factor = factor;
         _openValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MultiLevelIndicator;
@@ -436,11 +435,10 @@ public sealed class MultiVoteOnBalanceVolumeState : IStreamingIndicatorState, ID
     private double _prevMvo;
     private bool _hasPrev;
 
-    public MultiVoteOnBalanceVolumeState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public MultiVoteOnBalanceVolumeState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MultiVoteOnBalanceVolume;
@@ -507,12 +505,12 @@ public sealed class NarrowBandpassFilterState : IStreamingIndicatorState, IDispo
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public NarrowBandpassFilterState(int length = 50, InputName inputName = InputName.Close)
+    public NarrowBandpassFilterState(int length = 50)
     {
         _length = Math.Max(1, length);
         _weights = BuildWeights(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NarrowBandpassFilter;
@@ -574,10 +572,10 @@ public sealed class NaturalDirectionalComboState : IStreamingIndicatorState, IDi
     private readonly NaturalStochasticIndicatorState _nst;
 
     public NaturalDirectionalComboState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40,
-        int smoothLength = 20, InputName inputName = InputName.Close)
+        int smoothLength = 20)
     {
-        _ndx = new NaturalDirectionalIndexState(maType, length, smoothLength, inputName);
-        _nst = new NaturalStochasticIndicatorState(maType, length, smoothLength, inputName);
+        _ndx = new NaturalDirectionalIndexState(maType, length, smoothLength);
+        _nst = new NaturalStochasticIndicatorState(maType, length, smoothLength);
     }
 
     public IndicatorName Name => IndicatorName.NaturalDirectionalCombo;
@@ -624,12 +622,12 @@ public sealed class NaturalDirectionalIndexState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
 
     public NaturalDirectionalIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40,
-        int smoothLength = 20, InputName inputName = InputName.Close)
+        int smoothLength = 20)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalDirectionalIndex;
@@ -693,10 +691,10 @@ public sealed class NaturalMarketComboState : IStreamingIndicatorState, IDisposa
     private readonly IMovingAverageSmoother _signalSmoother;
 
     public NaturalMarketComboState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 40,
-        int smoothLength = 20, InputName inputName = InputName.Close)
+        int smoothLength = 20)
     {
-        _nmr = new NaturalMarketRiverState(maType, length, inputName);
-        _nmm = new NaturalMarketMirrorState(maType, length, inputName);
+        _nmr = new NaturalMarketRiverState(maType, length);
+        _nmm = new NaturalMarketMirrorState(maType, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
     }
 
@@ -746,13 +744,12 @@ public sealed class NaturalMarketMirrorState : IStreamingIndicatorState, IDispos
     private readonly PooledRingBuffer<double> _lnValues;
     private readonly StreamingInputResolver _input;
 
-    public NaturalMarketMirrorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40,
-        InputName inputName = InputName.Close)
+    public NaturalMarketMirrorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMarketMirror;
@@ -808,13 +805,12 @@ public sealed class NaturalMarketRiverState : IStreamingIndicatorState, IDisposa
     private readonly PooledRingBuffer<double> _lnValues;
     private readonly StreamingInputResolver _input;
 
-    public NaturalMarketRiverState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40,
-        InputName inputName = InputName.Close)
+    public NaturalMarketRiverState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 40)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMarketRiver;
@@ -872,11 +868,11 @@ public sealed class NaturalMarketSlopeState : IStreamingIndicatorState, IDisposa
     private double _prevLinReg;
     private bool _hasPrev;
 
-    public NaturalMarketSlopeState(int length = 40, InputName inputName = InputName.Close)
+    public NaturalMarketSlopeState(int length = 40)
     {
         _length = Math.Max(1, length);
         _regression = new LinearRegressionState(_length, _ => _regressionInput);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMarketSlope;
@@ -929,11 +925,11 @@ public sealed class NaturalMovingAverageState : IStreamingIndicatorState, IDispo
     private double _prevValue;
     private bool _hasPrev;
 
-    public NaturalMovingAverageState(int length = 40, InputName inputName = InputName.Close)
+    public NaturalMovingAverageState(int length = 40)
     {
         _length = Math.Max(1, length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMovingAverage;
@@ -1001,7 +997,7 @@ public sealed class NaturalStochasticIndicatorState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public NaturalStochasticIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        int smoothLength = 10, InputName inputName = InputName.Close)
+        int smoothLength = 10)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
@@ -1010,7 +1006,7 @@ public sealed class NaturalStochasticIndicatorState : IStreamingIndicatorState, 
         _highestValues = new PooledRingBuffer<double>(_length);
         _lowestValues = new PooledRingBuffer<double>(_length);
         _inputValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NaturalStochasticIndicator;
@@ -1139,15 +1135,15 @@ public sealed class NegativeVolumeDisparityIndicatorState : IStreamingIndicatorS
     private bool _hasPrev;
 
     public NegativeVolumeDisparityIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 33,
-        int signalLength = 4, double top = 1.1, double bottom = 0.9, InputName inputName = InputName.Close)
+        int signalLength = 4, double top = 1.1, double bottom = 0.9)
     {
         var resolved = Math.Max(1, length);
         _inputSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _nviSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved);
         _nviStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _nviInput);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _top = top;
         _bottom = bottom;
     }
@@ -1250,10 +1246,10 @@ public sealed class NegativeVolumeIndexState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public NegativeVolumeIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 255,
-        int initialValue = 1000, InputName inputName = InputName.Close)
+        int initialValue = 1000)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _initialValue = initialValue;
     }
 
@@ -1318,10 +1314,10 @@ public sealed class NickRypockTrailingReverseState : IStreamingIndicatorState
     private double _lp;
     private bool _hasPrev;
 
-    public NickRypockTrailingReverseState(int length = 2, InputName inputName = InputName.Close)
+    public NickRypockTrailingReverseState(int length = 2)
     {
         _pct = Math.Max(1, length) * 0.01;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NickRypockTrailingReverse;
@@ -1405,7 +1401,7 @@ public sealed class NormalizedRelativeVigorIndexState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public NormalizedRelativeVigorIndexState(MovingAvgType maType = MovingAvgType.SymmetricallyWeightedMovingAverage,
-        int length = 10, InputName inputName = InputName.Close)
+        int length = 10)
     {
         var resolved = Math.Max(1, length);
         _closeOpenSum = new RollingWindowSum(resolved);
@@ -1413,7 +1409,7 @@ public sealed class NormalizedRelativeVigorIndexState : IStreamingIndicatorState
         _closeOpenSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _highLowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NormalizedRelativeVigorIndex;
@@ -1469,12 +1465,12 @@ public sealed class NthOrderDifferencingOscillatorState : IStreamingIndicatorSta
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public NthOrderDifferencingOscillatorState(int length = 14, int lbLength = 2, InputName inputName = InputName.Close)
+    public NthOrderDifferencingOscillatorState(int length = 14, int lbLength = 2)
     {
         _length = Math.Max(1, length);
         _lbLength = Math.Max(0, lbLength);
         _values = new PooledRingBuffer<double>((_length * (_lbLength + 1)) + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NthOrderDifferencingOscillator;
@@ -1529,13 +1525,12 @@ public sealed class OceanIndicatorState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _lnValues;
     private readonly StreamingInputResolver _input;
 
-    public OceanIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public OceanIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OceanIndicator;
@@ -1585,13 +1580,12 @@ public sealed class OCHistogramState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _closeSmoother;
     private readonly StreamingInputResolver _input;
 
-    public OCHistogramState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 10,
-        InputName inputName = InputName.Close)
+    public OCHistogramState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 10)
     {
         var resolved = Math.Max(1, length);
         _openSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _closeSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OCHistogram;
@@ -1636,7 +1630,7 @@ public sealed class OmegaRatioState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _returns;
     private readonly StreamingInputResolver _input;
 
-    public OmegaRatioState(int length = 30, double bmk = 0.05, InputName inputName = InputName.Close)
+    public OmegaRatioState(int length = 30, double bmk = 0.05)
     {
         _length = Math.Max(1, length);
         var barMin = 60d * 24;
@@ -1645,7 +1639,7 @@ public sealed class OmegaRatioState : IStreamingIndicatorState, IDisposable
         _bench = MathHelper.Pow(1 + bmk, _length / barsPerYr) - 1;
         _values = new PooledRingBuffer<double>(_length + 1);
         _returns = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OmegaRatio;
@@ -1715,15 +1709,15 @@ public sealed class OnBalanceVolumeDisparityIndicatorState : IStreamingIndicator
     private bool _hasPrev;
 
     public OnBalanceVolumeDisparityIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 33,
-        int signalLength = 4, double top = 1.1, double bottom = 0.9, InputName inputName = InputName.Close)
+        int signalLength = 4, double top = 1.1, double bottom = 0.9)
     {
         var resolved = Math.Max(1, length);
         _inputSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _obvSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved);
         _obvStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _obvInput);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _top = top;
         _bottom = bottom;
     }

--- a/src/Streaming/StatefulIndicators.Batch18.cs
+++ b/src/Streaming/StatefulIndicators.Batch18.cs
@@ -24,20 +24,6 @@ public sealed class MovingAverageAdaptiveQState : IStreamingIndicatorState, IDis
         _slowAlpha = slowAlpha;
     }
 
-    public MovingAverageAdaptiveQState(int length, double fastAlpha, double slowAlpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _er = new EfficiencyRatioState(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _fastAlpha = fastAlpha;
-        _slowAlpha = slowAlpha;
-    }
-
     public IndicatorName Name => IndicatorName.MovingAverageAdaptiveQ;
 
     public void Reset()
@@ -97,23 +83,6 @@ public sealed class MovingAverageBandWidthState : IStreamingIndicatorState, IDis
         _sqSum = new RollingWindowSum(resolvedFast);
         _mult = mult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MovingAverageBandWidthState(MovingAvgType maType, int fastLength, int slowLength, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _sqSum = new RollingWindowSum(resolvedFast);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageBandWidth;
@@ -181,24 +150,6 @@ public sealed class MovingAverageConvergenceDivergenceLeaderState : IStreamingIn
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MovingAverageConvergenceDivergenceLeaderState(MovingAvgType maType, int fastLength, int slowLength,
-        int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _diffFastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _diffSlowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MovingAverageConvergenceDivergenceLeader;
 
     public void Reset()
@@ -263,22 +214,6 @@ public sealed class MovingAverageV3State : IStreamingIndicatorState, IDisposable
         _ma1 = MovingAverageSmootherFactory.Create(maType, resolved1);
         _ma2 = MovingAverageSmootherFactory.Create(maType, resolved2);
         _input = new StreamingInputResolver(inputName, null);
-        var lamdaRatio = (double)resolved1 / resolved2;
-        _alpha = resolved1 - lamdaRatio != 0 ? lamdaRatio * (resolved1 - 1) / (resolved1 - lamdaRatio) : 0;
-    }
-
-    public MovingAverageV3State(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _ma1 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _ma2 = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         var lamdaRatio = (double)resolved1 / resolved2;
         _alpha = resolved1 - lamdaRatio != 0 ? lamdaRatio * (resolved1 - 1) / (resolved1 - lamdaRatio) : 0;
     }
@@ -350,23 +285,6 @@ public sealed class MultiDepthZeroLagExponentialMovingAverageState : IStreamingI
         _b3 = 2 * _a3 * Math.Cos(MathHelper.Sqrt(3) * Math.PI / resolved);
         _c = MathHelper.Exp(-2 * Math.PI / resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MultiDepthZeroLagExponentialMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _a1 = (double)2 / (resolved + 1);
-        _a2 = MathHelper.Exp(-MathHelper.Sqrt(2) * Math.PI / resolved);
-        _a3 = MathHelper.Exp(-Math.PI / resolved);
-        _b2 = 2 * _a2 * Math.Cos(MathHelper.Sqrt(2) * Math.PI / resolved);
-        _b3 = 2 * _a3 * Math.Cos(MathHelper.Sqrt(3) * Math.PI / resolved);
-        _c = MathHelper.Exp(-2 * Math.PI / resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MultiDepthZeroLagExponentialMovingAverage;
@@ -471,19 +389,6 @@ public sealed class MultiLevelIndicatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MultiLevelIndicatorState(int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _factor = factor;
-        _openValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MultiLevelIndicator;
 
     public void Reset()
@@ -536,17 +441,6 @@ public sealed class MultiVoteOnBalanceVolumeState : IStreamingIndicatorState, ID
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MultiVoteOnBalanceVolumeState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MultiVoteOnBalanceVolume;
@@ -621,19 +515,6 @@ public sealed class NarrowBandpassFilterState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public NarrowBandpassFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = BuildWeights(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NarrowBandpassFilter;
 
     public void Reset()
@@ -699,12 +580,6 @@ public sealed class NaturalDirectionalComboState : IStreamingIndicatorState, IDi
         _nst = new NaturalStochasticIndicatorState(maType, length, smoothLength, inputName);
     }
 
-    public NaturalDirectionalComboState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        _ndx = new NaturalDirectionalIndexState(maType, length, smoothLength, selector);
-        _nst = new NaturalStochasticIndicatorState(maType, length, smoothLength, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NaturalDirectionalCombo;
 
     public void Reset()
@@ -755,19 +630,6 @@ public sealed class NaturalDirectionalIndexState : IStreamingIndicatorState, IDi
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _lnValues = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NaturalDirectionalIndexState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NaturalDirectionalIndex;
@@ -838,13 +700,6 @@ public sealed class NaturalMarketComboState : IStreamingIndicatorState, IDisposa
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
     }
 
-    public NaturalMarketComboState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        _nmr = new NaturalMarketRiverState(maType, length, selector);
-        _nmm = new NaturalMarketMirrorState(maType, length, selector);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-    }
-
     public IndicatorName Name => IndicatorName.NaturalMarketCombo;
 
     public void Reset()
@@ -898,19 +753,6 @@ public sealed class NaturalMarketMirrorState : IStreamingIndicatorState, IDispos
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NaturalMarketMirrorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMarketMirror;
@@ -975,19 +817,6 @@ public sealed class NaturalMarketRiverState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public NaturalMarketRiverState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NaturalMarketRiver;
 
     public void Reset()
@@ -1050,18 +879,6 @@ public sealed class NaturalMarketSlopeState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public NaturalMarketSlopeState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _regression = new LinearRegressionState(_length, _ => _regressionInput);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NaturalMarketSlope;
 
     public void Reset()
@@ -1117,18 +934,6 @@ public sealed class NaturalMovingAverageState : IStreamingIndicatorState, IDispo
         _length = Math.Max(1, length);
         _lnValues = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NaturalMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NaturalMovingAverage;
@@ -1206,23 +1011,6 @@ public sealed class NaturalStochasticIndicatorState : IStreamingIndicatorState, 
         _lowestValues = new PooledRingBuffer<double>(_length);
         _inputValues = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NaturalStochasticIndicatorState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _highValues = new PooledRingBuffer<double>(_length);
-        _lowValues = new PooledRingBuffer<double>(_length);
-        _highestValues = new PooledRingBuffer<double>(_length);
-        _lowestValues = new PooledRingBuffer<double>(_length);
-        _inputValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NaturalStochasticIndicator;
@@ -1364,25 +1152,6 @@ public sealed class NegativeVolumeDisparityIndicatorState : IStreamingIndicatorS
         _bottom = bottom;
     }
 
-    public NegativeVolumeDisparityIndicatorState(MovingAvgType maType, int length, int signalLength, double top, double bottom,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _inputSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _nviSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _nviStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _nviInput);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _top = top;
-        _bottom = bottom;
-    }
-
     public IndicatorName Name => IndicatorName.NegativeVolumeDisparityIndicator;
 
     public void Reset()
@@ -1488,18 +1257,6 @@ public sealed class NegativeVolumeIndexState : IStreamingIndicatorState, IDispos
         _initialValue = initialValue;
     }
 
-    public NegativeVolumeIndexState(MovingAvgType maType, int length, int initialValue, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _initialValue = initialValue;
-    }
-
     public IndicatorName Name => IndicatorName.NegativeVolumeIndex;
 
     public void Reset()
@@ -1565,17 +1322,6 @@ public sealed class NickRypockTrailingReverseState : IStreamingIndicatorState
     {
         _pct = Math.Max(1, length) * 0.01;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NickRypockTrailingReverseState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _pct = Math.Max(1, length) * 0.01;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NickRypockTrailingReverse;
@@ -1670,22 +1416,6 @@ public sealed class NormalizedRelativeVigorIndexState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public NormalizedRelativeVigorIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _closeOpenSum = new RollingWindowSum(resolved);
-        _highLowSum = new RollingWindowSum(resolved);
-        _closeOpenSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _highLowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NormalizedRelativeVigorIndex;
 
     public void Reset()
@@ -1745,19 +1475,6 @@ public sealed class NthOrderDifferencingOscillatorState : IStreamingIndicatorSta
         _lbLength = Math.Max(0, lbLength);
         _values = new PooledRingBuffer<double>((_length * (_lbLength + 1)) + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public NthOrderDifferencingOscillatorState(int length, int lbLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _lbLength = Math.Max(0, lbLength);
-        _values = new PooledRingBuffer<double>((_length * (_lbLength + 1)) + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.NthOrderDifferencingOscillator;
@@ -1821,19 +1538,6 @@ public sealed class OceanIndicatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public OceanIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _lnValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.OceanIndicator;
 
     public void Reset()
@@ -1890,19 +1594,6 @@ public sealed class OCHistogramState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public OCHistogramState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _openSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _closeSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.OCHistogram;
 
     public void Reset()
@@ -1955,23 +1646,6 @@ public sealed class OmegaRatioState : IStreamingIndicatorState, IDisposable
         _values = new PooledRingBuffer<double>(_length + 1);
         _returns = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public OmegaRatioState(int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var barMin = 60d * 24;
-        var minPerYr = 60d * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = MathHelper.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _returns = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.OmegaRatio;
@@ -2050,25 +1724,6 @@ public sealed class OnBalanceVolumeDisparityIndicatorState : IStreamingIndicator
         _inputStdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
         _obvStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _obvInput);
         _input = new StreamingInputResolver(inputName, null);
-        _top = top;
-        _bottom = bottom;
-    }
-
-    public OnBalanceVolumeDisparityIndicatorState(MovingAvgType maType, int length, int signalLength, double top, double bottom,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _inputSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _obvSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _inputStdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _obvStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _obvInput);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _top = top;
         _bottom = bottom;
     }

--- a/src/Streaming/StatefulIndicators.Batch19.cs
+++ b/src/Streaming/StatefulIndicators.Batch19.cs
@@ -22,18 +22,6 @@ public sealed class OnBalanceVolumeModifiedState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public OnBalanceVolumeModifiedState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _obvSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.OnBalanceVolumeModified;
 
     public void Reset()
@@ -101,20 +89,6 @@ public sealed class OnBalanceVolumeReflexState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public OnBalanceVolumeReflexState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.OnBalanceVolumeReflex;
 
     public void Reset()
@@ -177,19 +151,6 @@ public sealed class OptimalWeightedMovingAverageState : IStreamingIndicatorState
         _corrWindow = new RollingWindowCorrelation(_length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public OptimalWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _corrWindow = new RollingWindowCorrelation(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.OptimalWeightedMovingAverage;
@@ -268,21 +229,6 @@ public sealed class OptimizedTrendTrackerState : IStreamingIndicatorState, IDisp
         _percent = percent;
     }
 
-    public OptimizedTrendTrackerState(MovingAvgType maType, int length, double percent, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ma = maType == MovingAvgType.VariableIndexDynamicAverage
-            ? new VariableIndexDynamicAverageEngine(resolved)
-            : MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _percent = percent;
-    }
-
     public IndicatorName Name => IndicatorName.OptimizedTrendTracker;
 
     public void Reset()
@@ -350,19 +296,6 @@ public sealed class OscarIndicatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public OscarIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.OscarIndicator;
 
     public void Reset()
@@ -420,18 +353,6 @@ public sealed class OscOscillatorState : IStreamingIndicatorState, IDisposable
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public OscOscillatorState(MovingAvgType maType, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.OscOscillator;
@@ -499,25 +420,6 @@ public sealed class OvershootReductionMovingAverageState : IStreamingIndicatorSt
         _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public OvershootReductionMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _length1 = (int)Math.Ceiling((double)_length / 2);
-        _corrWindow = new RollingWindowCorrelation(_length);
-        _bSum = new RollingWindowSum(_length1);
-        _bSmaMax = new RollingWindowMax(_length);
-        _indexSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.OvershootReductionMovingAverage;
@@ -616,21 +518,6 @@ public sealed class ParabolicSARState : IStreamingIndicatorState, IDisposable
         _increment = increment;
         _maximum = maximum;
         _input = new StreamingInputResolver(inputName, null);
-        _highValues = new PooledRingBuffer<double>(3);
-        _lowValues = new PooledRingBuffer<double>(3);
-    }
-
-    public ParabolicSARState(double start, double increment, double maximum, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _start = start;
-        _increment = increment;
-        _maximum = maximum;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _highValues = new PooledRingBuffer<double>(3);
         _lowValues = new PooledRingBuffer<double>(3);
     }
@@ -781,28 +668,6 @@ public sealed class ParabolicWeightedMovingAverageState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ParabolicWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        double sum = 0;
-        for (var j = 0; j <= _length - 1; j++)
-        {
-            var weight = MathHelper.Pow(_length - j, 2);
-            _weights[j] = weight;
-            sum += weight;
-        }
-
-        _weightSum = sum;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ParabolicWeightedMovingAverage;
 
     public void Reset()
@@ -870,24 +735,6 @@ public sealed class ParametricCorrectiveLinearMovingAverageState : IStreamingInd
         _vw2Sum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ParametricCorrectiveLinearMovingAverageState(int length, double alpha, double per, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = alpha;
-        _per = per;
-        _w1Sum = new RollingWindowSum(_length);
-        _w2Sum = new RollingWindowSum(_length);
-        _vw1Sum = new RollingWindowSum(_length);
-        _vw2Sum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ParametricCorrectiveLinearMovingAverage;
@@ -969,18 +816,6 @@ public sealed class ParametricKalmanFilterState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ParametricKalmanFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _estValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ParametricKalmanFilter;
 
     public void Reset()
@@ -1052,20 +887,6 @@ public sealed class PeakValleyEstimationState : IStreamingIndicatorState, IDispo
         _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _absOs);
         _highestWindow = new RollingWindowMax(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PeakValleyEstimationState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _absOs);
-        _highestWindow = new RollingWindowMax(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PeakValleyEstimation;
@@ -1155,25 +976,6 @@ public sealed class PentupleExponentialMovingAverageState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PentupleExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema6 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema7 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema8 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PentupleExponentialMovingAverage;
 
     public void Reset()
@@ -1248,24 +1050,6 @@ public sealed class PercentagePriceOscillatorLeaderState : IStreamingIndicatorSt
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PercentagePriceOscillatorLeaderState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _diffFastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _diffSlowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PercentagePriceOscillatorLeader;
 
     public void Reset()
@@ -1335,20 +1119,6 @@ public sealed class PercentageTrailingStopsState : IStreamingIndicatorState, IDi
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _pct = pct;
-    }
-
-    public PercentageTrailingStopsState(int length, double pct, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _pct = pct;
     }
 
@@ -1424,19 +1194,6 @@ public sealed class PercentageTrendState : IStreamingIndicatorState, IDisposable
         _pct = pct;
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PercentageTrendState(int length, double pct, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _pct = pct;
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PercentageTrend;
@@ -1527,17 +1284,6 @@ public sealed class PercentChangeOscillatorState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PercentChangeOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PercentChangeOscillator;
 
     public void Reset()
@@ -1597,18 +1343,6 @@ public sealed class PerformanceIndexState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PerformanceIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PerformanceIndex;
 
     public void Reset()
@@ -1663,19 +1397,6 @@ public sealed class PhaseChangeIndexState : IStreamingIndicatorState, IDisposabl
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PhaseChangeIndexState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PhaseChangeIndex;
@@ -1745,18 +1466,6 @@ public sealed class PivotDetectorOscillatorState : IStreamingIndicatorState, IDi
         _rsi = new RsiState(maType, Math.Max(1, length2));
         _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PivotDetectorOscillatorState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rsi = new RsiState(maType, Math.Max(1, length2));
-        _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PivotDetectorOscillator;
@@ -1893,20 +1602,6 @@ public sealed class PolarizedFractalEfficiencyState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PolarizedFractalEfficiencyState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _c2cSum = new RollingWindowSum(_length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PolarizedFractalEfficiency;
 
     public void Reset()
@@ -1974,18 +1669,6 @@ public sealed class PolynomialLeastSquaresMovingAverageState : IStreamingIndicat
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PolynomialLeastSquaresMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PolynomialLeastSquaresMovingAverage;
@@ -2096,18 +1779,6 @@ public sealed class PositiveVolumeIndexState : IStreamingIndicatorState, IDispos
         _initialValue = initialValue;
     }
 
-    public PositiveVolumeIndexState(MovingAvgType maType, int length, int initialValue, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _initialValue = initialValue;
-    }
-
     public IndicatorName Name => IndicatorName.PositiveVolumeIndex;
 
     public void Reset()
@@ -2172,18 +1843,6 @@ public sealed class PoweredKaufmanAdaptiveMovingAverageState : IStreamingIndicat
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _factor = factor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PoweredKaufmanAdaptiveMovingAverageState(int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _er = new EfficiencyRatioState(Math.Max(1, length));
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PoweredKaufmanAdaptiveMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch19.cs
+++ b/src/Streaming/StatefulIndicators.Batch19.cs
@@ -15,11 +15,11 @@ public sealed class OnBalanceVolumeModifiedState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public OnBalanceVolumeModifiedState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 7,
-        int length2 = 10, InputName inputName = InputName.Close)
+        int length2 = 10)
     {
         _obvSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OnBalanceVolumeModified;
@@ -81,12 +81,12 @@ public sealed class OnBalanceVolumeReflexState : IStreamingIndicatorState, IDisp
     private bool _hasPrev;
 
     public OnBalanceVolumeReflexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 4,
-        int signalLength = 14, InputName inputName = InputName.Close)
+        int signalLength = 14)
     {
         _length = Math.Max(1, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OnBalanceVolumeReflex;
@@ -145,12 +145,12 @@ public sealed class OptimalWeightedMovingAverageState : IStreamingIndicatorState
     private double _prevOwma;
     private bool _hasPrev;
 
-    public OptimalWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public OptimalWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _corrWindow = new RollingWindowCorrelation(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OptimalWeightedMovingAverage;
@@ -219,13 +219,13 @@ public sealed class OptimizedTrendTrackerState : IStreamingIndicatorState, IDisp
     private bool _hasPrev;
 
     public OptimizedTrendTrackerState(MovingAvgType maType = MovingAvgType.VariableIndexDynamicAverage, int length = 2,
-        double percent = 1.4, InputName inputName = InputName.Close)
+        double percent = 1.4)
     {
         var resolved = Math.Max(1, length);
         _ma = maType == MovingAvgType.VariableIndexDynamicAverage
             ? new VariableIndexDynamicAverageEngine(resolved)
             : MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _percent = percent;
     }
 
@@ -288,12 +288,12 @@ public sealed class OscarIndicatorState : IStreamingIndicatorState, IDisposable
     private double _prevOscar;
     private bool _hasPrev;
 
-    public OscarIndicatorState(int length = 8, InputName inputName = InputName.Close)
+    public OscarIndicatorState(int length = 8)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OscarIndicator;
@@ -347,12 +347,11 @@ public sealed class OscOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _slowSmoother;
     private readonly StreamingInputResolver _input;
 
-    public OscOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 7, int slowLength = 14,
-        InputName inputName = InputName.Close)
+    public OscOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 7, int slowLength = 14)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OscOscillator;
@@ -407,8 +406,7 @@ public sealed class OvershootReductionMovingAverageState : IStreamingIndicatorSt
     private int _index;
     private bool _hasPrev;
 
-    public OvershootReductionMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public OvershootReductionMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _length1 = (int)Math.Ceiling((double)_length / 2);
@@ -417,9 +415,9 @@ public sealed class OvershootReductionMovingAverageState : IStreamingIndicatorSt
         _bSmaMax = new RollingWindowMax(_length);
         _indexSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OvershootReductionMovingAverage;
@@ -511,13 +509,12 @@ public sealed class ParabolicSARState : IStreamingIndicatorState, IDisposable
     private int _index;
     private bool _hasPrev;
 
-    public ParabolicSARState(double start = 0.02, double increment = 0.02, double maximum = 0.2,
-        InputName inputName = InputName.Close)
+    public ParabolicSARState(double start = 0.02, double increment = 0.02, double maximum = 0.2)
     {
         _start = start;
         _increment = increment;
         _maximum = maximum;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _highValues = new PooledRingBuffer<double>(3);
         _lowValues = new PooledRingBuffer<double>(3);
     }
@@ -651,7 +648,7 @@ public sealed class ParabolicWeightedMovingAverageState : IStreamingIndicatorSta
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public ParabolicWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public ParabolicWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -665,7 +662,7 @@ public sealed class ParabolicWeightedMovingAverageState : IStreamingIndicatorSta
 
         _weightSum = sum;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ParabolicWeightedMovingAverage;
@@ -723,8 +720,7 @@ public sealed class ParametricCorrectiveLinearMovingAverageState : IStreamingInd
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public ParametricCorrectiveLinearMovingAverageState(int length = 50, double alpha = 1, double per = 35,
-        InputName inputName = InputName.Close)
+    public ParametricCorrectiveLinearMovingAverageState(int length = 50, double alpha = 1, double per = 35)
     {
         _length = Math.Max(1, length);
         _alpha = alpha;
@@ -734,7 +730,7 @@ public sealed class ParametricCorrectiveLinearMovingAverageState : IStreamingInd
         _vw1Sum = new RollingWindowSum(_length);
         _vw2Sum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ParametricCorrectiveLinearMovingAverage;
@@ -809,11 +805,11 @@ public sealed class ParametricKalmanFilterState : IStreamingIndicatorState, IDis
     private int _index;
     private bool _hasPrev;
 
-    public ParametricKalmanFilterState(int length = 50, InputName inputName = InputName.Close)
+    public ParametricKalmanFilterState(int length = 50)
     {
         _length = Math.Max(1, length);
         _estValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ParametricKalmanFilter;
@@ -880,13 +876,13 @@ public sealed class PeakValleyEstimationState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public PeakValleyEstimationState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 500,
-        int smoothLength = 100, InputName inputName = InputName.Close)
+        int smoothLength = 100)
     {
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
         _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _absOs);
         _highestWindow = new RollingWindowMax(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PeakValleyEstimation;
@@ -961,8 +957,7 @@ public sealed class PentupleExponentialMovingAverageState : IStreamingIndicatorS
     private readonly IMovingAverageSmoother _ema8;
     private readonly StreamingInputResolver _input;
 
-    public PentupleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public PentupleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -973,7 +968,7 @@ public sealed class PentupleExponentialMovingAverageState : IStreamingIndicatorS
         _ema6 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema7 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema8 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PentupleExponentialMovingAverage;
@@ -1038,7 +1033,7 @@ public sealed class PercentagePriceOscillatorLeaderState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
 
     public PercentagePriceOscillatorLeaderState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 12,
-        int slowLength = 26, int signalLength = 9, InputName inputName = InputName.Close)
+        int slowLength = 26, int signalLength = 9)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1047,7 +1042,7 @@ public sealed class PercentagePriceOscillatorLeaderState : IStreamingIndicatorSt
         _diffFastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
         _diffSlowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PercentagePriceOscillatorLeader;
@@ -1113,12 +1108,12 @@ public sealed class PercentageTrailingStopsState : IStreamingIndicatorState, IDi
     private double _prevStopL;
     private bool _hasPrev;
 
-    public PercentageTrailingStopsState(int length = 100, double pct = 10, InputName inputName = InputName.Close)
+    public PercentageTrailingStopsState(int length = 100, double pct = 10)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _pct = pct;
     }
 
@@ -1188,12 +1183,12 @@ public sealed class PercentageTrendState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public PercentageTrendState(int length = 20, double pct = 0.15, InputName inputName = InputName.Close)
+    public PercentageTrendState(int length = 20, double pct = 0.15)
     {
         _length = Math.Max(1, length);
         _pct = pct;
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PercentageTrend;
@@ -1277,11 +1272,10 @@ public sealed class PercentChangeOscillatorState : IStreamingIndicatorState, IDi
     private double _prevPcc;
     private bool _hasPrev;
 
-    public PercentChangeOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public PercentChangeOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PercentChangeOscillator;
@@ -1336,11 +1330,11 @@ public sealed class PerformanceIndexState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public PerformanceIndexState(int length = 14, InputName inputName = InputName.Close)
+    public PerformanceIndexState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PerformanceIndex;
@@ -1391,12 +1385,12 @@ public sealed class PhaseChangeIndexState : IStreamingIndicatorState, IDisposabl
     private int _index;
 
     public PhaseChangeIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 35,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         _length = Math.Max(1, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PhaseChangeIndex;
@@ -1461,11 +1455,11 @@ public sealed class PivotDetectorOscillatorState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
 
     public PivotDetectorOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 200,
-        int length2 = 14, InputName inputName = InputName.Close)
+        int length2 = 14)
     {
         _rsi = new RsiState(maType, Math.Max(1, length2));
         _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PivotDetectorOscillator;
@@ -1593,13 +1587,13 @@ public sealed class PolarizedFractalEfficiencyState : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public PolarizedFractalEfficiencyState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 9,
-        int smoothLength = 5, InputName inputName = InputName.Close)
+        int smoothLength = 5)
     {
         _length = Math.Max(1, length);
         _c2cSum = new RollingWindowSum(_length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PolarizedFractalEfficiency;
@@ -1664,11 +1658,11 @@ public sealed class PolynomialLeastSquaresMovingAverageState : IStreamingIndicat
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public PolynomialLeastSquaresMovingAverageState(int length = 100, InputName inputName = InputName.Close)
+    public PolynomialLeastSquaresMovingAverageState(int length = 100)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PolynomialLeastSquaresMovingAverage;
@@ -1772,10 +1766,10 @@ public sealed class PositiveVolumeIndexState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public PositiveVolumeIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 255,
-        int initialValue = 1000, InputName inputName = InputName.Close)
+        int initialValue = 1000)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _initialValue = initialValue;
     }
 
@@ -1838,11 +1832,11 @@ public sealed class PoweredKaufmanAdaptiveMovingAverageState : IStreamingIndicat
     private double _prevPkamaSp;
     private bool _hasPrev;
 
-    public PoweredKaufmanAdaptiveMovingAverageState(int length = 100, double factor = 3, InputName inputName = InputName.Close)
+    public PoweredKaufmanAdaptiveMovingAverageState(int length = 100, double factor = 3)
     {
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PoweredKaufmanAdaptiveMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch20.cs
+++ b/src/Streaming/StatefulIndicators.Batch20.cs
@@ -12,10 +12,10 @@ public sealed class PremierStochasticOscillatorState : IStreamingIndicatorState,
     private readonly StochasticOscillatorState _stochastic;
 
     public PremierStochasticOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 8, int smoothLength = 25, InputName inputName = InputName.Close)
+        int length = 8, int smoothLength = 25)
     {
         var resolved = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(smoothLength)));
-        _stochastic = new StochasticOscillatorState(maType, Math.Max(1, length), 3, 3, inputName);
+        _stochastic = new StochasticOscillatorState(maType, Math.Max(1, length), 3, 3);
         _nskSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _ssSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
     }
@@ -64,13 +64,12 @@ public sealed class PrettyGoodOscillatorState : IStreamingIndicatorState, IDispo
     private readonly AverageTrueRangeSmoother _atrSmoother;
     private readonly StreamingInputResolver _input;
 
-    public PrettyGoodOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public PrettyGoodOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, InputName.Close);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PrettyGoodOscillator;
@@ -113,13 +112,12 @@ public sealed class PriceCycleOscillatorState : IStreamingIndicatorState, IDispo
     private readonly AverageTrueRangeSmoother _atrSmoother;
     private readonly StreamingInputResolver _input;
 
-    public PriceCycleOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 22,
-        InputName inputName = InputName.Close)
+    public PriceCycleOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 22)
     {
         var resolved = Math.Max(1, length);
         _diffSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, InputName.Close);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceCycleOscillator;
@@ -169,14 +167,14 @@ public sealed class PriceMomentumOscillatorState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public PriceMomentumOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 35,
-        int length2 = 20, int signalLength = 10, InputName inputName = InputName.Close)
+        int length2 = 20, int signalLength = 10)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         _sc1 = 2d / resolvedLength1;
         _sc2 = 2d / resolvedLength2;
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceMomentumOscillator;
@@ -238,7 +236,7 @@ public sealed class PriceVolumeOscillatorState : IStreamingIndicatorState, IDisp
     private readonly PooledRingBuffer<double> _volumes;
     private readonly StreamingInputResolver _input;
 
-    public PriceVolumeOscillatorState(int length1 = 50, int length2 = 14, InputName inputName = InputName.Close)
+    public PriceVolumeOscillatorState(int length1 = 50, int length2 = 14)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -248,7 +246,7 @@ public sealed class PriceVolumeOscillatorState : IStreamingIndicatorState, IDisp
         _absBSum = new RollingWindowSum(_length2);
         _values = new PooledRingBuffer<double>(_length1);
         _volumes = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceVolumeOscillator;
@@ -322,11 +320,11 @@ public sealed class PriceVolumeRankState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public PriceVolumeRankState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5,
-        int slowLength = 10, InputName inputName = InputName.Close)
+        int slowLength = 10)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceVolumeRank;
@@ -390,11 +388,10 @@ public sealed class PriceVolumeTrendState : IStreamingIndicatorState, IDisposabl
     private double _prevPvt;
     private bool _hasPrev;
 
-    public PriceVolumeTrendState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public PriceVolumeTrendState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceVolumeTrend;
@@ -450,13 +447,12 @@ public sealed class PriceZoneOscillatorState : IStreamingIndicatorState, IDispos
     private double _prevValue;
     private bool _hasPrev;
 
-    public PriceZoneOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public PriceZoneOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _dvmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceZoneOscillator;
@@ -513,14 +509,14 @@ public sealed class PrimeNumberBandsState : IStreamingIndicatorState, IDisposabl
     private readonly RollingWindowMin _lowerWindow;
     private readonly StreamingInputResolver _input;
 
-    public PrimeNumberBandsState(int length = 5, InputName inputName = InputName.Close)
+    public PrimeNumberBandsState(int length = 5)
     {
         _length = Math.Max(1, length);
         _upperPno = new PrimeNumberOscillatorState(_length, bar => bar.High);
         _lowerPno = new PrimeNumberOscillatorState(_length, bar => bar.Low);
         _upperWindow = new RollingWindowMax(_length);
         _lowerWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PrimeNumberBands;
@@ -572,10 +568,10 @@ public sealed class PrimeNumberOscillatorState : IStreamingIndicatorState, IDisp
     private double _prevPno;
     private bool _hasPrev;
 
-    public PrimeNumberOscillatorState(int length = 5, InputName inputName = InputName.Close)
+    public PrimeNumberOscillatorState(int length = 5)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     internal PrimeNumberOscillatorState(int length, Func<OhlcvBar, double> selector)
@@ -718,7 +714,7 @@ public sealed class PringSpecialKState : IStreamingIndicatorState, IDisposable
     public PringSpecialKState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 10, int length2 = 15,
         int length3 = 20, int length4 = 30, int length5 = 40, int length6 = 50, int length7 = 65, int length8 = 75,
         int length9 = 100, int length10 = 130, int length11 = 195, int length12 = 265, int length13 = 390, int length14 = 530,
-        int smoothLength = 10, InputName inputName = InputName.Close)
+        int smoothLength = 10)
     {
         var len1 = Math.Max(1, length1);
         var len2 = Math.Max(1, length2);
@@ -734,18 +730,18 @@ public sealed class PringSpecialKState : IStreamingIndicatorState, IDisposable
         var len12 = Math.Max(1, length12);
         var len13 = Math.Max(1, length13);
         var len14 = Math.Max(1, length14);
-        _roc10 = new RateOfChangeState(len1, inputName);
-        _roc15 = new RateOfChangeState(len2, inputName);
-        _roc20 = new RateOfChangeState(len3, inputName);
-        _roc30 = new RateOfChangeState(len4, inputName);
-        _roc40 = new RateOfChangeState(len5, inputName);
-        _roc65 = new RateOfChangeState(len7, inputName);
-        _roc75 = new RateOfChangeState(len8, inputName);
-        _roc100 = new RateOfChangeState(len9, inputName);
-        _roc195 = new RateOfChangeState(len11, inputName);
-        _roc265 = new RateOfChangeState(len12, inputName);
-        _roc390 = new RateOfChangeState(len13, inputName);
-        _roc530 = new RateOfChangeState(len14, inputName);
+        _roc10 = new RateOfChangeState(len1);
+        _roc15 = new RateOfChangeState(len2);
+        _roc20 = new RateOfChangeState(len3);
+        _roc30 = new RateOfChangeState(len4);
+        _roc40 = new RateOfChangeState(len5);
+        _roc65 = new RateOfChangeState(len7);
+        _roc75 = new RateOfChangeState(len8);
+        _roc100 = new RateOfChangeState(len9);
+        _roc195 = new RateOfChangeState(len11);
+        _roc265 = new RateOfChangeState(len12);
+        _roc390 = new RateOfChangeState(len13);
+        _roc530 = new RateOfChangeState(len14);
         _roc10Sma = MovingAverageSmootherFactory.Create(maType, len1);
         _roc15Sma = MovingAverageSmootherFactory.Create(maType, len1);
         _roc20Sma = MovingAverageSmootherFactory.Create(maType, len1);
@@ -874,11 +870,11 @@ public sealed class PsychologicalLineState : IStreamingIndicatorState, IDisposab
     private double _prevValue;
     private bool _hasPrev;
 
-    public PsychologicalLineState(int length = 20, InputName inputName = InputName.Close)
+    public PsychologicalLineState(int length = 20)
     {
         _length = Math.Max(1, length);
         _condSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PsychologicalLine;
@@ -928,11 +924,11 @@ public sealed class QmaSmaDifferenceState : IStreamingIndicatorState, IDisposabl
     private readonly IMovingAverageSmoother _sma;
     private readonly StreamingInputResolver _input;
 
-    public QmaSmaDifferenceState(int length = 14, InputName inputName = InputName.Close)
+    public QmaSmaDifferenceState(int length = 14)
     {
-        _qma = new QuadraticMovingAverageState(length, inputName);
+        _qma = new QuadraticMovingAverageState(length);
         _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.QmaSmaDifference;
@@ -987,7 +983,7 @@ public sealed class QuadraticLeastSquaresMovingAverageState : IStreamingIndicato
     private double _n2Value;
 
     public QuadraticLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50,
-        int forecastLength = 14, InputName inputName = InputName.Close)
+        int forecastLength = 14)
     {
         _length = Math.Max(1, length);
         _forecastLength = Math.Max(1, forecastLength);
@@ -999,7 +995,7 @@ public sealed class QuadraticLeastSquaresMovingAverageState : IStreamingIndicato
         _nvMa = MovingAverageSmootherFactory.Create(maType, _length);
         _nStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _nValue);
         _n2StdDev = new StandardDeviationVolatilityState(maType, _length, _ => _n2Value);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.QuadraticLeastSquaresMovingAverage;
@@ -1084,11 +1080,11 @@ public sealed class QuadraticMovingAverageState : IStreamingIndicatorState, IDis
     private readonly RollingWindowSum _sqSum;
     private readonly StreamingInputResolver _input;
 
-    public QuadraticMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public QuadraticMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _sqSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.QuadraticMovingAverage;
@@ -1128,10 +1124,9 @@ public sealed class QuadraticRegressionState : IStreamingIndicatorState, IDispos
 {
     private readonly QuadraticRegressionEngine _engine;
 
-    public QuadraticRegressionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 500,
-        InputName inputName = InputName.Close)
+    public QuadraticRegressionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 500)
     {
-        _engine = new QuadraticRegressionEngine(maType, length, inputName);
+        _engine = new QuadraticRegressionEngine(maType, length, InputName.Close);
     }
 
     public IndicatorName Name => IndicatorName.QuadraticRegression;
@@ -1172,8 +1167,7 @@ public sealed class QuadrupleExponentialMovingAverageState : IStreamingIndicator
     private readonly IMovingAverageSmoother _ema5;
     private readonly StreamingInputResolver _input;
 
-    public QuadrupleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public QuadrupleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -1181,7 +1175,7 @@ public sealed class QuadrupleExponentialMovingAverageState : IStreamingIndicator
         _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.QuadrupleExponentialMovingAverage;
@@ -1240,7 +1234,7 @@ public sealed class QuantitativeQualitativeEstimationState : IStreamingIndicator
     private bool _hasPrev;
 
     public QuantitativeQualitativeEstimationState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        int smoothLength = 5, double fastFactor = 2.618, double slowFactor = 4.236, InputName inputName = InputName.Close)
+        int smoothLength = 5, double fastFactor = 2.618, double slowFactor = 4.236)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedSmooth = Math.Max(1, smoothLength);
@@ -1249,7 +1243,7 @@ public sealed class QuantitativeQualitativeEstimationState : IStreamingIndicator
         _rsiSignal = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
         _atrRsiEma = MovingAverageSmootherFactory.Create(maType, wildersLength);
         _atrRsiSmooth = MovingAverageSmootherFactory.Create(maType, wildersLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _fastFactor = fastFactor;
         _slowFactor = slowFactor;
     }
@@ -1315,11 +1309,11 @@ public sealed class QuasiWhiteNoiseState : IStreamingIndicatorState, IDisposable
     private double _whiteNoiseValue;
 
     public QuasiWhiteNoiseState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 20, int noiseLength = 500,
-        double divisor = 40, InputName inputName = InputName.Close)
+        double divisor = 40)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedNoise = Math.Max(1, noiseLength);
-        _connors = new ConnorsRelativeStrengthIndexState(maType, resolvedNoise, resolvedNoise, resolvedLength, inputName);
+        _connors = new ConnorsRelativeStrengthIndexState(maType, resolvedNoise, resolvedNoise, resolvedLength);
         _whiteNoiseSma = MovingAverageSmootherFactory.Create(maType, resolvedNoise);
         _whiteNoiseStdDev = new StandardDeviationVolatilityState(maType, resolvedNoise, _ => _whiteNoiseValue);
         _divisor = divisor;
@@ -1373,12 +1367,12 @@ public sealed class QuickMovingAverageState : IStreamingIndicatorState, IDisposa
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public QuickMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public QuickMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _peak = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 3));
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.QuickMovingAverage;
@@ -1440,19 +1434,18 @@ public sealed class R2AdaptiveRegressionState : IStreamingIndicatorState, IDispo
     private double _prevOut;
     private bool _hasPrev;
 
-    public R2AdaptiveRegressionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public R2AdaptiveRegressionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         _length = Math.Max(1, length);
-        _linreg = new LinearRegressionState(_length, inputName);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _linreg = new LinearRegressionState(_length);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _x2Correlation = new RollingWindowCorrelation(_length);
         _y1Correlation = new RollingWindowCorrelation(_length);
         _y2Correlation = new RollingWindowCorrelation(_length);
         _x2Sum = new RollingWindowSum(_length);
         _x2PowSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.R2AdaptiveRegression;
@@ -1546,8 +1539,7 @@ public sealed class RahulMohindarOscillatorState : IStreamingIndicatorState, IDi
     private readonly IMovingAverageSmoother _rmoSmoother;
     private readonly StreamingInputResolver _input;
 
-    public RahulMohindarOscillatorState(int length1 = 2, int length2 = 10, int length3 = 30, int length4 = 81,
-        InputName inputName = InputName.Close)
+    public RahulMohindarOscillatorState(int length1 = 2, int length2 = 10, int length3 = 30, int length4 = 81)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1568,7 +1560,7 @@ public sealed class RahulMohindarOscillatorState : IStreamingIndicatorState, IDi
         _swing2Smoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved3);
         _swing3Smoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved3);
         _rmoSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved4);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RahulMohindarOscillator;
@@ -1664,8 +1656,7 @@ public sealed class RainbowOscillatorState : IStreamingIndicatorState, IDisposab
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public RainbowOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 2, int length2 = 10,
-        InputName inputName = InputName.Close)
+    public RainbowOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 2, int length2 = 10)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1681,7 +1672,7 @@ public sealed class RainbowOscillatorState : IStreamingIndicatorState, IDisposab
         _r10 = MovingAverageSmootherFactory.Create(maType, resolved1);
         _highWindow = new RollingWindowMax(resolved2);
         _lowWindow = new RollingWindowMin(resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RainbowOscillator;
@@ -1765,12 +1756,11 @@ public sealed class RandomWalkIndexState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _highValues;
     private readonly PooledRingBuffer<double> _lowValues;
 
-    public RandomWalkIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14,
-        InputName inputName = InputName.Close)
+    public RandomWalkIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14)
     {
         _length = Math.Max(1, length);
         _sqrtLength = MathHelper.Sqrt(_length);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, _length, inputName);
+        _atrSmoother = new AverageTrueRangeSmoother(maType, _length, InputName.Close);
         _highValues = new PooledRingBuffer<double>(_length);
         _lowValues = new PooledRingBuffer<double>(_length);
     }
@@ -1827,11 +1817,11 @@ public sealed class RangeActionVerificationIndexState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public RangeActionVerificationIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 7,
-        int slowLength = 65, InputName inputName = InputName.Close)
+        int slowLength = 65)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RangeActionVerificationIndex;

--- a/src/Streaming/StatefulIndicators.Batch20.cs
+++ b/src/Streaming/StatefulIndicators.Batch20.cs
@@ -20,20 +20,6 @@ public sealed class PremierStochasticOscillatorState : IStreamingIndicatorState,
         _ssSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
     }
 
-    public PremierStochasticOscillatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(smoothLength)));
-        _stochastic = new StochasticOscillatorState(maType, Math.Max(1, length), 3, 3, selector);
-        _nskSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ssSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-    }
-
     public IndicatorName Name => IndicatorName.PremierStochasticOscillator;
 
     public void Reset()
@@ -87,19 +73,6 @@ public sealed class PrettyGoodOscillatorState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PrettyGoodOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PrettyGoodOscillator;
 
     public void Reset()
@@ -147,19 +120,6 @@ public sealed class PriceCycleOscillatorState : IStreamingIndicatorState, IDispo
         _diffSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, inputName);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PriceCycleOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _diffSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, resolved, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PriceCycleOscillator;
@@ -217,22 +177,6 @@ public sealed class PriceMomentumOscillatorState : IStreamingIndicatorState, IDi
         _sc2 = 2d / resolvedLength2;
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PriceMomentumOscillatorState(MovingAvgType maType, int length1, int length2, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _sc1 = 2d / resolvedLength1;
-        _sc2 = 2d / resolvedLength2;
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PriceMomentumOscillator;
@@ -305,24 +249,6 @@ public sealed class PriceVolumeOscillatorState : IStreamingIndicatorState, IDisp
         _values = new PooledRingBuffer<double>(_length1);
         _volumes = new PooledRingBuffer<double>(_length2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PriceVolumeOscillatorState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _aSum = new RollingWindowSum(_length1);
-        _bSum = new RollingWindowSum(_length2);
-        _absASum = new RollingWindowSum(_length1);
-        _absBSum = new RollingWindowSum(_length2);
-        _values = new PooledRingBuffer<double>(_length1);
-        _volumes = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PriceVolumeOscillator;
@@ -403,18 +329,6 @@ public sealed class PriceVolumeRankState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PriceVolumeRankState(MovingAvgType maType, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PriceVolumeRank;
 
     public void Reset()
@@ -483,17 +397,6 @@ public sealed class PriceVolumeTrendState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PriceVolumeTrendState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PriceVolumeTrend;
 
     public void Reset()
@@ -554,19 +457,6 @@ public sealed class PriceZoneOscillatorState : IStreamingIndicatorState, IDispos
         _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _dvmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PriceZoneOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _dvmaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PriceZoneOscillator;
@@ -633,21 +523,6 @@ public sealed class PrimeNumberBandsState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PrimeNumberBandsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _upperPno = new PrimeNumberOscillatorState(_length, bar => bar.High);
-        _lowerPno = new PrimeNumberOscillatorState(_length, bar => bar.Low);
-        _upperWindow = new RollingWindowMax(_length);
-        _lowerWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PrimeNumberBands;
 
     public void Reset()
@@ -703,7 +578,7 @@ public sealed class PrimeNumberOscillatorState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PrimeNumberOscillatorState(int length, Func<OhlcvBar, double> selector)
+    internal PrimeNumberOscillatorState(int length, Func<OhlcvBar, double> selector)
     {
         if (selector == null)
         {
@@ -886,56 +761,6 @@ public sealed class PringSpecialKState : IStreamingIndicatorState, IDisposable
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
     }
 
-    public PringSpecialKState(MovingAvgType maType, int length1, int length2, int length3, int length4, int length5, int length6,
-        int length7, int length8, int length9, int length10, int length11, int length12, int length13, int length14,
-        int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var len1 = Math.Max(1, length1);
-        var len2 = Math.Max(1, length2);
-        var len3 = Math.Max(1, length3);
-        var len4 = Math.Max(1, length4);
-        var len5 = Math.Max(1, length5);
-        var len6 = Math.Max(1, length6);
-        var len7 = Math.Max(1, length7);
-        var len8 = Math.Max(1, length8);
-        var len9 = Math.Max(1, length9);
-        var len10 = Math.Max(1, length10);
-        var len11 = Math.Max(1, length11);
-        var len12 = Math.Max(1, length12);
-        var len13 = Math.Max(1, length13);
-        var len14 = Math.Max(1, length14);
-        _roc10 = new RateOfChangeState(len1, selector);
-        _roc15 = new RateOfChangeState(len2, selector);
-        _roc20 = new RateOfChangeState(len3, selector);
-        _roc30 = new RateOfChangeState(len4, selector);
-        _roc40 = new RateOfChangeState(len5, selector);
-        _roc65 = new RateOfChangeState(len7, selector);
-        _roc75 = new RateOfChangeState(len8, selector);
-        _roc100 = new RateOfChangeState(len9, selector);
-        _roc195 = new RateOfChangeState(len11, selector);
-        _roc265 = new RateOfChangeState(len12, selector);
-        _roc390 = new RateOfChangeState(len13, selector);
-        _roc530 = new RateOfChangeState(len14, selector);
-        _roc10Sma = MovingAverageSmootherFactory.Create(maType, len1);
-        _roc15Sma = MovingAverageSmootherFactory.Create(maType, len1);
-        _roc20Sma = MovingAverageSmootherFactory.Create(maType, len1);
-        _roc30Sma = MovingAverageSmootherFactory.Create(maType, len2);
-        _roc40Sma = MovingAverageSmootherFactory.Create(maType, len6);
-        _roc65Sma = MovingAverageSmootherFactory.Create(maType, len7);
-        _roc75Sma = MovingAverageSmootherFactory.Create(maType, len8);
-        _roc100Sma = MovingAverageSmootherFactory.Create(maType, len9);
-        _roc195Sma = MovingAverageSmootherFactory.Create(maType, len10);
-        _roc265Sma = MovingAverageSmootherFactory.Create(maType, len10);
-        _roc390Sma = MovingAverageSmootherFactory.Create(maType, len10);
-        _roc530Sma = MovingAverageSmootherFactory.Create(maType, len11);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-    }
-
     public IndicatorName Name => IndicatorName.PringSpecialK;
 
     public void Reset()
@@ -1056,18 +881,6 @@ public sealed class PsychologicalLineState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PsychologicalLineState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _condSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PsychologicalLine;
 
     public void Reset()
@@ -1120,18 +933,6 @@ public sealed class QmaSmaDifferenceState : IStreamingIndicatorState, IDisposabl
         _qma = new QuadraticMovingAverageState(length, inputName);
         _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public QmaSmaDifferenceState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _qma = new QuadraticMovingAverageState(length, selector);
-        _sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.QmaSmaDifference;
@@ -1199,27 +1000,6 @@ public sealed class QuadraticLeastSquaresMovingAverageState : IStreamingIndicato
         _nStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _nValue);
         _n2StdDev = new StandardDeviationVolatilityState(maType, _length, _ => _n2Value);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public QuadraticLeastSquaresMovingAverageState(MovingAvgType maType, int length, int forecastLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _forecastLength = Math.Max(1, forecastLength);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _nMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _n2Ma = MovingAverageSmootherFactory.Create(maType, _length);
-        _nn2Ma = MovingAverageSmootherFactory.Create(maType, _length);
-        _n2vMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _nvMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _nStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _nValue);
-        _n2StdDev = new StandardDeviationVolatilityState(maType, _length, _ => _n2Value);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.QuadraticLeastSquaresMovingAverage;
@@ -1311,18 +1091,6 @@ public sealed class QuadraticMovingAverageState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public QuadraticMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sqSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.QuadraticMovingAverage;
 
     public void Reset()
@@ -1364,11 +1132,6 @@ public sealed class QuadraticRegressionState : IStreamingIndicatorState, IDispos
         InputName inputName = InputName.Close)
     {
         _engine = new QuadraticRegressionEngine(maType, length, inputName);
-    }
-
-    public QuadraticRegressionState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        _engine = new QuadraticRegressionEngine(maType, length, selector);
     }
 
     public IndicatorName Name => IndicatorName.QuadraticRegression;
@@ -1419,22 +1182,6 @@ public sealed class QuadrupleExponentialMovingAverageState : IStreamingIndicator
         _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public QuadrupleExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.QuadrupleExponentialMovingAverage;
@@ -1503,26 +1250,6 @@ public sealed class QuantitativeQualitativeEstimationState : IStreamingIndicator
         _atrRsiEma = MovingAverageSmootherFactory.Create(maType, wildersLength);
         _atrRsiSmooth = MovingAverageSmootherFactory.Create(maType, wildersLength);
         _input = new StreamingInputResolver(inputName, null);
-        _fastFactor = fastFactor;
-        _slowFactor = slowFactor;
-    }
-
-    public QuantitativeQualitativeEstimationState(MovingAvgType maType, int length, int smoothLength, double fastFactor,
-        double slowFactor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        var wildersLength = Math.Max(1, (resolvedLength * 2) - 1);
-        _rsi = new RsiState(maType, resolvedLength);
-        _rsiSignal = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _atrRsiEma = MovingAverageSmootherFactory.Create(maType, wildersLength);
-        _atrRsiSmooth = MovingAverageSmootherFactory.Create(maType, wildersLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _fastFactor = fastFactor;
         _slowFactor = slowFactor;
     }
@@ -1598,21 +1325,6 @@ public sealed class QuasiWhiteNoiseState : IStreamingIndicatorState, IDisposable
         _divisor = divisor;
     }
 
-    public QuasiWhiteNoiseState(MovingAvgType maType, int length, int noiseLength, double divisor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedNoise = Math.Max(1, noiseLength);
-        _connors = new ConnorsRelativeStrengthIndexState(maType, resolvedNoise, resolvedNoise, resolvedLength, selector);
-        _whiteNoiseSma = MovingAverageSmootherFactory.Create(maType, resolvedNoise);
-        _whiteNoiseStdDev = new StandardDeviationVolatilityState(maType, resolvedNoise, _ => _whiteNoiseValue);
-        _divisor = divisor;
-    }
-
     public IndicatorName Name => IndicatorName.QuasiWhiteNoise;
 
     public void Reset()
@@ -1667,19 +1379,6 @@ public sealed class QuickMovingAverageState : IStreamingIndicatorState, IDisposa
         _peak = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 3));
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public QuickMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _peak = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 3));
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.QuickMovingAverage;
@@ -1754,25 +1453,6 @@ public sealed class R2AdaptiveRegressionState : IStreamingIndicatorState, IDispo
         _x2Sum = new RollingWindowSum(_length);
         _x2PowSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public R2AdaptiveRegressionState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _linreg = new LinearRegressionState(_length, selector);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _x2Correlation = new RollingWindowCorrelation(_length);
-        _y1Correlation = new RollingWindowCorrelation(_length);
-        _y2Correlation = new RollingWindowCorrelation(_length);
-        _x2Sum = new RollingWindowSum(_length);
-        _x2PowSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.R2AdaptiveRegression;
@@ -1891,35 +1571,6 @@ public sealed class RahulMohindarOscillatorState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RahulMohindarOscillatorState(int length1, int length2, int length3, int length4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        var resolved4 = Math.Max(1, length4);
-        _r1 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r2 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r3 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r4 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r5 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r6 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r7 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r8 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r9 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _r10 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolved1);
-        _highWindow = new RollingWindowMax(resolved2);
-        _lowWindow = new RollingWindowMin(resolved2);
-        _swing2Smoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved3);
-        _swing3Smoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved3);
-        _rmoSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolved4);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RahulMohindarOscillator;
 
     public void Reset()
@@ -2033,30 +1684,6 @@ public sealed class RainbowOscillatorState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RainbowOscillatorState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _r1 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r2 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r3 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r4 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r5 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r6 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r7 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r8 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r9 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _r10 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _highWindow = new RollingWindowMax(resolved2);
-        _lowWindow = new RollingWindowMin(resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RainbowOscillator;
 
     public void Reset()
@@ -2148,20 +1775,6 @@ public sealed class RandomWalkIndexState : IStreamingIndicatorState, IDisposable
         _lowValues = new PooledRingBuffer<double>(_length);
     }
 
-    public RandomWalkIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sqrtLength = MathHelper.Sqrt(_length);
-        _atrSmoother = new AverageTrueRangeSmoother(maType, _length, selector);
-        _highValues = new PooledRingBuffer<double>(_length);
-        _lowValues = new PooledRingBuffer<double>(_length);
-    }
-
     public IndicatorName Name => IndicatorName.RandomWalkIndex;
 
     public void Reset()
@@ -2219,19 +1832,6 @@ public sealed class RangeActionVerificationIndexState : IStreamingIndicatorState
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RangeActionVerificationIndexState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RangeActionVerificationIndex;

--- a/src/Streaming/StatefulIndicators.Batch21.cs
+++ b/src/Streaming/StatefulIndicators.Batch21.cs
@@ -14,13 +14,13 @@ public sealed class RapidRelativeStrengthIndexState : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public RapidRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _upSum = new RollingWindowSum(resolved);
         _downSum = new RollingWindowSum(resolved);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RapidRelativeStrengthIndex;
@@ -81,9 +81,9 @@ public sealed class RatioOCHLAveragerState : IStreamingIndicatorState
     private double _prevD;
     private bool _hasPrev;
 
-    public RatioOCHLAveragerState(InputName inputName = InputName.Close)
+    public RatioOCHLAveragerState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RatioOCHLAverager;
@@ -129,11 +129,11 @@ public sealed class ReallySimpleIndicatorState : IStreamingIndicatorState, IDisp
     private readonly StreamingInputResolver _input;
 
     public ReallySimpleIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 21, int smoothLength = 10, InputName inputName = InputName.Close)
+        int length = 21, int smoothLength = 10)
     {
         _ma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ReallySimpleIndicator;
@@ -187,14 +187,14 @@ public sealed class RecursiveDifferenciatorState : IStreamingIndicatorState, IDi
     private bool _hasPrevBChg;
 
     public RecursiveDifferenciatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, double alpha = 0.6, InputName inputName = InputName.Close)
+        int length = 14, double alpha = 0.6)
     {
         _length = Math.Max(1, length);
         _alpha = alpha;
         _ema = MovingAverageSmootherFactory.Create(maType, _length);
         _avgGain = new WilderState(_length);
         _avgLoss = new WilderState(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _bValues = new PooledRingBuffer<double>(_length);
     }
 
@@ -269,11 +269,11 @@ public sealed class RecursiveMovingTrendAverageState : IStreamingIndicatorState
     private double _prevNRes;
     private bool _hasPrev;
 
-    public RecursiveMovingTrendAverageState(int length = 14, InputName inputName = InputName.Close)
+    public RecursiveMovingTrendAverageState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _alpha = 2d / (resolved + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RecursiveMovingTrendAverage;
@@ -331,13 +331,13 @@ public sealed class RecursiveRelativeStrengthIndexState : IStreamingIndicatorSta
     private bool _hasPrevSrc;
 
     public RecursiveRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _length = Math.Max(1, length);
         _srcMa = MovingAverageSmootherFactory.Create(maType, _length);
         _avgGain = new WilderState(_length);
         _avgLoss = new WilderState(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
         _bValues = new PooledRingBuffer<double>(_length);
         _avgValues = new PooledRingBuffer<double>(_length);
@@ -462,7 +462,7 @@ public sealed class RecursiveStochasticState : IStreamingIndicatorState, IDispos
     private double _prevK;
     private bool _hasPrevK;
 
-    public RecursiveStochasticState(int length = 200, double alpha = 0.1, InputName inputName = InputName.Close)
+    public RecursiveStochasticState(int length = 200, double alpha = 0.1)
     {
         _length = Math.Max(1, length);
         _alpha = alpha;
@@ -470,7 +470,7 @@ public sealed class RecursiveStochasticState : IStreamingIndicatorState, IDispos
         _lowWindow = new RollingWindowMin(_length);
         _maHighWindow = new RollingWindowMax(_length);
         _maLowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RecursiveStochastic;
@@ -531,10 +531,10 @@ public sealed class RegressionOscillatorState : IStreamingIndicatorState, IDispo
     private readonly LinearRegressionState _linReg;
     private readonly StreamingInputResolver _input;
 
-    public RegressionOscillatorState(int length = 63, InputName inputName = InputName.Close)
+    public RegressionOscillatorState(int length = 63)
     {
-        _linReg = new LinearRegressionState(length, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _linReg = new LinearRegressionState(length);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RegressionOscillator;
@@ -576,12 +576,12 @@ public sealed class RegularizedExponentialMovingAverageState : IStreamingIndicat
     private double _prevRema1;
     private double _prevRema2;
 
-    public RegularizedExponentialMovingAverageState(int length = 14, double lambda = 0.5, InputName inputName = InputName.Close)
+    public RegularizedExponentialMovingAverageState(int length = 14, double lambda = 0.5)
     {
         var resolved = Math.Max(1, length);
         _alpha = 2d / (resolved + 1);
         _lambda = lambda;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RegularizedExponentialMovingAverage;
@@ -626,13 +626,13 @@ public sealed class RelativeDifferenceOfSquaresOscillatorState : IStreamingIndic
     private double _prevValue;
     private bool _hasPrev;
 
-    public RelativeDifferenceOfSquaresOscillatorState(int length = 20, InputName inputName = InputName.Close)
+    public RelativeDifferenceOfSquaresOscillatorState(int length = 20)
     {
         var resolved = Math.Max(1, length);
         _aSum = new RollingWindowSum(resolved);
         _dSum = new RollingWindowSum(resolved);
         _nSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeDifferenceOfSquaresOscillator;
@@ -696,14 +696,14 @@ public sealed class RelativeMomentumIndexState : IStreamingIndicatorState, IDisp
     private readonly StreamingInputResolver _input;
 
     public RelativeMomentumIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length1 = 14, int length2 = 3, InputName inputName = InputName.Close)
+        int length1 = 14, int length2 = 3)
     {
         _length2 = Math.Max(1, length2);
         _avgGain = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _avgLoss = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _values = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeMomentumIndex;
@@ -780,8 +780,8 @@ public sealed class RelativeNormalizedVolatilityState : IMultiSeriesIndicatorSta
         _primarySeries = primarySeries;
         _marketSeries = marketSeries;
         var resolved = Math.Max(1, length);
-        _primaryStdDev = new StandardDeviationVolatilityState(maType, resolved, InputName.Close);
-        _marketStdDev = new StandardDeviationVolatilityState(maType, resolved, InputName.Close);
+        _primaryStdDev = new StandardDeviationVolatilityState(maType, resolved);
+        _marketStdDev = new StandardDeviationVolatilityState(maType, resolved);
         _primaryAbsSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _marketAbsSma = MovingAverageSmootherFactory.Create(maType, resolved);
     }
@@ -894,15 +894,14 @@ public sealed class RelativeSpreadStrengthState : IStreamingIndicatorState, IDis
     private bool _hasPrevSpread;
 
     public RelativeSpreadStrengthState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 10, int slowLength = 40, int length = 14, int smoothLength = 5,
-        InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 40, int length = 14, int smoothLength = 5)
     {
         _fastMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _avgGain = new WilderState(Math.Max(1, length));
         _avgLoss = new WilderState(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeSpreadStrength;
@@ -1092,8 +1091,7 @@ public sealed class RelativeVigorIndexState : IStreamingIndicatorState, IDisposa
     private double _prevRvi2;
     private double _prevRvi3;
 
-    public RelativeVigorIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public RelativeVigorIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _numeratorMa = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -1101,7 +1099,7 @@ public sealed class RelativeVigorIndexState : IStreamingIndicatorState, IDisposa
         _openValues = new PooledRingBuffer<double>(3);
         _closeValues = new PooledRingBuffer<double>(3);
         _highValues = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeVigorIndex;
@@ -1192,13 +1190,24 @@ public sealed class RelativeVolatilityIndexV1State : IStreamingIndicatorState, I
     private double _prevValue;
     private bool _hasPrev;
 
-    public RelativeVolatilityIndexV1State(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length = 10, int smoothLength = 14, InputName inputName = InputName.Close)
+    // Internal: the library composes this state on a named input other than its own default -
+    // a volatility of volume, a relative volatility of the high and of the low. Every parameter is
+    // required, so this can never be chosen in place of the public constructor.
+    internal RelativeVolatilityIndexV1State(MovingAvgType maType, int length, int smoothLength, InputName inputName)
     {
         _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length), inputName);
         _upAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _downAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
+    }
+
+    public RelativeVolatilityIndexV1State(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
+        int length = 10, int smoothLength = 14)
+    {
+        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length));
+        _upAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
+        _downAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeVolatilityIndexV1;
@@ -1306,12 +1315,12 @@ public sealed class RelativeVolumeIndicatorState : IStreamingIndicatorState, IDi
     private bool _hasPrevDpl;
 
     public RelativeVolumeIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 60, InputName inputName = InputName.Close)
+        int length = 60)
     {
         var resolved = Math.Max(1, length);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _volumeStdDev = new StandardDeviationVolatilityState(maType, resolved, InputName.Volume);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeVolumeIndicator;
@@ -1375,8 +1384,7 @@ public sealed class RepulseState : IStreamingIndicatorState, IDisposable
     private double _prevOpen;
     private bool _hasPrevOpen;
 
-    public RepulseState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 5,
-        InputName inputName = InputName.Close)
+    public RepulseState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 5)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
@@ -1384,7 +1392,7 @@ public sealed class RepulseState : IStreamingIndicatorState, IDisposable
         _bullMa = MovingAverageSmootherFactory.Create(maType, resolved * 5);
         _bearMa = MovingAverageSmootherFactory.Create(maType, resolved * 5);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Repulse;
@@ -1449,14 +1457,13 @@ public sealed class RepulsionMovingAverageState : IStreamingIndicatorState, IDis
     private readonly IMovingAverageSmoother _sma3;
     private readonly StreamingInputResolver _input;
 
-    public RepulsionMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public RepulsionMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         var resolved = Math.Max(1, length);
         _sma1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _sma2 = MovingAverageSmootherFactory.Create(maType, resolved * 2);
         _sma3 = MovingAverageSmootherFactory.Create(maType, resolved * 3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RepulsionMovingAverage;
@@ -1507,14 +1514,14 @@ public sealed class RetentionAccelerationFilterState : IStreamingIndicatorState,
     private double _prevAltma;
     private bool _hasPrev;
 
-    public RetentionAccelerationFilterState(int length = 50, InputName inputName = InputName.Close)
+    public RetentionAccelerationFilterState(int length = 50)
     {
         _length = Math.Max(1, length);
         _highWindow1 = new RollingWindowMax(_length);
         _lowWindow1 = new RollingWindowMin(_length);
         _highWindow2 = new RollingWindowMax(_length * 2);
         _lowWindow2 = new RollingWindowMin(_length * 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RetentionAccelerationFilter;
@@ -1587,12 +1594,12 @@ public sealed class RetrospectiveCandlestickChartState : IStreamingIndicatorStat
     private bool _hasPrev;
     private bool _hasPrevC;
 
-    public RetrospectiveCandlestickChartState(int length = 100, InputName inputName = InputName.Close)
+    public RetrospectiveCandlestickChartState(int length = 100)
     {
         var resolved = Math.Max(1, length);
         _absMax = new RollingWindowMax(resolved);
         _absMin = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RetrospectiveCandlestickChart;
@@ -1665,14 +1672,14 @@ public sealed class ReversalPointsState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public ReversalPointsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 100, InputName inputName = InputName.Close)
+        int length = 100)
     {
         _length = Math.Max(1, length);
         var length1 = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
         _aEma1 = MovingAverageSmootherFactory.Create(maType, length1);
         _aEma2 = MovingAverageSmootherFactory.Create(maType, length1);
         _bSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ReversalPoints;
@@ -1735,14 +1742,13 @@ public sealed class ReverseEngineeringRelativeStrengthIndexState : IStreamingInd
     private double _prevValue;
     private bool _hasPrev;
 
-    public ReverseEngineeringRelativeStrengthIndexState(int length = 14, double rsiLevel = 50,
-        InputName inputName = InputName.Close)
+    public ReverseEngineeringRelativeStrengthIndexState(int length = 14, double rsiLevel = 50)
     {
         _length = Math.Max(1, length);
         _rsiLevel = rsiLevel;
         var expPeriod = (2 * _length) - 1;
         _k = 2d / (expPeriod + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _prevAuc = 1;
         _prevAdc = 1;
     }
@@ -1803,7 +1809,7 @@ public sealed class ReverseMovingAverageConvergenceDivergenceState : IStreamingI
 
     public ReverseMovingAverageConvergenceDivergenceState(
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 12, int slowLength = 26,
-        int signalLength = 9, double macdLevel = 0, InputName inputName = InputName.Close)
+        int signalLength = 9, double macdLevel = 0)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1812,7 +1818,7 @@ public sealed class ReverseMovingAverageConvergenceDivergenceState : IStreamingI
         _fastMa = MovingAverageSmootherFactory.Create(maType, resolvedFast);
         _slowMa = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _signalMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ReverseMovingAverageConvergenceDivergence;

--- a/src/Streaming/StatefulIndicators.Batch21.cs
+++ b/src/Streaming/StatefulIndicators.Batch21.cs
@@ -23,20 +23,6 @@ public sealed class RapidRelativeStrengthIndexState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RapidRelativeStrengthIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _upSum = new RollingWindowSum(resolved);
-        _downSum = new RollingWindowSum(resolved);
-        _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RapidRelativeStrengthIndex;
 
     public void Reset()
@@ -100,16 +86,6 @@ public sealed class RatioOCHLAveragerState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RatioOCHLAveragerState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RatioOCHLAverager;
 
     public void Reset()
@@ -158,19 +134,6 @@ public sealed class ReallySimpleIndicatorState : IStreamingIndicatorState, IDisp
         _ma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ReallySimpleIndicatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ReallySimpleIndicator;
@@ -232,22 +195,6 @@ public sealed class RecursiveDifferenciatorState : IStreamingIndicatorState, IDi
         _avgGain = new WilderState(_length);
         _avgLoss = new WilderState(_length);
         _input = new StreamingInputResolver(inputName, null);
-        _bValues = new PooledRingBuffer<double>(_length);
-    }
-
-    public RecursiveDifferenciatorState(MovingAvgType maType, int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = alpha;
-        _ema = MovingAverageSmootherFactory.Create(maType, _length);
-        _avgGain = new WilderState(_length);
-        _avgLoss = new WilderState(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _bValues = new PooledRingBuffer<double>(_length);
     }
 
@@ -329,18 +276,6 @@ public sealed class RecursiveMovingTrendAverageState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RecursiveMovingTrendAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = 2d / (resolved + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RecursiveMovingTrendAverage;
 
     public void Reset()
@@ -403,26 +338,6 @@ public sealed class RecursiveRelativeStrengthIndexState : IStreamingIndicatorSta
         _avgGain = new WilderState(_length);
         _avgLoss = new WilderState(_length);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length);
-        _bValues = new PooledRingBuffer<double>(_length);
-        _avgValues = new PooledRingBuffer<double>(_length);
-        _gainValues = new PooledRingBuffer<double>(_length);
-        _lossValues = new PooledRingBuffer<double>(_length);
-        _avgRsiValues = new PooledRingBuffer<double>(_length);
-    }
-
-    public RecursiveRelativeStrengthIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _srcMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _avgGain = new WilderState(_length);
-        _avgLoss = new WilderState(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length);
         _bValues = new PooledRingBuffer<double>(_length);
         _avgValues = new PooledRingBuffer<double>(_length);
@@ -558,22 +473,6 @@ public sealed class RecursiveStochasticState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RecursiveStochasticState(int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = alpha;
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _maHighWindow = new RollingWindowMax(_length);
-        _maLowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RecursiveStochastic;
 
     public void Reset()
@@ -638,17 +537,6 @@ public sealed class RegressionOscillatorState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RegressionOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _linReg = new LinearRegressionState(length, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RegressionOscillator;
 
     public void Reset()
@@ -694,19 +582,6 @@ public sealed class RegularizedExponentialMovingAverageState : IStreamingIndicat
         _alpha = 2d / (resolved + 1);
         _lambda = lambda;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RegularizedExponentialMovingAverageState(int length, double lambda, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = 2d / (resolved + 1);
-        _lambda = lambda;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RegularizedExponentialMovingAverage;
@@ -758,20 +633,6 @@ public sealed class RelativeDifferenceOfSquaresOscillatorState : IStreamingIndic
         _dSum = new RollingWindowSum(resolved);
         _nSum = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RelativeDifferenceOfSquaresOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _aSum = new RollingWindowSum(resolved);
-        _dSum = new RollingWindowSum(resolved);
-        _nSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RelativeDifferenceOfSquaresOscillator;
@@ -843,21 +704,6 @@ public sealed class RelativeMomentumIndexState : IStreamingIndicatorState, IDisp
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _values = new PooledRingBuffer<double>(_length2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RelativeMomentumIndexState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _avgGain = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _avgLoss = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _values = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RelativeMomentumIndex;
@@ -1059,22 +905,6 @@ public sealed class RelativeSpreadStrengthState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RelativeSpreadStrengthState(MovingAvgType maType, int fastLength, int slowLength, int length,
-        int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _avgGain = new WilderState(Math.Max(1, length));
-        _avgLoss = new WilderState(Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RelativeSpreadStrength;
 
     public void Reset()
@@ -1274,22 +1104,6 @@ public sealed class RelativeVigorIndexState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RelativeVigorIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _numeratorMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _denominatorMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _openValues = new PooledRingBuffer<double>(3);
-        _closeValues = new PooledRingBuffer<double>(3);
-        _highValues = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RelativeVigorIndex;
 
     public void Reset()
@@ -1385,20 +1199,6 @@ public sealed class RelativeVolatilityIndexV1State : IStreamingIndicatorState, I
         _upAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _downAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RelativeVolatilityIndexV1State(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length), selector);
-        _upAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _downAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RelativeVolatilityIndexV1;
@@ -1514,19 +1314,6 @@ public sealed class RelativeVolumeIndicatorState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RelativeVolumeIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _volumeStdDev = new StandardDeviationVolatilityState(maType, resolved, InputName.Volume);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RelativeVolumeIndicator;
 
     public void Reset()
@@ -1598,22 +1385,6 @@ public sealed class RepulseState : IStreamingIndicatorState, IDisposable
         _bearMa = MovingAverageSmootherFactory.Create(maType, resolved * 5);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RepulseState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _bullMa = MovingAverageSmootherFactory.Create(maType, resolved * 5);
-        _bearMa = MovingAverageSmootherFactory.Create(maType, resolved * 5);
-        _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Repulse;
@@ -1688,20 +1459,6 @@ public sealed class RepulsionMovingAverageState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RepulsionMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _sma2 = MovingAverageSmootherFactory.Create(maType, resolved * 2);
-        _sma3 = MovingAverageSmootherFactory.Create(maType, resolved * 3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RepulsionMovingAverage;
 
     public void Reset()
@@ -1758,21 +1515,6 @@ public sealed class RetentionAccelerationFilterState : IStreamingIndicatorState,
         _highWindow2 = new RollingWindowMax(_length * 2);
         _lowWindow2 = new RollingWindowMin(_length * 2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RetentionAccelerationFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow1 = new RollingWindowMax(_length);
-        _lowWindow1 = new RollingWindowMin(_length);
-        _highWindow2 = new RollingWindowMax(_length * 2);
-        _lowWindow2 = new RollingWindowMin(_length * 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RetentionAccelerationFilter;
@@ -1851,19 +1593,6 @@ public sealed class RetrospectiveCandlestickChartState : IStreamingIndicatorStat
         _absMax = new RollingWindowMax(resolved);
         _absMin = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RetrospectiveCandlestickChartState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _absMax = new RollingWindowMax(resolved);
-        _absMin = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RetrospectiveCandlestickChart;
@@ -1946,21 +1675,6 @@ public sealed class ReversalPointsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ReversalPointsState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var length1 = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
-        _aEma1 = MovingAverageSmootherFactory.Create(maType, length1);
-        _aEma2 = MovingAverageSmootherFactory.Create(maType, length1);
-        _bSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ReversalPoints;
 
     public void Reset()
@@ -2033,22 +1747,6 @@ public sealed class ReverseEngineeringRelativeStrengthIndexState : IStreamingInd
         _prevAdc = 1;
     }
 
-    public ReverseEngineeringRelativeStrengthIndexState(int length, double rsiLevel, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _rsiLevel = rsiLevel;
-        var expPeriod = (2 * _length) - 1;
-        _k = 2d / (expPeriod + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _prevAuc = 1;
-        _prevAdc = 1;
-    }
-
     public IndicatorName Name => IndicatorName.ReverseEngineeringRelativeStrengthIndex;
 
     public void Reset()
@@ -2115,24 +1813,6 @@ public sealed class ReverseMovingAverageConvergenceDivergenceState : IStreamingI
         _slowMa = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _signalMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ReverseMovingAverageConvergenceDivergenceState(MovingAvgType maType, int fastLength, int slowLength,
-        int signalLength, double macdLevel, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastAlpha = 2d / (1 + resolvedFast);
-        _slowAlpha = 2d / (1 + resolvedSlow);
-        _fastMa = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowMa = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _signalMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ReverseMovingAverageConvergenceDivergence;

--- a/src/Streaming/StatefulIndicators.Batch22.cs
+++ b/src/Streaming/StatefulIndicators.Batch22.cs
@@ -20,19 +20,6 @@ public sealed class RexOscillatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RexOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _roSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RexOscillator;
 
     public void Reset()
@@ -94,30 +81,6 @@ public sealed class RightSidedRickerMovingAverageState : IStreamingIndicatorStat
         _weightSum = cumulative;
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RightSidedRickerMovingAverageState(int length, double pctWidth, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var width = pctWidth / 100d * _length;
-        _cumulativeWeights = new double[_length];
-        double cumulative = 0;
-        for (var j = 0; j < _length; j++)
-        {
-            var weight = (1 - MathHelper.Pow(j / width, 2))
-                * MathHelper.Exp(-(MathHelper.Pow(j, 2) / (2 * MathHelper.Pow(width, 2))));
-            cumulative += weight;
-            _cumulativeWeights[j] = cumulative;
-        }
-
-        _weightSum = cumulative;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RightSidedRickerMovingAverage;
@@ -207,23 +170,6 @@ public sealed class RobustWeightingOscillatorState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RobustWeightingOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _corrWindow = new RollingWindowCorrelation(_length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _indexSma = MovingAverageSmootherFactory.Create(maType, _length);
-        _lSma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RobustWeightingOscillator;
 
     public void Reset()
@@ -305,21 +251,6 @@ public sealed class RSINGIndicatorState : IStreamingIndicatorState, IDisposable
         _rangeStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _rangeValue);
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RSINGIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _signalMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _rangeStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _rangeValue);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RSINGIndicator;
@@ -488,19 +419,6 @@ public sealed class RunningEquityState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RunningEquityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _chgXSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RunningEquity;
 
     public void Reset()
@@ -568,22 +486,6 @@ public sealed class SchaffTrendCycleState : IStreamingIndicatorState, IDisposabl
         _maxWindow = new RollingWindowMax(_cycleLength);
         _minWindow = new RollingWindowMin(_cycleLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SchaffTrendCycleState(MovingAvgType maType, int fastLength, int slowLength, int cycleLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _cycleLength = Math.Max(1, cycleLength);
-        _fastEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _maxWindow = new RollingWindowMax(_cycleLength);
-        _minWindow = new RollingWindowMin(_cycleLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SchaffTrendCycle;
@@ -755,22 +657,6 @@ public sealed class SelfAdjustingRelativeStrengthIndexState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SelfAdjustingRelativeStrengthIndexState(MovingAvgType maType, int length, int smoothingLength, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _mult = mult;
-        var resolvedLength = Math.Max(1, length);
-        _rsi = new RsiState(maType, resolvedLength);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
-        _stdDev = new StandardDeviationVolatilityState(maType, resolvedLength, _ => _rsiValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SelfAdjustingRelativeStrengthIndex;
 
     public void Reset()
@@ -826,18 +712,6 @@ public sealed class SelfWeightedMovingAverageState : IStreamingIndicatorState, I
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length * 2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SelfWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SelfWeightedMovingAverage;
@@ -956,22 +830,6 @@ public sealed class SentimentZoneOscillatorState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SentimentZoneOscillatorState(MovingAvgType maType, int fastLength, int slowLength, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _factor = factor;
-        _maxWindow = new RollingWindowMax(Math.Max(1, slowLength));
-        _minWindow = new RollingWindowMin(Math.Max(1, slowLength));
-        _smoother = MovingAverageSmootherFactory.Create(maType, _fastLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SentimentZoneOscillator;
 
     public void Reset()
@@ -1041,19 +899,6 @@ public sealed class SequentiallyFilteredMovingAverageState : IStreamingIndicator
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SequentiallyFilteredMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _signSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SequentiallyFilteredMovingAverage;
 
     public void Reset()
@@ -1114,16 +959,6 @@ public sealed class SettingLessTrendStepFilteringState : IStreamingIndicatorStat
     public SettingLessTrendStepFilteringState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SettingLessTrendStepFilteringState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SettingLessTrendStepFiltering;
@@ -1218,46 +1053,6 @@ public sealed class ShapeshiftingMovingAverageState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ShapeshiftingMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weightsX = new double[_length];
-        _weightsN = new double[_length];
-        double sumX = 0;
-        double sumN = 0;
-        if (_length == 1)
-        {
-            _weightsX[0] = 1;
-            _weightsN[0] = 1;
-            sumX = 1;
-            sumN = 1;
-        }
-        else
-        {
-            for (var j = 0; j < _length; j++)
-            {
-                var x = (double)j / (_length - 1);
-                var n = -1 + (x * 2);
-                var wx = 1 - (2 * x / (MathHelper.Pow(x, 4) + 1));
-                var wn = 1 - (2 * MathHelper.Pow(n, 2) / (MathHelper.Pow(n, 4) + 1));
-                _weightsX[j] = wx;
-                _weightsN[j] = wn;
-                sumX += wx;
-                sumN += wn;
-            }
-        }
-
-        _weightSumX = sumX;
-        _weightSumN = sumN;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ShapeshiftingMovingAverage;
 
     public void Reset()
@@ -1327,24 +1122,6 @@ public sealed class SharpeRatioState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SharpeRatioState(MovingAvgType maType, int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var barMin = 60d * 24;
-        var minPerYr = 60d * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = MathHelper.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, _ => _retValue);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SharpeRatio;
 
     public void Reset()
@@ -1412,26 +1189,6 @@ public sealed class SharpModifiedMovingAverageState : IStreamingIndicatorState, 
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SharpModifiedMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        for (var j = 0; j < _length; j++)
-        {
-            var factor = 1 + (2 * j);
-            _weights[j] = (_length - factor) / 2d;
-        }
-
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SharpModifiedMovingAverage;
@@ -1571,19 +1328,6 @@ public sealed class SimpleCycleState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SimpleCycleState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = 1d / _length;
-        _srcValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SimpleCycle;
 
     public void Reset()
@@ -1648,19 +1392,6 @@ public sealed class SimpleLinesState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SimpleLinesState(int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mult = mult;
-        _s = 0.01 * 100 * (1d / _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SimpleLines;
 
     public void Reset()
@@ -1715,19 +1446,6 @@ public sealed class SimplifiedLeastSquaresMovingAverageState : IStreamingIndicat
         _cmlValues = new PooledRingBuffer<double>(_length + 1);
         _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SimplifiedLeastSquaresMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _cmlValues = new PooledRingBuffer<double>(_length + 1);
-        _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SimplifiedLeastSquaresMovingAverage;
@@ -1797,18 +1515,6 @@ public sealed class SimplifiedWeightedMovingAverageState : IStreamingIndicatorSt
         _length = Math.Max(1, length);
         _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SimplifiedWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SimplifiedWeightedMovingAverage;
@@ -1884,28 +1590,6 @@ public sealed class SineWeightedMovingAverageState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SineWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        double sum = 0;
-        for (var j = 0; j <= _length - 1; j++)
-        {
-            var weight = Math.Sin((j + 1) * Math.PI / (_length + 1));
-            _weights[j] = weight;
-            sum += weight;
-        }
-
-        _weightSum = sum;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SineWeightedMovingAverage;
 
     public void Reset()
@@ -1968,23 +1652,6 @@ public sealed class SlowSmoothedMovingAverageState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SlowSmoothedMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var w2 = MathHelper.MinOrMax((int)Math.Ceiling(resolved / 3d));
-        var w1 = MathHelper.MinOrMax((int)Math.Ceiling((resolved - w2) / 2d));
-        var w3 = MathHelper.MinOrMax((int)Math.Floor((resolved - w2) / 2d));
-        _l1 = MovingAverageSmootherFactory.Create(maType, w1);
-        _l2 = MovingAverageSmootherFactory.Create(maType, w2);
-        _l3 = MovingAverageSmootherFactory.Create(maType, w3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SlowSmoothedMovingAverage;
 
     public void Reset()
@@ -2041,22 +1708,6 @@ public sealed class SMIErgodicIndicatorState : IStreamingIndicatorState, IDispos
         _absSmoothSlow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SMIErgodicIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _pcSmoothFast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _pcSmoothSlow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _absSmoothFast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _absSmoothSlow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SMIErgodicIndicator;

--- a/src/Streaming/StatefulIndicators.Batch22.cs
+++ b/src/Streaming/StatefulIndicators.Batch22.cs
@@ -11,13 +11,12 @@ public sealed class RexOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _signalSmoother;
     private readonly StreamingInputResolver _input;
 
-    public RexOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public RexOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _roSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RexOscillator;
@@ -63,8 +62,7 @@ public sealed class RightSidedRickerMovingAverageState : IStreamingIndicatorStat
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public RightSidedRickerMovingAverageState(int length = 50, double pctWidth = 60,
-        InputName inputName = InputName.Close)
+    public RightSidedRickerMovingAverageState(int length = 50, double pctWidth = 60)
     {
         _length = Math.Max(1, length);
         var width = pctWidth / 100d * _length;
@@ -80,7 +78,7 @@ public sealed class RightSidedRickerMovingAverageState : IStreamingIndicatorStat
 
         _weightSum = cumulative;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RightSidedRickerMovingAverage;
@@ -157,17 +155,16 @@ public sealed class RobustWeightingOscillatorState : IStreamingIndicatorState, I
     private double _indexValue;
     private int _index;
 
-    public RobustWeightingOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200,
-        InputName inputName = InputName.Close)
+    public RobustWeightingOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200)
     {
         _length = Math.Max(1, length);
         _corrWindow = new RollingWindowCorrelation(_length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _indexSma = MovingAverageSmootherFactory.Create(maType, _length);
         _lSma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _indexStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _indexValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RobustWeightingOscillator;
@@ -242,15 +239,14 @@ public sealed class RSINGIndicatorState : IStreamingIndicatorState, IDisposable
     private double _rangeValue;
     private int _index;
 
-    public RSINGIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public RSINGIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20)
     {
         _length = Math.Max(1, length);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, _length);
         _signalMa = MovingAverageSmootherFactory.Create(maType, _length);
         _rangeStdDev = new StandardDeviationVolatilityState(maType, _length, _ => _rangeValue);
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RSINGIndicator;
@@ -410,13 +406,12 @@ public sealed class RunningEquityState : IStreamingIndicatorState, IDisposable
     private double _prevX;
     private bool _hasPrev;
 
-    public RunningEquityState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public RunningEquityState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         _length = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _chgXSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RunningEquity;
@@ -477,15 +472,14 @@ public sealed class SchaffTrendCycleState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
 
     public SchaffTrendCycleState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 23, int slowLength = 50, int cycleLength = 10,
-        InputName inputName = InputName.Close)
+        int fastLength = 23, int slowLength = 50, int cycleLength = 10)
     {
         _cycleLength = Math.Max(1, cycleLength);
         _fastEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowEma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _maxWindow = new RollingWindowMax(_cycleLength);
         _minWindow = new RollingWindowMin(_cycleLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SchaffTrendCycle;
@@ -646,15 +640,14 @@ public sealed class SelfAdjustingRelativeStrengthIndexState : IStreamingIndicato
     private double _rsiValue;
 
     public SelfAdjustingRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 14, int smoothingLength = 21, double mult = 2,
-        InputName inputName = InputName.Close)
+        int length = 14, int smoothingLength = 21, double mult = 2)
     {
         _mult = mult;
         var resolvedLength = Math.Max(1, length);
         _rsi = new RsiState(maType, resolvedLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
         _stdDev = new StandardDeviationVolatilityState(maType, resolvedLength, _ => _rsiValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SelfAdjustingRelativeStrengthIndex;
@@ -707,11 +700,11 @@ public sealed class SelfWeightedMovingAverageState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public SelfWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SelfWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SelfWeightedMovingAverage;
@@ -819,15 +812,14 @@ public sealed class SentimentZoneOscillatorState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public SentimentZoneOscillatorState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage,
-        int fastLength = 14, int slowLength = 30, double factor = 0.95,
-        InputName inputName = InputName.Close)
+        int fastLength = 14, int slowLength = 30, double factor = 0.95)
     {
         _fastLength = Math.Max(1, fastLength);
         _factor = factor;
         _maxWindow = new RollingWindowMax(Math.Max(1, slowLength));
         _minWindow = new RollingWindowMin(Math.Max(1, slowLength));
         _smoother = MovingAverageSmootherFactory.Create(maType, _fastLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SentimentZoneOscillator;
@@ -891,12 +883,12 @@ public sealed class SequentiallyFilteredMovingAverageState : IStreamingIndicator
     private bool _hasPrev;
 
     public SequentiallyFilteredMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 50, InputName inputName = InputName.Close)
+        int length = 50)
     {
         _length = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _signSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SequentiallyFilteredMovingAverage;
@@ -956,9 +948,9 @@ public sealed class SettingLessTrendStepFilteringState : IStreamingIndicatorStat
     private double _prevB;
     private bool _hasPrev;
 
-    public SettingLessTrendStepFilteringState(InputName inputName = InputName.Close)
+    public SettingLessTrendStepFilteringState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SettingLessTrendStepFiltering;
@@ -1018,7 +1010,7 @@ public sealed class ShapeshiftingMovingAverageState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public ShapeshiftingMovingAverageState(int length = 50, InputName inputName = InputName.Close)
+    public ShapeshiftingMovingAverageState(int length = 50)
     {
         _length = Math.Max(1, length);
         _weightsX = new double[_length];
@@ -1050,7 +1042,7 @@ public sealed class ShapeshiftingMovingAverageState : IStreamingIndicatorState, 
         _weightSumX = sumX;
         _weightSumN = sumN;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ShapeshiftingMovingAverage;
@@ -1108,8 +1100,7 @@ public sealed class SharpeRatioState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private double _retValue;
 
-    public SharpeRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.02,
-        InputName inputName = InputName.Close)
+    public SharpeRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.02)
     {
         _length = Math.Max(1, length);
         var barMin = 60d * 24;
@@ -1119,7 +1110,7 @@ public sealed class SharpeRatioState : IStreamingIndicatorState, IDisposable
         _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _stdDev = new StandardDeviationVolatilityState(maType, _length, _ => _retValue);
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SharpeRatio;
@@ -1175,8 +1166,7 @@ public sealed class SharpModifiedMovingAverageState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public SharpModifiedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public SharpModifiedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -1188,7 +1178,7 @@ public sealed class SharpModifiedMovingAverageState : IStreamingIndicatorState, 
 
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SharpModifiedMovingAverage;
@@ -1320,12 +1310,12 @@ public sealed class SimpleCycleState : IStreamingIndicatorState, IDisposable
     private double _prevC;
     private int _count;
 
-    public SimpleCycleState(int length = 50, InputName inputName = InputName.Close)
+    public SimpleCycleState(int length = 50)
     {
         _length = Math.Max(1, length);
         _alpha = 1d / _length;
         _srcValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SimpleCycle;
@@ -1384,12 +1374,12 @@ public sealed class SimpleLinesState : IStreamingIndicatorState
     private double _prevA2;
     private int _count;
 
-    public SimpleLinesState(int length = 10, double mult = 10, InputName inputName = InputName.Close)
+    public SimpleLinesState(int length = 10, double mult = 10)
     {
         _length = Math.Max(1, length);
         _mult = mult;
         _s = 0.01 * 100 * (1d / _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SimpleLines;
@@ -1440,12 +1430,12 @@ public sealed class SimplifiedLeastSquaresMovingAverageState : IStreamingIndicat
     private double _cmlSumTotal;
     private double _prevSum;
 
-    public SimplifiedLeastSquaresMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SimplifiedLeastSquaresMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _cmlValues = new PooledRingBuffer<double>(_length + 1);
         _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SimplifiedLeastSquaresMovingAverage;
@@ -1510,11 +1500,11 @@ public sealed class SimplifiedWeightedMovingAverageState : IStreamingIndicatorSt
     private double _cmlSumTotal;
     private double _prevSum;
 
-    public SimplifiedWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SimplifiedWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _cmlSumValues = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SimplifiedWeightedMovingAverage;
@@ -1573,7 +1563,7 @@ public sealed class SineWeightedMovingAverageState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public SineWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SineWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -1587,7 +1577,7 @@ public sealed class SineWeightedMovingAverageState : IStreamingIndicatorState, I
 
         _weightSum = sum;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SineWeightedMovingAverage;
@@ -1639,8 +1629,7 @@ public sealed class SlowSmoothedMovingAverageState : IStreamingIndicatorState, I
     private readonly IMovingAverageSmoother _l3;
     private readonly StreamingInputResolver _input;
 
-    public SlowSmoothedMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 15,
-        InputName inputName = InputName.Close)
+    public SlowSmoothedMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 15)
     {
         var resolved = Math.Max(1, length);
         var w2 = MathHelper.MinOrMax((int)Math.Ceiling(resolved / 3d));
@@ -1649,7 +1638,7 @@ public sealed class SlowSmoothedMovingAverageState : IStreamingIndicatorState, I
         _l1 = MovingAverageSmootherFactory.Create(maType, w1);
         _l2 = MovingAverageSmootherFactory.Create(maType, w2);
         _l3 = MovingAverageSmootherFactory.Create(maType, w3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SlowSmoothedMovingAverage;
@@ -1700,14 +1689,14 @@ public sealed class SMIErgodicIndicatorState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public SMIErgodicIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 5,
-        int slowLength = 20, int signalLength = 5, InputName inputName = InputName.Close)
+        int slowLength = 20, int signalLength = 5)
     {
         _pcSmoothFast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _pcSmoothSlow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _absSmoothFast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _absSmoothSlow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SMIErgodicIndicator;

--- a/src/Streaming/StatefulIndicators.Batch23.cs
+++ b/src/Streaming/StatefulIndicators.Batch23.cs
@@ -891,7 +891,17 @@ public sealed class StandardPivotPointsState : IStreamingIndicatorState
 
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
-        var close = _input.GetValue(bar);
+        // bar.Close, not the resolver. Pivot points are defined on the previous period's OHLC, and
+        // the batch says so structurally: CalculateStandardPivotPoints resolves through
+        // GetInputValuesList(stockData, inputLength), which rebuilds every series from
+        // TickerDataList by period and never consults CustomValuesList or InputValues. A chained
+        // series is invisible to it by construction.
+        //
+        // Reading the resolver here let a streaming caller compute "pivot points" on a series the
+        // batch has no way to accept, so the two engines disagreed whenever a selector was supplied.
+        // The InputName and selector constructor overloads remain for signature uniformity across
+        // the catalogue; for this indicator they have nothing to select.
+        var close = bar.Close;
         var prevHigh = _hasPrev ? _prevHigh : 0;
         var prevLow = _hasPrev ? _prevLow : 0;
         var prevClose = _hasPrev ? _prevClose : 0;

--- a/src/Streaming/StatefulIndicators.Batch23.cs
+++ b/src/Streaming/StatefulIndicators.Batch23.cs
@@ -26,21 +26,6 @@ public sealed class SmoothedDeltaRatioOscillatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SmoothedDeltaRatioOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _absSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _values = new PooledRingBuffer<double>(_length);
-        _smaValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SmoothedDeltaRatioOscillator;
 
     public void Reset()
@@ -108,20 +93,6 @@ public sealed class SmoothedRateOfChangeState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SmoothedRateOfChangeState(MovingAvgType maType, int length, int smoothingLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
-        _maValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SmoothedRateOfChange;
 
     public void Reset()
@@ -179,18 +150,6 @@ public sealed class SmoothedWilliamsAccumulationDistributionState : IStreamingIn
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SmoothedWilliamsAccumulationDistributionState(MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SmoothedWilliamsAccumulationDistribution;
@@ -269,26 +228,6 @@ public sealed class SortinoRatioState : IStreamingIndicatorState, IDisposable
         _devWindow = new PooledRingBuffer<double>(_length);
         _exactWindow = maType == MovingAvgType.SimpleMovingAverage;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SortinoRatioState(MovingAvgType maType, int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var barMin = 60d * 24;
-        var minPerYr = 60d * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = MathHelper.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _retSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _devSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _devWindow = new PooledRingBuffer<double>(_length);
-        _exactWindow = maType == MovingAvgType.SimpleMovingAverage;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SortinoRatio;
@@ -388,19 +327,6 @@ public sealed class SpearmanIndicatorState : IStreamingIndicatorState, IDisposab
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SpearmanIndicatorState(MovingAvgType maType, int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SpearmanIndicator;
@@ -538,18 +464,6 @@ public sealed class Spencer15PointMovingAverageState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Spencer15PointMovingAverageState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _weightSum = SumWeights();
-        _values = new PooledRingBuffer<double>(Weights.Length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Spencer15PointMovingAverage;
 
     public void Reset()
@@ -619,18 +533,6 @@ public sealed class Spencer21PointMovingAverageState : IStreamingIndicatorState,
         _weightSum = SumWeights();
         _values = new PooledRingBuffer<double>(Weights.Length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public Spencer21PointMovingAverageState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _weightSum = SumWeights();
-        _values = new PooledRingBuffer<double>(Weights.Length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Spencer21PointMovingAverage;
@@ -711,28 +613,6 @@ public sealed class SquareRootWeightedMovingAverageState : IStreamingIndicatorSt
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SquareRootWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        double sum = 0;
-        for (var j = 0; j <= _length - 1; j++)
-        {
-            var weight = MathHelper.Pow(_length - j, 0.5);
-            _weights[j] = weight;
-            sum += weight;
-        }
-
-        _weightSum = sum;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SquareRootWeightedMovingAverage;
 
     public void Reset()
@@ -796,21 +676,6 @@ public sealed class SqueezeMomentumIndicatorState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SqueezeMomentumIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _linReg = new LinearRegressionState(_length, _ => _diffValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SqueezeMomentumIndicator;
 
     public void Reset()
@@ -866,16 +731,6 @@ public sealed class StandardPivotPointsState : IStreamingIndicatorState
     public StandardPivotPointsState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StandardPivotPointsState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StandardPivotPoints;
@@ -972,22 +827,6 @@ public sealed class StationaryExtrapolatedLevelsOscillatorState : IStreamingIndi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StationaryExtrapolatedLevelsOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stochLength = Math.Max(1, _length * 2);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _maxWindow = new RollingWindowMax(_stochLength);
-        _minWindow = new RollingWindowMin(_stochLength);
-        _yValues = new PooledRingBuffer<double>(_stochLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StationaryExtrapolatedLevelsOscillator;
 
     public void Reset()
@@ -1062,24 +901,6 @@ public sealed class StiffnessIndicatorState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StiffnessIndicatorState(MovingAvgType maType, int length1, int length2, int smoothingLength, double threshold,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = threshold;
-        _length2 = Math.Max(1, length2);
-        var resolved = Math.Max(1, length1);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _aboveSum = new RollingWindowSum(_length2);
-        _signal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, smoothingLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StiffnessIndicator;
 
     public void Reset()
@@ -1141,23 +962,6 @@ public sealed class StochasticCustomOscillatorState : IStreamingIndicatorState, 
         _denomSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StochasticCustomOscillatorState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved1);
-        _lowWindow = new RollingWindowMin(resolved1);
-        _numSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _denomSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StochasticCustomOscillator;
@@ -1225,22 +1029,6 @@ public sealed class StochasticFastOscillatorState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StochasticFastOscillatorState(MovingAvgType maType, int length, int smoothLength1, int smoothLength2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StochasticFastOscillator;
 
     public void Reset()
@@ -1303,24 +1091,6 @@ public sealed class StochasticMovingAverageConvergenceDivergenceOscillatorState 
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StochasticMovingAverageConvergenceDivergenceOscillatorState(
-        MovingAvgType maType, int length, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StochasticMovingAverageConvergenceDivergenceOscillator;
@@ -1389,20 +1159,6 @@ public sealed class StochasticRegularState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StochasticRegularState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StochasticRegular;
 
     public void Reset()
@@ -1465,24 +1221,6 @@ public sealed class StrengthOfMovementState : IStreamingIndicatorState, IDisposa
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
         _values = new PooledRingBuffer<double>(_length2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StrengthOfMovementState(MovingAvgType maType, int length1, int length2, int smoothingLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _maxWindow = new RollingWindowMax(_length1);
-        _minWindow = new RollingWindowMin(_length1);
-        _bSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
-        _values = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StrengthOfMovement;
@@ -1558,18 +1296,6 @@ public sealed class SuperTrendState : IStreamingIndicatorState, IDisposable
     {
         _atrSmoother = new AverageTrueRangeSmoother(maType, Math.Max(1, length), inputName);
         _input = new StreamingInputResolver(inputName, null);
-        _atrMult = atrMult;
-    }
-
-    public SuperTrendState(MovingAvgType maType, int length, double atrMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _atrSmoother = new AverageTrueRangeSmoother(maType, Math.Max(1, length), selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _atrMult = atrMult;
     }
 
@@ -1654,20 +1380,6 @@ public sealed class SuperTrendFilterState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SuperTrendFilterState(int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var p = MathHelper.Pow(resolved, 2);
-        _a = 2 / (p + 1);
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SuperTrendFilter;
 
     public void Reset()
@@ -1741,16 +1453,6 @@ public sealed class SupportAndResistanceOscillatorState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SupportAndResistanceOscillatorState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SupportAndResistanceOscillator;
 
     public void Reset()
@@ -1802,19 +1504,6 @@ public sealed class SurfaceRoughnessEstimatorState : IStreamingIndicatorState, I
         var resolved = Math.Max(1, length);
         _corrWindow = new RollingWindowCorrelation(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SurfaceRoughnessEstimatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = maType;
-        var resolved = Math.Max(1, length);
-        _corrWindow = new RollingWindowCorrelation(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SurfaceRoughnessEstimator;
@@ -1871,17 +1560,6 @@ public sealed class SvamaState : IStreamingIndicatorState
     {
         _ = length;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SvamaState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = length;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Svama;
@@ -1953,19 +1631,6 @@ public sealed class SwamiStochasticsState : IStreamingIndicatorState, IDisposabl
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SwamiStochasticsState(int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, slowLength - fastLength);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SwamiStochastics;
@@ -2060,39 +1725,6 @@ public sealed class SymmetricallyWeightedMovingAverageState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SymmetricallyWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        var floorLength = (int)Math.Floor((double)_length / 2);
-        var roundLength = (int)Math.Round((double)_length / 2);
-        double sum = 0;
-        for (var j = 0; j <= _length - 1; j++)
-        {
-            double weight;
-            if (floorLength == roundLength)
-            {
-                weight = j < floorLength ? (j + 1) * _length : (_length - j) * _length;
-            }
-            else
-            {
-                weight = j <= floorLength ? (j + 1) * _length : (_length - j) * _length;
-            }
-
-            _weights[j] = weight;
-            sum += weight;
-        }
-
-        _weightSum = sum;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SymmetricallyWeightedMovingAverage;
 
     public void Reset()
@@ -2165,27 +1797,6 @@ public sealed class TechnicalRankState : IStreamingIndicatorState, IDisposable
         _ppoSignal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length7));
         _histValues = new PooledRingBuffer<double>(_length8);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TechnicalRankState(int length1, int length2, int length3, int length4, int length5, int length6,
-        int length7, int length8, int length9, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length8 = Math.Max(1, length8);
-        _ma1 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length1));
-        _ma2 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length3));
-        _rocLong = new RateOfChangeState(Math.Max(1, length2), selector);
-        _rocShort = new RateOfChangeState(Math.Max(1, length4), selector);
-        _rsi = new RelativeStrengthIndexState(Math.Max(1, length9), 3, selector);
-        _ppoFast = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length5));
-        _ppoSlow = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length6));
-        _ppoSignal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length7));
-        _histValues = new PooledRingBuffer<double>(_length8);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TechnicalRank;

--- a/src/Streaming/StatefulIndicators.Batch23.cs
+++ b/src/Streaming/StatefulIndicators.Batch23.cs
@@ -891,17 +891,10 @@ public sealed class StandardPivotPointsState : IStreamingIndicatorState
 
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
-        // bar.Close, not the resolver. Pivot points are defined on the previous period's OHLC, and
-        // the batch says so structurally: CalculateStandardPivotPoints resolves through
-        // GetInputValuesList(stockData, inputLength), which rebuilds every series from
-        // TickerDataList by period and never consults CustomValuesList or InputValues. A chained
-        // series is invisible to it by construction.
-        //
-        // Reading the resolver here let a streaming caller compute "pivot points" on a series the
-        // batch has no way to accept, so the two engines disagreed whenever a selector was supplied.
-        // The InputName and selector constructor overloads remain for signature uniformity across
-        // the catalogue; for this indicator they have nothing to select.
-        var close = bar.Close;
+        // The input series, like every other indicator: pivot points take custom values. The batch
+        // twin builds each period from the chained series and the per-bar high and low, and wrapped in
+        // CustomInputState this state sees exactly those adjusted bars.
+        var close = _input.GetValue(bar);
         var prevHigh = _hasPrev ? _prevHigh : 0;
         var prevLow = _hasPrev ? _prevLow : 0;
         var prevClose = _hasPrev ? _prevClose : 0;

--- a/src/Streaming/StatefulIndicators.Batch23.cs
+++ b/src/Streaming/StatefulIndicators.Batch23.cs
@@ -15,15 +15,14 @@ public sealed class SmoothedDeltaRatioOscillatorState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public SmoothedDeltaRatioOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public SmoothedDeltaRatioOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         _length = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _absSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _values = new PooledRingBuffer<double>(_length);
         _smaValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SmoothedDeltaRatioOscillator;
@@ -85,12 +84,12 @@ public sealed class SmoothedRateOfChangeState : IStreamingIndicatorState, IDispo
     private int _index;
 
     public SmoothedRateOfChangeState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 21,
-        int smoothingLength = 13, InputName inputName = InputName.Close)
+        int smoothingLength = 13)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
         _maValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SmoothedRateOfChange;
@@ -146,10 +145,10 @@ public sealed class SmoothedWilliamsAccumulationDistributionState : IStreamingIn
     private bool _hasPrev;
 
     public SmoothedWilliamsAccumulationDistributionState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SmoothedWilliamsAccumulationDistribution;
@@ -214,8 +213,7 @@ public sealed class SortinoRatioState : IStreamingIndicatorState, IDisposable
     private readonly bool _exactWindow;
     private readonly StreamingInputResolver _input;
 
-    public SortinoRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.02,
-        InputName inputName = InputName.Close)
+    public SortinoRatioState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 30, double bmk = 0.02)
     {
         _length = Math.Max(1, length);
         var barMin = 60d * 24;
@@ -227,7 +225,7 @@ public sealed class SortinoRatioState : IStreamingIndicatorState, IDisposable
         _values = new PooledRingBuffer<double>(_length + 1);
         _devWindow = new PooledRingBuffer<double>(_length);
         _exactWindow = maType == MovingAvgType.SimpleMovingAverage;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SortinoRatio;
@@ -321,12 +319,12 @@ public sealed class SpearmanIndicatorState : IStreamingIndicatorState, IDisposab
     private readonly StreamingInputResolver _input;
 
     public SpearmanIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10,
-        int signalLength = 3, InputName inputName = InputName.Close)
+        int signalLength = 3)
     {
         _length = Math.Max(1, length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SpearmanIndicator;
@@ -457,11 +455,11 @@ public sealed class Spencer15PointMovingAverageState : IStreamingIndicatorState,
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public Spencer15PointMovingAverageState(InputName inputName = InputName.Close)
+    public Spencer15PointMovingAverageState()
     {
         _weightSum = SumWeights();
         _values = new PooledRingBuffer<double>(Weights.Length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Spencer15PointMovingAverage;
@@ -528,11 +526,11 @@ public sealed class Spencer21PointMovingAverageState : IStreamingIndicatorState,
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public Spencer21PointMovingAverageState(InputName inputName = InputName.Close)
+    public Spencer21PointMovingAverageState()
     {
         _weightSum = SumWeights();
         _values = new PooledRingBuffer<double>(Weights.Length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Spencer21PointMovingAverage;
@@ -596,7 +594,7 @@ public sealed class SquareRootWeightedMovingAverageState : IStreamingIndicatorSt
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public SquareRootWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SquareRootWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -610,7 +608,7 @@ public sealed class SquareRootWeightedMovingAverageState : IStreamingIndicatorSt
 
         _weightSum = sum;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SquareRootWeightedMovingAverage;
@@ -665,15 +663,14 @@ public sealed class SqueezeMomentumIndicatorState : IStreamingIndicatorState, ID
     private readonly StreamingInputResolver _input;
     private double _diffValue;
 
-    public SqueezeMomentumIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public SqueezeMomentumIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _linReg = new LinearRegressionState(_length, _ => _diffValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SqueezeMomentumIndicator;
@@ -728,9 +725,9 @@ public sealed class StandardPivotPointsState : IStreamingIndicatorState
     private double _prevOpen;
     private bool _hasPrev;
 
-    public StandardPivotPointsState(InputName inputName = InputName.Close)
+    public StandardPivotPointsState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StandardPivotPoints;
@@ -816,7 +813,7 @@ public sealed class StationaryExtrapolatedLevelsOscillatorState : IStreamingIndi
     private int _index;
 
     public StationaryExtrapolatedLevelsOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 200, InputName inputName = InputName.Close)
+        int length = 200)
     {
         _length = Math.Max(1, length);
         _stochLength = Math.Max(1, _length * 2);
@@ -824,7 +821,7 @@ public sealed class StationaryExtrapolatedLevelsOscillatorState : IStreamingIndi
         _maxWindow = new RollingWindowMax(_stochLength);
         _minWindow = new RollingWindowMin(_stochLength);
         _yValues = new PooledRingBuffer<double>(_stochLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StationaryExtrapolatedLevelsOscillator;
@@ -888,17 +885,16 @@ public sealed class StiffnessIndicatorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public StiffnessIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 100, int length2 = 60, int smoothingLength = 3, double threshold = 90,
-        InputName inputName = InputName.Close)
+        int length1 = 100, int length2 = 60, int smoothingLength = 3, double threshold = 90)
     {
         _ = threshold;
         _length2 = Math.Max(1, length2);
         var resolved = Math.Max(1, length1);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, resolved);
         _aboveSum = new RollingWindowSum(_length2);
         _signal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, smoothingLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StiffnessIndicator;
@@ -953,7 +949,7 @@ public sealed class StochasticCustomOscillatorState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public StochasticCustomOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 7,
-        int length2 = 3, int length3 = 12, InputName inputName = InputName.Close)
+        int length2 = 3, int length3 = 12)
     {
         var resolved1 = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved1);
@@ -961,7 +957,7 @@ public sealed class StochasticCustomOscillatorState : IStreamingIndicatorState, 
         _numSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _denomSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticCustomOscillator;
@@ -1019,14 +1015,14 @@ public sealed class StochasticFastOscillatorState : IStreamingIndicatorState, ID
     private readonly StreamingInputResolver _input;
 
     public StochasticFastOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        int smoothLength1 = 3, int smoothLength2 = 2, InputName inputName = InputName.Close)
+        int smoothLength1 = 3, int smoothLength2 = 2)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticFastOscillator;
@@ -1082,7 +1078,7 @@ public sealed class StochasticMovingAverageConvergenceDivergenceOscillatorState 
 
     public StochasticMovingAverageConvergenceDivergenceOscillatorState(
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 45, int fastLength = 12,
-        int slowLength = 26, int signalLength = 9, InputName inputName = InputName.Close)
+        int slowLength = 26, int signalLength = 9)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
@@ -1090,7 +1086,7 @@ public sealed class StochasticMovingAverageConvergenceDivergenceOscillatorState 
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticMovingAverageConvergenceDivergenceOscillator;
@@ -1150,13 +1146,13 @@ public sealed class StochasticRegularState : IStreamingIndicatorState, IDisposab
     private readonly StreamingInputResolver _input;
 
     public StochasticRegularState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 5,
-        int length2 = 3, InputName inputName = InputName.Close)
+        int length2 = 3)
     {
         var resolved = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticRegular;
@@ -1211,7 +1207,7 @@ public sealed class StrengthOfMovementState : IStreamingIndicatorState, IDisposa
     private int _index;
 
     public StrengthOfMovementState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length1 = 10,
-        int length2 = 3, int smoothingLength = 3, InputName inputName = InputName.Close)
+        int length2 = 3, int smoothingLength = 3)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -1220,7 +1216,7 @@ public sealed class StrengthOfMovementState : IStreamingIndicatorState, IDisposa
         _bSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothingLength));
         _values = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StrengthOfMovement;
@@ -1292,10 +1288,10 @@ public sealed class SuperTrendState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public SuperTrendState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 22,
-        double atrMult = 3, InputName inputName = InputName.Close)
+        double atrMult = 3)
     {
-        _atrSmoother = new AverageTrueRangeSmoother(maType, Math.Max(1, length), inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _atrSmoother = new AverageTrueRangeSmoother(maType, Math.Max(1, length), InputName.Close);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _atrMult = atrMult;
     }
 
@@ -1371,13 +1367,13 @@ public sealed class SuperTrendFilterState : IStreamingIndicatorState
     private double _prevTrend;
     private bool _hasPrev;
 
-    public SuperTrendFilterState(int length = 200, double factor = 0.9, InputName inputName = InputName.Close)
+    public SuperTrendFilterState(int length = 200, double factor = 0.9)
     {
         var resolved = Math.Max(1, length);
         var p = MathHelper.Pow(resolved, 2);
         _a = 2 / (p + 1);
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SuperTrendFilter;
@@ -1448,9 +1444,9 @@ public sealed class SupportAndResistanceOscillatorState : IStreamingIndicatorSta
     private double _prevClose;
     private bool _hasPrev;
 
-    public SupportAndResistanceOscillatorState(InputName inputName = InputName.Close)
+    public SupportAndResistanceOscillatorState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SupportAndResistanceOscillator;
@@ -1497,13 +1493,12 @@ public sealed class SurfaceRoughnessEstimatorState : IStreamingIndicatorState, I
     private double _prevValue;
     private bool _hasPrev;
 
-    public SurfaceRoughnessEstimatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public SurfaceRoughnessEstimatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 100)
     {
         _ = maType;
         var resolved = Math.Max(1, length);
         _corrWindow = new RollingWindowCorrelation(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SurfaceRoughnessEstimator;
@@ -1556,10 +1551,10 @@ public sealed class SvamaState : IStreamingIndicatorState
     private double _prevCMin;
     private bool _hasPrev;
 
-    public SvamaState(int length = 14, InputName inputName = InputName.Close)
+    public SvamaState(int length = 14)
     {
         _ = length;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Svama;
@@ -1625,12 +1620,12 @@ public sealed class SwamiStochasticsState : IStreamingIndicatorState, IDisposabl
     private double _prevStoch;
     private bool _hasPrev;
 
-    public SwamiStochasticsState(int fastLength = 12, int slowLength = 48, InputName inputName = InputName.Close)
+    public SwamiStochasticsState(int fastLength = 12, int slowLength = 48)
     {
         var resolved = Math.Max(1, slowLength - fastLength);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SwamiStochastics;
@@ -1697,7 +1692,7 @@ public sealed class SymmetricallyWeightedMovingAverageState : IStreamingIndicato
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public SymmetricallyWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SymmetricallyWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -1722,7 +1717,7 @@ public sealed class SymmetricallyWeightedMovingAverageState : IStreamingIndicato
 
         _weightSum = sum;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SymmetricallyWeightedMovingAverage;
@@ -1783,20 +1778,19 @@ public sealed class TechnicalRankState : IStreamingIndicatorState, IDisposable
     private int _index;
 
     public TechnicalRankState(int length1 = 200, int length2 = 125, int length3 = 50, int length4 = 20,
-        int length5 = 12, int length6 = 26, int length7 = 9, int length8 = 3, int length9 = 14,
-        InputName inputName = InputName.Close)
+        int length5 = 12, int length6 = 26, int length7 = 9, int length8 = 3, int length9 = 14)
     {
         _length8 = Math.Max(1, length8);
         _ma1 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length1));
         _ma2 = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, Math.Max(1, length3));
-        _rocLong = new RateOfChangeState(Math.Max(1, length2), inputName);
-        _rocShort = new RateOfChangeState(Math.Max(1, length4), inputName);
-        _rsi = new RelativeStrengthIndexState(Math.Max(1, length9), 3, inputName);
+        _rocLong = new RateOfChangeState(Math.Max(1, length2));
+        _rocShort = new RateOfChangeState(Math.Max(1, length4));
+        _rsi = new RelativeStrengthIndexState(Math.Max(1, length9), 3);
         _ppoFast = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length5));
         _ppoSlow = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length6));
         _ppoSignal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, length7));
         _histValues = new PooledRingBuffer<double>(_length8);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TechnicalRank;

--- a/src/Streaming/StatefulIndicators.Batch24.cs
+++ b/src/Streaming/StatefulIndicators.Batch24.cs
@@ -5,7 +5,7 @@ using OoplesFinance.StockIndicators.Helpers;
 
 namespace OoplesFinance.StockIndicators.Streaming;
 
-public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposable
+public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _uoLength1;
     private readonly int _uoLength2;
@@ -113,6 +113,14 @@ public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposabl
     }
 
     public IndicatorName Name => IndicatorName.TechnicalRatings;
+
+    // No resolver of its own: the inner states that default to a typical or median price are the
+    // ones that must switch to reading the close when this state is wrapped.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_ao).ReadCloseAsInput();
+        ((ICustomInputConsumer)_cci).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch24.cs
+++ b/src/Streaming/StatefulIndicators.Batch24.cs
@@ -113,60 +113,6 @@ public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TechnicalRatingsState(MovingAvgType maType, int aoLength1, int aoLength2, int rsiLength, int stochLength1,
-        int stochLength2, int stochLength3, int ultOscLength1, int ultOscLength2, int ultOscLength3, int ichiLength1,
-        int ichiLength2, int ichiLength3, int vwmaLength, int cciLength, int adxLength, int momLength, int macdLength1,
-        int macdLength2, int macdLength3, int bullBearLength, int williamRLength, int maLength1, int maLength2,
-        int maLength3, int maLength4, int maLength5, int maLength6, int hullMaLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = stochLength3;
-        _uoLength1 = Math.Max(1, ultOscLength1);
-        _uoLength2 = Math.Max(1, ultOscLength2);
-        _uoLength3 = Math.Max(1, ultOscLength3);
-        _vwmaLength = Math.Max(1, vwmaLength);
-        var resolvedStoch = Math.Max(1, stochLength1);
-        var resolvedStochSmooth = Math.Max(1, stochLength2);
-
-        _bpSum1 = new RollingWindowSum(_uoLength1);
-        _bpSum2 = new RollingWindowSum(_uoLength2);
-        _bpSum3 = new RollingWindowSum(_uoLength3);
-        _trSum1 = new RollingWindowSum(_uoLength1);
-        _trSum2 = new RollingWindowSum(_uoLength2);
-        _trSum3 = new RollingWindowSum(_uoLength3);
-        _ma10 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength1));
-        _ma20 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength2));
-        _ma30 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength3));
-        _ma50 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength4));
-        _ma100 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength5));
-        _ma200 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, maLength6));
-        _vwmaVolumeSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, _vwmaLength);
-        _vwmaVolumePriceSum = new RollingWindowSum(_vwmaLength);
-        _stochHighWindow = new RollingWindowMax(resolvedStoch);
-        _stochLowWindow = new RollingWindowMin(resolvedStoch);
-        _stochFastSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedStochSmooth);
-        _stochRsiHighWindow = new RollingWindowMax(resolvedStoch);
-        _stochRsiLowWindow = new RollingWindowMin(resolvedStoch);
-        _stochRsiFastSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedStochSmooth);
-        _rsi = new RelativeStrengthIndexState(Math.Max(1, rsiLength), 3, selector);
-        _ao = new AwesomeOscillatorState(Math.Max(1, aoLength1), Math.Max(1, aoLength2), selector);
-        _macdFast = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength1));
-        _macdSlow = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength2));
-        _macdSignal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength3));
-        _ichimoku = new IchimokuCloudState(ichiLength1, ichiLength2, ichiLength3, selector);
-        _adx = new AverageDirectionalIndexState(Math.Max(1, adxLength));
-        _cci = new CommodityChannelIndexState(InputName.TypicalPrice, MovingAvgType.SimpleMovingAverage, Math.Max(1, cciLength), 0.015, selector);
-        _elderRay = new ElderRayIndexState(MovingAvgType.ExponentialMovingAverage, Math.Max(1, bullBearLength), selector);
-        _hma = new HullMovingAverageState(MovingAvgType.WeightedMovingAverage, Math.Max(1, hullMaLength), selector);
-        _williamsR = new WilliamsRState(Math.Max(1, williamRLength), selector);
-        _momentum = new MomentumOscillatorState(MovingAvgType.WeightedMovingAverage, Math.Max(1, momLength), selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TechnicalRatings;
 
     public void Reset()
@@ -440,20 +386,6 @@ public sealed class TFSMboIndicatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TFSMboIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TFSMboIndicator;
 
     public void Reset()
@@ -508,20 +440,6 @@ public sealed class TFSMboPercentagePriceOscillatorState : IStreamingIndicatorSt
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TFSMboPercentagePriceOscillatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TFSMboPercentagePriceOscillator;
@@ -579,19 +497,6 @@ public sealed class TFSTetherLineIndicatorState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TFSTetherLineIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TFSTetherLineIndicator;
 
     public void Reset()
@@ -647,20 +552,6 @@ public sealed class TopsAndBottomsFinderState : IStreamingIndicatorState, IDispo
         _bStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _bValue);
         _cStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _cValue);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TopsAndBottomsFinderState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema = MovingAverageSmootherFactory.Create(maType, resolved);
-        _bStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _bValue);
-        _cStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _cValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TopsAndBottomsFinder;
@@ -737,19 +628,6 @@ public sealed class TotalPowerIndicatorState : IStreamingIndicatorState, IDispos
         _bullCountSum = new RollingWindowSum(_length1);
         _bearCountSum = new RollingWindowSum(_length1);
         _elderRay = new ElderRayIndexState(maType, Math.Max(1, length2), inputName);
-    }
-
-    public TotalPowerIndicatorState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _bullCountSum = new RollingWindowSum(_length1);
-        _bearCountSum = new RollingWindowSum(_length1);
-        _elderRay = new ElderRayIndexState(maType, Math.Max(1, length2), selector);
     }
 
     public IndicatorName Name => IndicatorName.TotalPowerIndicator;
@@ -910,22 +788,6 @@ public sealed class TradersDynamicIndexState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TradersDynamicIndexState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rsi = new RsiState(maType, Math.Max(1, length1));
-        _rsiSignal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length2), _ => _rsiValue);
-        _mabSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _mbbSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TradersDynamicIndex;
 
     public void Reset()
@@ -992,19 +854,6 @@ public sealed class TradeVolumeIndexState : IStreamingIndicatorState, IDisposabl
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-        _minTickValue = minTickValue;
-    }
-
-    public TradeVolumeIndexState(MovingAvgType maType, int length, double minTickValue,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _minTickValue = minTickValue;
     }
 
@@ -1088,29 +937,6 @@ public sealed class TradingMadeMoreSimplerOscillatorState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TradingMadeMoreSimplerOscillatorState(MovingAvgType maType, int length1, int length2, int length3,
-        int smoothLength, double threshold, double limit, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = length3;
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _threshold = threshold;
-        _limit = limit;
-        _rsi = new RsiState(maType, _length1);
-        _stoch1High = new RollingWindowMax(_length2);
-        _stoch1Low = new RollingWindowMin(_length2);
-        _stoch2High = new RollingWindowMax(_length1);
-        _stoch2Low = new RollingWindowMin(_length1);
-        _stoch1Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _stoch2Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TradingMadeMoreSimplerOscillator;
 
     public void Reset()
@@ -1185,18 +1011,6 @@ public sealed class TFSVolumeOscillatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TFSVolumeOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _totvSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TFSVolumeOscillator;
 
     public void Reset()
@@ -1251,22 +1065,6 @@ public sealed class TheRangeIndicatorState : IStreamingIndicatorState, IDisposab
         _minWindow = new RollingWindowMin(_length);
         _triSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TheRangeIndicatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = smoothLength;
-        _length = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(_length);
-        _minWindow = new RollingWindowMin(_length);
-        _triSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TheRangeIndicator;
@@ -1342,21 +1140,6 @@ public sealed class TickLineMomentumOscillatorState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TickLineMomentumOscillatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoothLength = Math.Max(1, smoothLength);
-        _maSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _rocSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _cumoValues = new PooledRingBuffer<double>(_smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TickLineMomentumOscillator;
 
     public void Reset()
@@ -1429,19 +1212,6 @@ public sealed class TillsonIE2State : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TillsonIE2State(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _linReg = new LinearRegressionState(resolved, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TillsonIE2;
 
     public void Reset()
@@ -1511,27 +1281,6 @@ public sealed class TillsonT3MovingAverageState : IStreamingIndicatorState, IDis
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema6 = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _c1 = -vFactor * vFactor * vFactor;
-        _c2 = (3 * vFactor * vFactor) + (3 * vFactor * vFactor * vFactor);
-        _c3 = (-6 * vFactor * vFactor) - (3 * vFactor) - (3 * vFactor * vFactor * vFactor);
-        _c4 = 1 + (3 * vFactor) + (vFactor * vFactor * vFactor) + (3 * vFactor * vFactor);
-    }
-
-    public TillsonT3MovingAverageState(MovingAvgType maType, int length, double vFactor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema6 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _c1 = -vFactor * vFactor * vFactor;
         _c2 = (3 * vFactor * vFactor) + (3 * vFactor * vFactor * vFactor);
         _c3 = (-6 * vFactor * vFactor) - (3 * vFactor) - (3 * vFactor * vFactor * vFactor);
@@ -1611,25 +1360,6 @@ public sealed class TimeAndMoneyChannelState : IStreamingIndicatorState, IDispos
         _basisValues = new PooledRingBuffer<double>(_halfLength);
         _varyomValues = new PooledRingBuffer<double>(_halfLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TimeAndMoneyChannelState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _halfLength = MathHelper.MinOrMax((int)Math.Ceiling((double)_length1 / 2));
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _avyomSmoother = MovingAverageSmootherFactory.Create(maType, _length2);
-        _yomSquaredSmoother = MovingAverageSmootherFactory.Create(maType, _length2);
-        _sigomSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _basisValues = new PooledRingBuffer<double>(_halfLength);
-        _varyomValues = new PooledRingBuffer<double>(_halfLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TimeAndMoneyChannel;
@@ -1725,21 +1455,6 @@ public sealed class TimePriceIndicatorState : IStreamingIndicatorState, IDisposa
         _lastFallingIndex = -1;
     }
 
-    public TimePriceIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _lastRisingIndex = -1;
-        _lastFallingIndex = -1;
-    }
-
     public IndicatorName Name => IndicatorName.TimePriceIndicator;
 
     public void Reset()
@@ -1813,19 +1528,6 @@ public sealed class TironeLevelsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TironeLevelsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TironeLevels;
 
     public void Reset()
@@ -1895,23 +1597,6 @@ public sealed class TrendAnalysisIndexState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendAnalysisIndexState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _inputSmoother = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _maxWindow = new RollingWindowMax(resolved2);
-        _minWindow = new RollingWindowMin(resolved2);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendAnalysisIndex;
 
     public void Reset()
@@ -1974,23 +1659,6 @@ public sealed class TrendAnalysisIndicatorState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendAnalysisIndicatorState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _slowMa = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _fastMa = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved2, _ => _slowValue);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendAnalysisIndicator;
 
     public void Reset()
@@ -2050,19 +1718,6 @@ public sealed class TrendContinuationFactorState : IStreamingIndicatorState, IDi
         _diffPlusSum = new RollingWindowSum(resolved);
         _diffMinusSum = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrendContinuationFactorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _diffPlusSum = new RollingWindowSum(resolved);
-        _diffMinusSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TrendContinuationFactor;
@@ -2146,22 +1801,6 @@ public sealed class TrendDetectionIndexState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendDetectionIndexState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _momSum = new RollingWindowSum(_length1);
-        _momAbsSum1 = new RollingWindowSum(_length1);
-        _momAbsSum2 = new RollingWindowSum(resolved2);
-        _values = new PooledRingBuffer<double>(_length1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendDetectionIndex;
 
     public void Reset()
@@ -2236,23 +1875,6 @@ public sealed class TrendDirectionForceIndexState : IStreamingIndicatorState, ID
         _ema2 = MovingAverageSmootherFactory.Create(maType, halfLength);
         _absTdfWindow = new RollingWindowMax(resolved2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrendDirectionForceIndexState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var halfLength = MathHelper.MinOrMax((int)Math.Ceiling((double)resolved1 / 2));
-        _ema1 = MovingAverageSmootherFactory.Create(maType, halfLength);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, halfLength);
-        _absTdfWindow = new RollingWindowMax(resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TrendDirectionForceIndex;
@@ -2351,22 +1973,6 @@ public sealed class TrenderState : IStreamingIndicatorState, IDisposable
         _adSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrMult = atrMult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrenderState(MovingAvgType maType, int length, double atrMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atr = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _atrValue);
-        _adSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrMult = atrMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Trender;
@@ -2480,20 +2086,6 @@ public sealed class TrendExhaustionIndicatorState : IStreamingIndicatorState, ID
         _highWindow = new RollingWindowMax(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _sc = (double)2 / (resolved + 1);
-    }
-
-    public TrendExhaustionIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _sc = (double)2 / (resolved + 1);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch24.cs
+++ b/src/Streaming/StatefulIndicators.Batch24.cs
@@ -67,8 +67,7 @@ public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposabl
         int ichiLength1 = 9, int ichiLength2 = 26, int ichiLength3 = 52, int vwmaLength = 20, int cciLength = 20,
         int adxLength = 14, int momLength = 10, int macdLength1 = 12, int macdLength2 = 26, int macdLength3 = 9,
         int bullBearLength = 13, int williamRLength = 14, int maLength1 = 10, int maLength2 = 20, int maLength3 = 30,
-        int maLength4 = 50, int maLength5 = 100, int maLength6 = 200, int hullMaLength = 9,
-        InputName inputName = InputName.Close)
+        int maLength4 = 50, int maLength5 = 100, int maLength6 = 200, int hullMaLength = 9)
     {
         _ = stochLength3;
         _uoLength1 = Math.Max(1, ultOscLength1);
@@ -98,19 +97,19 @@ public sealed class TechnicalRatingsState : IStreamingIndicatorState, IDisposabl
         _stochRsiHighWindow = new RollingWindowMax(resolvedStoch);
         _stochRsiLowWindow = new RollingWindowMin(resolvedStoch);
         _stochRsiFastSmoother = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedStochSmooth);
-        _rsi = new RelativeStrengthIndexState(Math.Max(1, rsiLength), 3, inputName);
-        _ao = new AwesomeOscillatorState(Math.Max(1, aoLength1), Math.Max(1, aoLength2), InputName.MedianPrice);
+        _rsi = new RelativeStrengthIndexState(Math.Max(1, rsiLength), 3);
+        _ao = new AwesomeOscillatorState(Math.Max(1, aoLength1), Math.Max(1, aoLength2));
         _macdFast = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength1));
         _macdSlow = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength2));
         _macdSignal = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, macdLength3));
-        _ichimoku = new IchimokuCloudState(ichiLength1, ichiLength2, ichiLength3, inputName);
+        _ichimoku = new IchimokuCloudState(ichiLength1, ichiLength2, ichiLength3);
         _adx = new AverageDirectionalIndexState(Math.Max(1, adxLength));
-        _cci = new CommodityChannelIndexState(InputName.TypicalPrice, MovingAvgType.SimpleMovingAverage, Math.Max(1, cciLength), 0.015);
-        _elderRay = new ElderRayIndexState(MovingAvgType.ExponentialMovingAverage, Math.Max(1, bullBearLength), inputName);
-        _hma = new HullMovingAverageState(MovingAvgType.WeightedMovingAverage, Math.Max(1, hullMaLength), inputName);
-        _williamsR = new WilliamsRState(Math.Max(1, williamRLength), inputName);
-        _momentum = new MomentumOscillatorState(MovingAvgType.WeightedMovingAverage, Math.Max(1, momLength), inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _cci = new CommodityChannelIndexState(MovingAvgType.SimpleMovingAverage, Math.Max(1, cciLength), 0.015);
+        _elderRay = new ElderRayIndexState(MovingAvgType.ExponentialMovingAverage, Math.Max(1, bullBearLength));
+        _hma = new HullMovingAverageState(MovingAvgType.WeightedMovingAverage, Math.Max(1, hullMaLength));
+        _williamsR = new WilliamsRState(Math.Max(1, williamRLength));
+        _momentum = new MomentumOscillatorState(MovingAvgType.WeightedMovingAverage, Math.Max(1, momLength));
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TechnicalRatings;
@@ -378,12 +377,12 @@ public sealed class TFSMboIndicatorState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public TFSMboIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 25,
-        int slowLength = 200, int signalLength = 18, InputName inputName = InputName.Close)
+        int slowLength = 200, int signalLength = 18)
     {
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TFSMboIndicator;
@@ -434,12 +433,12 @@ public sealed class TFSMboPercentagePriceOscillatorState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
 
     public TFSMboPercentagePriceOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int fastLength = 25, int slowLength = 200, int signalLength = 18, InputName inputName = InputName.Close)
+        int fastLength = 25, int slowLength = 200, int signalLength = 18)
     {
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TFSMboPercentagePriceOscillator;
@@ -489,12 +488,12 @@ public sealed class TFSTetherLineIndicatorState : IStreamingIndicatorState, IDis
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public TFSTetherLineIndicatorState(int length = 50, InputName inputName = InputName.Close)
+    public TFSTetherLineIndicatorState(int length = 50)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TFSTetherLineIndicator;
@@ -545,13 +544,13 @@ public sealed class TopsAndBottomsFinderState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public TopsAndBottomsFinderState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 50, InputName inputName = InputName.Close)
+        int length = 50)
     {
         var resolved = Math.Max(1, length);
         _ema = MovingAverageSmootherFactory.Create(maType, resolved);
         _bStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _bValue);
         _cStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _cValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TopsAndBottomsFinder;
@@ -622,12 +621,12 @@ public sealed class TotalPowerIndicatorState : IStreamingIndicatorState, IDispos
     private readonly ElderRayIndexState _elderRay;
 
     public TotalPowerIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 45, int length2 = 10, InputName inputName = InputName.Close)
+        int length1 = 45, int length2 = 10)
     {
         _length1 = Math.Max(1, length1);
         _bullCountSum = new RollingWindowSum(_length1);
         _bearCountSum = new RollingWindowSum(_length1);
-        _elderRay = new ElderRayIndexState(maType, Math.Max(1, length2), inputName);
+        _elderRay = new ElderRayIndexState(maType, Math.Max(1, length2));
     }
 
     public IndicatorName Name => IndicatorName.TotalPowerIndicator;
@@ -778,14 +777,14 @@ public sealed class TradersDynamicIndexState : IStreamingIndicatorState, IDispos
     private double _rsiValue;
 
     public TradersDynamicIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 13, int length2 = 34, int length3 = 2, int length4 = 7, InputName inputName = InputName.Close)
+        int length1 = 13, int length2 = 34, int length3 = 2, int length4 = 7)
     {
         _rsi = new RsiState(maType, Math.Max(1, length1));
         _rsiSignal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length2), _ => _rsiValue);
         _mabSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _mbbSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TradersDynamicIndex;
@@ -850,10 +849,10 @@ public sealed class TradeVolumeIndexState : IStreamingIndicatorState, IDisposabl
     private bool _hasPrev;
 
     public TradeVolumeIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double minTickValue = 0.5, InputName inputName = InputName.Close)
+        double minTickValue = 0.5)
     {
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _minTickValue = minTickValue;
     }
 
@@ -920,7 +919,7 @@ public sealed class TradingMadeMoreSimplerOscillatorState : IStreamingIndicatorS
 
     public TradingMadeMoreSimplerOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
         int length1 = 14, int length2 = 8, int length3 = 12, int smoothLength = 3,
-        double threshold = 50, double limit = 0, InputName inputName = InputName.Close)
+        double threshold = 50, double limit = 0)
     {
         _ = length3;
         _length1 = Math.Max(1, length1);
@@ -934,7 +933,7 @@ public sealed class TradingMadeMoreSimplerOscillatorState : IStreamingIndicatorS
         _stoch2Low = new RollingWindowMin(_length1);
         _stoch1Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _stoch2Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TradingMadeMoreSimplerOscillator;
@@ -1004,11 +1003,11 @@ public sealed class TFSVolumeOscillatorState : IStreamingIndicatorState, IDispos
     private readonly RollingWindowSum _totvSum;
     private readonly StreamingInputResolver _input;
 
-    public TFSVolumeOscillatorState(int length = 7, InputName inputName = InputName.Close)
+    public TFSVolumeOscillatorState(int length = 7)
     {
         _length = Math.Max(1, length);
         _totvSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TFSVolumeOscillator;
@@ -1057,14 +1056,14 @@ public sealed class TheRangeIndicatorState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public TheRangeIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 10,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         _ = smoothLength;
         _length = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(_length);
         _minWindow = new RollingWindowMin(_length);
         _triSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TheRangeIndicator;
@@ -1131,13 +1130,13 @@ public sealed class TickLineMomentumOscillatorState : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public TickLineMomentumOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 10, int smoothLength = 5, InputName inputName = InputName.Close)
+        int length = 10, int smoothLength = 5)
     {
         _smoothLength = Math.Max(1, smoothLength);
         _maSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _rocSmoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
         _cumoValues = new PooledRingBuffer<double>(_smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TickLineMomentumOscillator;
@@ -1203,13 +1202,12 @@ public sealed class TillsonIE2State : IStreamingIndicatorState, IDisposable
     private double _prevLinReg;
     private bool _hasPrev;
 
-    public TillsonIE2State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 15,
-        InputName inputName = InputName.Close)
+    public TillsonIE2State(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 15)
     {
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _linReg = new LinearRegressionState(resolved, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _linReg = new LinearRegressionState(resolved);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TillsonIE2;
@@ -1271,7 +1269,7 @@ public sealed class TillsonT3MovingAverageState : IStreamingIndicatorState, IDis
     private readonly double _c4;
 
     public TillsonT3MovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 5,
-        double vFactor = 0.7, InputName inputName = InputName.Close)
+        double vFactor = 0.7)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -1280,7 +1278,7 @@ public sealed class TillsonT3MovingAverageState : IStreamingIndicatorState, IDis
         _ema4 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema6 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _c1 = -vFactor * vFactor * vFactor;
         _c2 = (3 * vFactor * vFactor) + (3 * vFactor * vFactor * vFactor);
         _c3 = (-6 * vFactor * vFactor) - (3 * vFactor) - (3 * vFactor * vFactor * vFactor);
@@ -1348,7 +1346,7 @@ public sealed class TimeAndMoneyChannelState : IStreamingIndicatorState, IDispos
     private int _index;
 
     public TimeAndMoneyChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 41,
-        int length2 = 82, InputName inputName = InputName.Close)
+        int length2 = 82)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -1359,7 +1357,7 @@ public sealed class TimeAndMoneyChannelState : IStreamingIndicatorState, IDispos
         _sigomSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
         _basisValues = new PooledRingBuffer<double>(_halfLength);
         _varyomValues = new PooledRingBuffer<double>(_halfLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TimeAndMoneyChannel;
@@ -1445,12 +1443,12 @@ public sealed class TimePriceIndicatorState : IStreamingIndicatorState, IDisposa
     private int _index;
     private bool _hasPrev;
 
-    public TimePriceIndicatorState(int length = 50, InputName inputName = InputName.Close)
+    public TimePriceIndicatorState(int length = 50)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _lastRisingIndex = -1;
         _lastFallingIndex = -1;
     }
@@ -1520,12 +1518,12 @@ public sealed class TironeLevelsState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public TironeLevelsState(int length = 20, InputName inputName = InputName.Close)
+    public TironeLevelsState(int length = 20)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TironeLevels;
@@ -1586,7 +1584,7 @@ public sealed class TrendAnalysisIndexState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public TrendAnalysisIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 28, int length2 = 5, InputName inputName = InputName.Close)
+        int length1 = 28, int length2 = 5)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1594,7 +1592,7 @@ public sealed class TrendAnalysisIndexState : IStreamingIndicatorState, IDisposa
         _maxWindow = new RollingWindowMax(resolved2);
         _minWindow = new RollingWindowMin(resolved2);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendAnalysisIndex;
@@ -1648,7 +1646,7 @@ public sealed class TrendAnalysisIndicatorState : IStreamingIndicatorState, IDis
     private double _slowValue;
 
     public TrendAnalysisIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 21, int length2 = 4, InputName inputName = InputName.Close)
+        int length1 = 21, int length2 = 4)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1656,7 +1654,7 @@ public sealed class TrendAnalysisIndicatorState : IStreamingIndicatorState, IDis
         _fastMa = MovingAverageSmootherFactory.Create(maType, resolved2);
         _stdDev = new StandardDeviationVolatilityState(maType, resolved2, _ => _slowValue);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendAnalysisIndicator;
@@ -1712,12 +1710,12 @@ public sealed class TrendContinuationFactorState : IStreamingIndicatorState, IDi
     private double _prevCfMinus;
     private bool _hasPrev;
 
-    public TrendContinuationFactorState(int length = 35, InputName inputName = InputName.Close)
+    public TrendContinuationFactorState(int length = 35)
     {
         var resolved = Math.Max(1, length);
         _diffPlusSum = new RollingWindowSum(resolved);
         _diffMinusSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendContinuationFactor;
@@ -1790,7 +1788,7 @@ public sealed class TrendDetectionIndexState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public TrendDetectionIndexState(int length1 = 20, int length2 = 40, InputName inputName = InputName.Close)
+    public TrendDetectionIndexState(int length1 = 20, int length2 = 40)
     {
         _length1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1798,7 +1796,7 @@ public sealed class TrendDetectionIndexState : IStreamingIndicatorState, IDispos
         _momAbsSum1 = new RollingWindowSum(_length1);
         _momAbsSum2 = new RollingWindowSum(resolved2);
         _values = new PooledRingBuffer<double>(_length1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendDetectionIndex;
@@ -1866,7 +1864,7 @@ public sealed class TrendDirectionForceIndexState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public TrendDirectionForceIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 10, int length2 = 30, InputName inputName = InputName.Close)
+        int length1 = 10, int length2 = 30)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1874,7 +1872,7 @@ public sealed class TrendDirectionForceIndexState : IStreamingIndicatorState, ID
         _ema1 = MovingAverageSmootherFactory.Create(maType, halfLength);
         _ema2 = MovingAverageSmootherFactory.Create(maType, halfLength);
         _absTdfWindow = new RollingWindowMax(resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendDirectionForceIndex;
@@ -1964,7 +1962,7 @@ public sealed class TrenderState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public TrenderState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        double atrMult = 2, InputName inputName = InputName.Close)
+        double atrMult = 2)
     {
         var resolved = Math.Max(1, length);
         _ema = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -1972,7 +1970,7 @@ public sealed class TrenderState : IStreamingIndicatorState, IDisposable
         _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _atrValue);
         _adSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrMult = atrMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Trender;
@@ -2079,13 +2077,12 @@ public sealed class TrendExhaustionIndicatorState : IStreamingIndicatorState, ID
     private double _prevHighest;
     private bool _hasPrev;
 
-    public TrendExhaustionIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10,
-        InputName inputName = InputName.Close)
+    public TrendExhaustionIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _sc = (double)2 / (resolved + 1);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -680,9 +680,9 @@ public sealed class TrimeanState : IStreamingIndicatorState, IDisposable
             _order.Add(value);
         }
 
-        var q1 = _order.PercentileNearestRank(25);
-        var median = _order.PercentileNearestRank(50);
-        var q3 = _order.PercentileNearestRank(75);
+        var q1 = isFinal ? _order.PercentileNearestRank(25) : _order.PercentileNearestRank(25, value);
+        var median = isFinal ? _order.PercentileNearestRank(50) : _order.PercentileNearestRank(50, value);
+        var q3 = isFinal ? _order.PercentileNearestRank(75) : _order.PercentileNearestRank(75, value);
         var trimean = (q1 + (2 * median) + q3) / 4;
 
         IReadOnlyDictionary<string, double>? outputs = null;

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -1893,7 +1893,9 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
         var low = bar.Low;
         var open = bar.Open;
         var prevClose = _hasPrev ? _prevClose : 0;
-        var tr = CalculationsHelper.CalculateTrueRange(high, low, prevClose);
+        // The first bar's true range uses the bar's own close, as the batch does, so it is High - Low rather
+        // than the whole high. The momentum term c below keeps the batch's zero.
+        var tr = CalculationsHelper.CalculateTrueRange(high, low, _hasPrev ? _prevClose : close);
         var trEnvelopeHigh = isFinal ? _trEnvelopeMax.Add(tr, out _) : _trEnvelopeMax.Preview(tr, out _);
         var trEnvelopeLow = isFinal ? _trEnvelopeMin.Add(tr, out _) : _trEnvelopeMin.Preview(tr, out _);
         var trHigh = isFinal ? _trMax.Add(trEnvelopeHigh, out _) : _trMax.Preview(trEnvelopeHigh, out _);

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -1780,7 +1780,7 @@ public sealed class UhlMaCrossoverSystemState : IStreamingIndicatorState, IDispo
     }
 }
 
-public sealed class UltimateMomentumIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class UltimateMomentumIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly McClellanOscillatorState _mo;
     private readonly BollingerBandsPercentBState _bbPct;
@@ -1823,6 +1823,15 @@ public sealed class UltimateMomentumIndicatorState : IStreamingIndicatorState, I
     }
 
     public IndicatorName Name => IndicatorName.UltimateMomentumIndicator;
+
+    // No resolver of its own: the input was handed to these inner states, so they are the
+    // ones that must switch to reading the close.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_mfi1).ReadCloseAsInput();
+        ((ICustomInputConsumer)_mfi2).ReadCloseAsInput();
+        ((ICustomInputConsumer)_mfi3).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -21,12 +21,12 @@ public sealed class TrendForceHistogramState : IStreamingIndicatorState, IDispos
     private int _index;
     private bool _hasPrev;
 
-    public TrendForceHistogramState(int length = 14, InputName inputName = InputName.Close)
+    public TrendForceHistogramState(int length = 14)
     {
         _length = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(_length);
         _minWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendForceHistogram;
@@ -104,12 +104,12 @@ public sealed class TrendImpulseFilterState : IStreamingIndicatorState, IDisposa
     private bool _hasPrev;
 
     public TrendImpulseFilterState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 100, int length2 = 10, InputName inputName = InputName.Close)
+        int length1 = 100, int length2 = 10)
     {
         _maxWindow = new RollingWindowMax(Math.Max(1, length1));
         _minWindow = new RollingWindowMin(Math.Max(1, length1));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendImpulseFilter;
@@ -171,13 +171,13 @@ public sealed class TrendIntensityIndexState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
 
     public TrendIntensityIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int fastLength = 30, int slowLength = 60, InputName inputName = InputName.Close)
+        int fastLength = 30, int slowLength = 60)
     {
         var resolvedFast = Math.Max(1, fastLength);
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _upSum = new RollingWindowSum(resolvedFast);
         _downSum = new RollingWindowSum(resolvedFast);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendIntensityIndex;
@@ -233,7 +233,7 @@ public sealed class TrendPersistenceRateState : IStreamingIndicatorState, IDispo
     private int _index;
 
     public TrendPersistenceRateState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        int smoothLength = 5, double mult = 0.01, double threshold = 1, InputName inputName = InputName.Close)
+        int smoothLength = 5, double mult = 0.01, double threshold = 1)
     {
         _length = Math.Max(1, length);
         _mult = mult;
@@ -242,7 +242,7 @@ public sealed class TrendPersistenceRateState : IStreamingIndicatorState, IDispo
         _ctrPSum = new RollingWindowSum(_length);
         _ctrMSum = new RollingWindowSum(_length);
         _maValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendPersistenceRate;
@@ -305,11 +305,11 @@ public sealed class TrendStepState : IStreamingIndicatorState, IDisposable
     private int _index;
     private bool _hasPrev;
 
-    public TrendStepState(int length = 50, InputName inputName = InputName.Close)
+    public TrendStepState(int length = 50)
     {
         _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendStep;
@@ -371,7 +371,7 @@ public sealed class TrendTraderBandsState : IStreamingIndicatorState, IDisposabl
     private bool _hasPrev;
 
     public TrendTraderBandsState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 21, double mult = 3, double bandStep = 20, InputName inputName = InputName.Close)
+        int length = 21, double mult = 3, double bandStep = 20)
     {
         var resolved = Math.Max(1, length);
         _mult = mult;
@@ -380,7 +380,7 @@ public sealed class TrendTraderBandsState : IStreamingIndicatorState, IDisposabl
         _minWindow = new RollingWindowMin(resolved);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _retSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendTraderBands;
@@ -465,14 +465,14 @@ public sealed class TrendTriggerFactorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public TrendTriggerFactorState(int length = 15, InputName inputName = InputName.Close)
+    public TrendTriggerFactorState(int length = 15)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
         _highestValues = new PooledRingBuffer<double>(_length);
         _lowestValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrendTriggerFactor;
@@ -534,7 +534,7 @@ public sealed class TreynorRatioState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public TreynorRatioState(int length = 30, double beta = 1, double bmk = 0.02, InputName inputName = InputName.Close)
+    public TreynorRatioState(int length = 30, double beta = 1, double bmk = 0.02)
     {
         _length = Math.Max(1, length);
         _beta = beta;
@@ -544,7 +544,7 @@ public sealed class TreynorRatioState : IStreamingIndicatorState, IDisposable
         _bench = Math.Pow(1 + bmk, _length / barsPerYr) - 1;
         _retSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TreynorRatio;
@@ -597,10 +597,10 @@ public sealed class TrigonometricOscillatorState : IStreamingIndicatorState, IDi
     private double _prevS;
     private bool _hasPrev;
 
-    public TrigonometricOscillatorState(int length = 200, InputName inputName = InputName.Close)
+    public TrigonometricOscillatorState(int length = 200)
     {
         var resolved = Math.Max(1, length);
-        _sRegression = new LinearRegressionState(resolved, inputName);
+        _sRegression = new LinearRegressionState(resolved);
         _uRegression = new LinearRegressionState(resolved, _ => _uValue);
     }
 
@@ -657,11 +657,11 @@ public sealed class TrimeanState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private RollingOrderStatistic _order;
 
-    public TrimeanState(int length = 14, InputName inputName = InputName.Close)
+    public TrimeanState(int length = 14)
     {
         _length = Math.Max(1, length);
         _order = new RollingOrderStatistic(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Trimean;
@@ -714,13 +714,13 @@ public sealed class TripleExponentialMovingAverageState : IStreamingIndicatorSta
     private readonly StreamingInputResolver _input;
 
     public TripleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TripleExponentialMovingAverage;
@@ -776,17 +776,17 @@ public sealed class TStepLeastSquaresMovingAverageState : IStreamingIndicatorSta
     private bool _hasPrev;
 
     public TStepLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 100, double sc = 0.5, InputName inputName = InputName.Close)
+        int length = 100, double sc = 0.5)
     {
         var resolved = Math.Max(1, length);
         _ = sc;
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _bSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, resolved);
         _bStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _bValue);
         _corrWindow = new RollingWindowCorrelation(resolved);
         _er = new EfficiencyRatioState(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TStepLeastSquaresMovingAverage;
@@ -869,10 +869,10 @@ public sealed class TTMScalperIndicatorState : IStreamingIndicatorState, IDispos
     private double _prevSbs;
     private double _prevClrs;
 
-    public TTMScalperIndicatorState(InputName inputName = InputName.Close)
+    public TTMScalperIndicatorState()
     {
         _closes = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TTMScalperIndicator;
@@ -939,7 +939,7 @@ public sealed class TurboScalerState : IStreamingIndicatorState, IDisposable
     private readonly double _alpha;
 
     public TurboScalerState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50,
-        double alpha = 0.5, InputName inputName = InputName.Close)
+        double alpha = 0.5)
     {
         var resolved = Math.Max(1, length);
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -948,7 +948,7 @@ public sealed class TurboScalerState : IStreamingIndicatorState, IDisposable
         _smoMinWindow = new RollingWindowMin(resolved);
         _smoSmaMaxWindow = new RollingWindowMax(resolved);
         _smoSmaMinWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _alpha = alpha;
     }
 
@@ -1017,7 +1017,7 @@ public sealed class TurboStochasticsFastState : IStreamingIndicatorState, IDispo
     private double _fastDValue;
 
     public TurboStochasticsFastState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 20, int length2 = 10, int turboLength = 2, InputName inputName = InputName.Close)
+        int length1 = 20, int length2 = 10, int turboLength = 2)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
@@ -1027,7 +1027,7 @@ public sealed class TurboStochasticsFastState : IStreamingIndicatorState, IDispo
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
         _fastKRegression = new LinearRegressionState(regressionLength, _ => _fastKValue);
         _fastDRegression = new LinearRegressionState(regressionLength, _ => _fastDValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TurboStochasticsFast;
@@ -1096,7 +1096,7 @@ public sealed class TurboStochasticsSlowState : IStreamingIndicatorState, IDispo
     private double _slowDValue;
 
     public TurboStochasticsSlowState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length1 = 20, int length2 = 10, int turboLength = 2, InputName inputName = InputName.Close)
+        int length1 = 20, int length2 = 10, int turboLength = 2)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
@@ -1107,7 +1107,7 @@ public sealed class TurboStochasticsSlowState : IStreamingIndicatorState, IDispo
         _slowDSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
         _slowKRegression = new LinearRegressionState(regressionLength, _ => _slowKValue);
         _slowDRegression = new LinearRegressionState(regressionLength, _ => _slowDValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TurboStochasticsSlow;
@@ -1179,7 +1179,7 @@ public sealed class TurboTriggerState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public TurboTriggerState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        int smoothLength = 2, InputName inputName = InputName.Close)
+        int smoothLength = 2)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedSmooth = Math.Max(1, smoothLength);
@@ -1191,7 +1191,7 @@ public sealed class TurboTriggerState : IStreamingIndicatorState, IDisposable
         _hySmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _ylSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _oscSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TurboTrigger;
@@ -1256,13 +1256,12 @@ public sealed class TwiggsMoneyFlowState : IStreamingIndicatorState, IDisposable
     private double _prevPrice;
     private bool _hasPrev;
 
-    public TwiggsMoneyFlowState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 21,
-        InputName inputName = InputName.Close)
+    public TwiggsMoneyFlowState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 21)
     {
         var resolved = Math.Max(1, length);
         _adSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _volumeSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TwiggsMoneyFlow;
@@ -1324,14 +1323,14 @@ public sealed class UberTrendIndicatorState : IStreamingIndicatorState, IDisposa
     private double _prevValue;
     private bool _hasPrev;
 
-    public UberTrendIndicatorState(int length = 14, InputName inputName = InputName.Close)
+    public UberTrendIndicatorState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _advSum = new RollingWindowSum(resolved);
         _decSum = new RollingWindowSum(resolved);
         _advVolSum = new RollingWindowSum(resolved);
         _decVolSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UberTrendIndicator;
@@ -1403,14 +1402,13 @@ public sealed class UhlMaCrossoverSystemState : IStreamingIndicatorState, IDispo
     private double _prevCts;
     private bool _hasPrev;
 
-    public UhlMaCrossoverSystemState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public UhlMaCrossoverSystemState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         _length = Math.Max(1, length);
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _stdDevValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UhlMaCrossoverSystem;
@@ -1479,16 +1477,15 @@ public sealed class UltimateMomentumIndicatorState : IStreamingIndicatorState, I
     private readonly RsiState _rsi;
     private readonly IMovingAverageSmoother _utmSmoother;
 
-    public UltimateMomentumIndicatorState(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 13, int length2 = 19,
+    public UltimateMomentumIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 13, int length2 = 19,
         int length3 = 21, int length4 = 39, int length5 = 50, int length6 = 200, double stdDevMult = 1.5)
     {
         _ = length6;
         _mo = new McClellanOscillatorState(maType, length2, length4, 9, 1000);
         _bbPct = new BollingerBandsPercentBState(stdDevMult, maType, length5);
-        _mfi1 = new MoneyFlowIndexState(length2, inputName);
-        _mfi2 = new MoneyFlowIndexState(length3, inputName);
-        _mfi3 = new MoneyFlowIndexState(length4, inputName);
+        _mfi1 = new MoneyFlowIndexState(length2);
+        _mfi2 = new MoneyFlowIndexState(length3);
+        _mfi3 = new MoneyFlowIndexState(length4);
         _rsi = new RsiState(maType, Math.Max(1, length1));
         _utmSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
     }
@@ -1571,17 +1568,17 @@ public sealed class UltimateMovingAverageState : IStreamingIndicatorState, IDisp
     private bool _hasPrev;
 
     public UltimateMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int minLength = 5,
-        int maxLength = 50, double acc = 1, InputName inputName = InputName.Close)
+        int maxLength = 50, double acc = 1)
     {
         _minLength = Math.Max(1, minLength);
         _maxLength = Math.Max(_minLength, maxLength);
         _acc = acc;
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, _maxLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength);
         _posFlowSum = new RollingCumulativeSum();
         _negFlowSum = new RollingCumulativeSum();
         _values = new PooledRingBuffer<double>(_maxLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _prevLength = _maxLength;
     }
 
@@ -1669,10 +1666,10 @@ public sealed class UltimateMovingAverageBandsState : IStreamingIndicatorState, 
     private readonly double _stdDevMult;
 
     public UltimateMovingAverageBandsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int minLength = 5,
-        int maxLength = 50, double stdDevMult = 2, InputName inputName = InputName.Close)
+        int maxLength = 50, double stdDevMult = 2)
     {
-        _uma = new UltimateMovingAverageState(maType, minLength, maxLength, 1, inputName);
-        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, minLength), inputName);
+        _uma = new UltimateMovingAverageState(maType, minLength, maxLength, 1);
+        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, minLength));
         _stdDevMult = stdDevMult;
     }
 
@@ -1724,7 +1721,7 @@ public sealed class UltimateOscillatorState : IStreamingIndicatorState, IDisposa
     private double _prevClose;
     private bool _hasPrev;
 
-    public UltimateOscillatorState(int length1 = 7, int length2 = 14, int length3 = 28, InputName inputName = InputName.Close)
+    public UltimateOscillatorState(int length1 = 7, int length2 = 14, int length3 = 28)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1735,7 +1732,7 @@ public sealed class UltimateOscillatorState : IStreamingIndicatorState, IDisposa
         _trSum1 = new RollingWindowSum(resolved1);
         _trSum2 = new RollingWindowSum(resolved2);
         _trSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UltimateOscillator;
@@ -1831,8 +1828,8 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public UltimateTraderOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 10,
-        int lbLength = 5, int smoothLength = 4, int rangeLength = 2, InputName inputName = InputName.Close)
-        : this(maType, length, lbLength, smoothLength, rangeLength, inputName, null)
+        int lbLength = 5, int smoothLength = 4, int rangeLength = 2)
+        : this(maType, length, lbLength, smoothLength, rangeLength, InputName.Close, null)
     {
     }
 

--- a/src/Streaming/StatefulIndicators.Batch25.cs
+++ b/src/Streaming/StatefulIndicators.Batch25.cs
@@ -29,19 +29,6 @@ public sealed class TrendForceHistogramState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendForceHistogramState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(_length);
-        _minWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendForceHistogram;
 
     public void Reset()
@@ -125,20 +112,6 @@ public sealed class TrendImpulseFilterState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendImpulseFilterState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _maxWindow = new RollingWindowMax(Math.Max(1, length1));
-        _minWindow = new RollingWindowMin(Math.Max(1, length1));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendImpulseFilter;
 
     public void Reset()
@@ -207,21 +180,6 @@ public sealed class TrendIntensityIndexState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendIntensityIndexState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _upSum = new RollingWindowSum(resolvedFast);
-        _downSum = new RollingWindowSum(resolvedFast);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendIntensityIndex;
 
     public void Reset()
@@ -285,24 +243,6 @@ public sealed class TrendPersistenceRateState : IStreamingIndicatorState, IDispo
         _ctrMSum = new RollingWindowSum(_length);
         _maValues = new PooledRingBuffer<double>(2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrendPersistenceRateState(MovingAvgType maType, int length, int smoothLength, double mult, double threshold,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mult = mult;
-        _threshold = threshold;
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _ctrPSum = new RollingWindowSum(_length);
-        _ctrMSum = new RollingWindowSum(_length);
-        _maValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TrendPersistenceRate;
@@ -370,18 +310,6 @@ public sealed class TrendStepState : IStreamingIndicatorState, IDisposable
         _length = Math.Max(1, length);
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, inputName);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrendStepState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TrendStep;
@@ -453,24 +381,6 @@ public sealed class TrendTraderBandsState : IStreamingIndicatorState, IDisposabl
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _retSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TrendTraderBandsState(MovingAvgType maType, int length, double mult, double bandStep,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _mult = mult;
-        _bandStep = bandStep;
-        _maxWindow = new RollingWindowMax(resolved);
-        _minWindow = new RollingWindowMin(resolved);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _retSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TrendTraderBands;
@@ -565,21 +475,6 @@ public sealed class TrendTriggerFactorState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrendTriggerFactorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _highestValues = new PooledRingBuffer<double>(_length);
-        _lowestValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrendTriggerFactor;
 
     public void Reset()
@@ -652,24 +547,6 @@ public sealed class TreynorRatioState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TreynorRatioState(int length, double beta, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _beta = beta;
-        double barMin = 60 * 24;
-        double minPerYr = 60 * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = Math.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _retSum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TreynorRatio;
 
     public void Reset()
@@ -724,18 +601,6 @@ public sealed class TrigonometricOscillatorState : IStreamingIndicatorState, IDi
     {
         var resolved = Math.Max(1, length);
         _sRegression = new LinearRegressionState(resolved, inputName);
-        _uRegression = new LinearRegressionState(resolved, _ => _uValue);
-    }
-
-    public TrigonometricOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sRegression = new LinearRegressionState(resolved, selector);
         _uRegression = new LinearRegressionState(resolved, _ => _uValue);
     }
 
@@ -799,18 +664,6 @@ public sealed class TrimeanState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrimeanState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _order = new RollingOrderStatistic(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Trimean;
 
     public void Reset()
@@ -868,21 +721,6 @@ public sealed class TripleExponentialMovingAverageState : IStreamingIndicatorSta
         _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TripleExponentialMovingAverageState(MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema3 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TripleExponentialMovingAverage;
@@ -949,25 +787,6 @@ public sealed class TStepLeastSquaresMovingAverageState : IStreamingIndicatorSta
         _corrWindow = new RollingWindowCorrelation(resolved);
         _er = new EfficiencyRatioState(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TStepLeastSquaresMovingAverageState(MovingAvgType maType, int length, double sc,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ = sc;
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _bSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _bStdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _bValue);
-        _corrWindow = new RollingWindowCorrelation(resolved);
-        _er = new EfficiencyRatioState(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TStepLeastSquaresMovingAverage;
@@ -1056,17 +875,6 @@ public sealed class TTMScalperIndicatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TTMScalperIndicatorState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _closes = new PooledRingBuffer<double>(3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TTMScalperIndicator;
 
     public void Reset()
@@ -1141,24 +949,6 @@ public sealed class TurboScalerState : IStreamingIndicatorState, IDisposable
         _smoSmaMaxWindow = new RollingWindowMax(resolved);
         _smoSmaMinWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _alpha = alpha;
-    }
-
-    public TurboScalerState(MovingAvgType maType, int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _sma2Smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _smoMaxWindow = new RollingWindowMax(resolved);
-        _smoMinWindow = new RollingWindowMin(resolved);
-        _smoSmaMaxWindow = new RollingWindowMax(resolved);
-        _smoSmaMinWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _alpha = alpha;
     }
 
@@ -1240,25 +1030,6 @@ public sealed class TurboStochasticsFastState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TurboStochasticsFastState(MovingAvgType maType, int length1, int length2, int turboLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
-        var regressionLength = Math.Max(1, length2 + turbo);
-        _highWindow = new RollingWindowMax(resolvedLength1);
-        _lowWindow = new RollingWindowMin(resolvedLength1);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _fastKRegression = new LinearRegressionState(regressionLength, _ => _fastKValue);
-        _fastDRegression = new LinearRegressionState(regressionLength, _ => _fastDValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TurboStochasticsFast;
 
     public void Reset()
@@ -1337,26 +1108,6 @@ public sealed class TurboStochasticsSlowState : IStreamingIndicatorState, IDispo
         _slowKRegression = new LinearRegressionState(regressionLength, _ => _slowKValue);
         _slowDRegression = new LinearRegressionState(regressionLength, _ => _slowDValue);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TurboStochasticsSlowState(MovingAvgType maType, int length1, int length2, int turboLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var turbo = turboLength < 0 ? Math.Max(turboLength, length2 * -1) : turboLength > 0 ? Math.Min(turboLength, length2) : 0;
-        var regressionLength = Math.Max(1, length2 + turbo);
-        _highWindow = new RollingWindowMax(resolvedLength1);
-        _lowWindow = new RollingWindowMin(resolvedLength1);
-        _slowKSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _slowDSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _slowKRegression = new LinearRegressionState(regressionLength, _ => _slowKValue);
-        _slowDRegression = new LinearRegressionState(regressionLength, _ => _slowDValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TurboStochasticsSlow;
@@ -1443,26 +1194,6 @@ public sealed class TurboTriggerState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TurboTriggerState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _closeSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _openSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _highSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _avgSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _hySmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _ylSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _oscSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TurboTrigger;
 
     public void Reset()
@@ -1534,19 +1265,6 @@ public sealed class TwiggsMoneyFlowState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TwiggsMoneyFlowState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _adSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _volumeSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TwiggsMoneyFlow;
 
     public void Reset()
@@ -1614,21 +1332,6 @@ public sealed class UberTrendIndicatorState : IStreamingIndicatorState, IDisposa
         _advVolSum = new RollingWindowSum(resolved);
         _decVolSum = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public UberTrendIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _advSum = new RollingWindowSum(resolved);
-        _decSum = new RollingWindowSum(resolved);
-        _advVolSum = new RollingWindowSum(resolved);
-        _decVolSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.UberTrendIndicator;
@@ -1710,20 +1413,6 @@ public sealed class UhlMaCrossoverSystemState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public UhlMaCrossoverSystemState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _stdDevValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.UhlMaCrossoverSystem;
 
     public void Reset()
@@ -1800,24 +1489,6 @@ public sealed class UltimateMomentumIndicatorState : IStreamingIndicatorState, I
         _mfi1 = new MoneyFlowIndexState(length2, inputName);
         _mfi2 = new MoneyFlowIndexState(length3, inputName);
         _mfi3 = new MoneyFlowIndexState(length4, inputName);
-        _rsi = new RsiState(maType, Math.Max(1, length1));
-        _utmSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-    }
-
-    public UltimateMomentumIndicatorState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int length6, double stdDevMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = length6;
-        _mo = new McClellanOscillatorState(maType, length2, length4, 9, 1000, selector);
-        _bbPct = new BollingerBandsPercentBState(stdDevMult, maType, length5, selector);
-        _mfi1 = new MoneyFlowIndexState(length2, selector);
-        _mfi2 = new MoneyFlowIndexState(length3, selector);
-        _mfi3 = new MoneyFlowIndexState(length4, selector);
         _rsi = new RsiState(maType, Math.Max(1, length1));
         _utmSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
     }
@@ -1914,26 +1585,6 @@ public sealed class UltimateMovingAverageState : IStreamingIndicatorState, IDisp
         _prevLength = _maxLength;
     }
 
-    public UltimateMovingAverageState(MovingAvgType maType, int minLength, int maxLength, double acc,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _minLength = Math.Max(1, minLength);
-        _maxLength = Math.Max(_minLength, maxLength);
-        _acc = acc;
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, _maxLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength, selector);
-        _posFlowSum = new RollingCumulativeSum();
-        _negFlowSum = new RollingCumulativeSum();
-        _values = new PooledRingBuffer<double>(_maxLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _prevLength = _maxLength;
-    }
-
     public IndicatorName Name => IndicatorName.UltimateMovingAverage;
 
     public void Reset()
@@ -2025,19 +1676,6 @@ public sealed class UltimateMovingAverageBandsState : IStreamingIndicatorState, 
         _stdDevMult = stdDevMult;
     }
 
-    public UltimateMovingAverageBandsState(MovingAvgType maType, int minLength, int maxLength, double stdDevMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _uma = new UltimateMovingAverageState(maType, minLength, maxLength, 1, selector);
-        _stdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, minLength), selector);
-        _stdDevMult = stdDevMult;
-    }
-
     public IndicatorName Name => IndicatorName.UltimateMovingAverageBands;
 
     public void Reset()
@@ -2098,25 +1736,6 @@ public sealed class UltimateOscillatorState : IStreamingIndicatorState, IDisposa
         _trSum2 = new RollingWindowSum(resolved2);
         _trSum3 = new RollingWindowSum(resolved3);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public UltimateOscillatorState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        _bpSum1 = new RollingWindowSum(resolved1);
-        _bpSum2 = new RollingWindowSum(resolved2);
-        _bpSum3 = new RollingWindowSum(resolved3);
-        _trSum1 = new RollingWindowSum(resolved1);
-        _trSum2 = new RollingWindowSum(resolved2);
-        _trSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.UltimateOscillator;
@@ -2214,13 +1833,6 @@ public sealed class UltimateTraderOscillatorState : IStreamingIndicatorState, ID
     public UltimateTraderOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 10,
         int lbLength = 5, int smoothLength = 4, int rangeLength = 2, InputName inputName = InputName.Close)
         : this(maType, length, lbLength, smoothLength, rangeLength, inputName, null)
-    {
-    }
-
-    public UltimateTraderOscillatorState(MovingAvgType maType, int length, int lbLength, int smoothLength, int rangeLength,
-        Func<OhlcvBar, double> selector)
-        : this(maType, length, lbLength, smoothLength, rangeLength, InputName.Close,
-            selector ?? throw new ArgumentNullException(nameof(selector)))
     {
     }
 

--- a/src/Streaming/StatefulIndicators.Batch26.cs
+++ b/src/Streaming/StatefulIndicators.Batch26.cs
@@ -14,12 +14,12 @@ public sealed class UpsideDownsideVolumeState : IStreamingIndicatorState, IDispo
     private double _prevValue;
     private bool _hasPrev;
 
-    public UpsideDownsideVolumeState(int length = 50, InputName inputName = InputName.Close)
+    public UpsideDownsideVolumeState(int length = 50)
     {
         _length = Math.Max(1, length);
         _upSum = new RollingWindowSum(_length);
         _downSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UpsideDownsideVolume;
@@ -77,7 +77,7 @@ public sealed class UpsidePotentialRatioState : IStreamingIndicatorState, IDispo
     private readonly PooledRingBuffer<double> _retValues;
     private readonly StreamingInputResolver _input;
 
-    public UpsidePotentialRatioState(int length = 30, double bmk = 0.05, InputName inputName = InputName.Close)
+    public UpsidePotentialRatioState(int length = 30, double bmk = 0.05)
     {
         _length = Math.Max(1, length);
         _ratio = 1d / _length;
@@ -87,7 +87,7 @@ public sealed class UpsidePotentialRatioState : IStreamingIndicatorState, IDispo
         _bench = Math.Pow(1 + bmk, _length / barsPerYr) - 1;
         _values = new PooledRingBuffer<double>(_length + 1);
         _retValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UpsidePotentialRatio;
@@ -159,8 +159,7 @@ public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDispos
     private readonly PooledRingBuffer<double> _closeValues;
     private StreamingInputResolver _input;
 
-    public ValueChartIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.MedianPrice, int length = 5)
+    public ValueChartIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 5)
     {
         _length = Math.Max(1, length);
         _varp = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 5));
@@ -170,7 +169,7 @@ public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDispos
         _highestValues = new PooledRingBuffer<double>(5);
         _lowestValues = new PooledRingBuffer<double>(5);
         _closeValues = new PooledRingBuffer<double>(6);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.ValueChartIndicator;
@@ -271,9 +270,9 @@ public sealed class VanillaABCDPatternState : IStreamingIndicatorState
     private double _prevOs;
     private int _index;
 
-    public VanillaABCDPatternState(InputName inputName = InputName.Close)
+    public VanillaABCDPatternState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VanillaABCDPattern;
@@ -330,14 +329,13 @@ public sealed class VaradiOscillatorState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
     private RollingOrderStatistic _order;
 
-    public VaradiOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public VaradiOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _ratioMa = MovingAverageSmootherFactory.Create(maType, _length);
         _order = new RollingOrderStatistic(_length);
         _order.Add(0);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VaradiOscillator;
@@ -393,15 +391,14 @@ public sealed class VariableAdaptiveMovingAverageState : IStreamingIndicatorStat
     private double _prevVma;
     private bool _hasPrev;
 
-    public VariableAdaptiveMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public VariableAdaptiveMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _closeMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _openMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _highMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VariableAdaptiveMovingAverage;
@@ -463,12 +460,11 @@ public sealed class VariableIndexDynamicAverageState : IStreamingIndicatorState,
     private double _prevVidya;
     private bool _hasPrev;
 
-    public VariableIndexDynamicAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public VariableIndexDynamicAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         _alpha = (double)2 / (Math.Max(1, length) + 1);
-        _cmo = new ChandeMomentumOscillatorState(maType, Math.Max(1, length), 3, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _cmo = new ChandeMomentumOscillatorState(maType, Math.Max(1, length), 3);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VariableIndexDynamicAverage;
@@ -525,13 +521,13 @@ public sealed class VariableLengthMovingAverageState : IStreamingIndicatorState,
     private bool _hasPrev;
 
     public VariableLengthMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int minLength = 5,
-        int maxLength = 50, InputName inputName = InputName.Close)
+        int maxLength = 50)
     {
         _minLength = Math.Max(1, minLength);
         _maxLength = Math.Max(_minLength, maxLength);
         _sma = MovingAverageSmootherFactory.Create(maType, _maxLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _prevLength = _maxLength;
     }
 
@@ -594,10 +590,10 @@ public sealed class VariableMovingAverageState : IStreamingIndicatorState, IDisp
     private readonly VariableMovingAverageEngine _engine;
     private readonly StreamingInputResolver _input;
 
-    public VariableMovingAverageState(int length = 6, InputName inputName = InputName.Close)
+    public VariableMovingAverageState(int length = 6)
     {
         _engine = new VariableMovingAverageEngine(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VariableMovingAverage;
@@ -643,7 +639,7 @@ public sealed class VariableMovingAverageBandsState : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public VariableMovingAverageBandsState(MovingAvgType maType = MovingAvgType.VariableMovingAverage, int length = 6,
-        double mult = 1.5, InputName inputName = InputName.Close)
+        double mult = 1.5)
     {
         _mult = mult;
         _useVariable = maType == MovingAvgType.VariableMovingAverage;
@@ -659,7 +655,7 @@ public sealed class VariableMovingAverageBandsState : IStreamingIndicatorState, 
             _atrMa = MovingAverageSmootherFactory.Create(maType, resolved);
         }
 
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VariableMovingAverageBands;
@@ -733,14 +729,14 @@ public sealed class VerticalHorizontalMovingAverageState : IStreamingIndicatorSt
     private double _prevVhma;
     private bool _hasPrev;
 
-    public VerticalHorizontalMovingAverageState(int length = 50, InputName inputName = InputName.Close)
+    public VerticalHorizontalMovingAverageState(int length = 50)
     {
         _length = Math.Max(1, length);
         _changeSum = new RollingWindowSum(_length);
         _maxWindow = new RollingWindowMax(_length);
         _minWindow = new RollingWindowMin(_length);
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VerticalHorizontalMovingAverage;
@@ -817,15 +813,14 @@ public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingInd
     private double _prevHaco;
     private bool _hasPrev;
 
-    public VervoortHeikenAshiCandlestickOscillatorState(MovingAvgType maType = MovingAvgType.ZeroLagTripleExponentialMovingAverage,
-        InputName inputName = InputName.FullTypicalPrice, int length = 34)
+    public VervoortHeikenAshiCandlestickOscillatorState(MovingAvgType maType = MovingAvgType.ZeroLagTripleExponentialMovingAverage, int length = 34)
     {
         var resolved = Math.Max(1, length);
         _haMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _haMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _medianMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _medianMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VervoortHeikenAshiCandlestickOscillator;
@@ -957,15 +952,14 @@ public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStre
     private double _prevHaco;
     private bool _hasPrev;
 
-    public VervoortHeikenAshiLongTermCandlestickOscillatorState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage,
-        InputName inputName = InputName.FullTypicalPrice, int length = 55, double factor = 1.1)
+    public VervoortHeikenAshiLongTermCandlestickOscillatorState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length = 55, double factor = 1.1)
     {
         var resolved = Math.Max(1, length);
         _tacMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _tacMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _thlMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _thlMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
         _factor = factor;
     }
 
@@ -1088,8 +1082,7 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
     private double _percbValue;
     private bool _hasPrev;
 
-    public VervoortModifiedBollingerBandIndicatorState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage,
-        InputName inputName = InputName.FullTypicalPrice, int length1 = 18, int length2 = 200,
+    public VervoortModifiedBollingerBandIndicatorState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length1 = 18, int length2 = 200,
         int smoothLength = 8, double stdDevMult = 1.6)
     {
         _stdDevMult = stdDevMult;
@@ -1099,7 +1092,7 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
         _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, length1));
         _zlhaStdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length1), _ => _zlhaTemaValue);
         _percbStdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length2), _ => _percbValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VervoortModifiedBollingerBandIndicator;
@@ -1203,7 +1196,7 @@ public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, 
     private StreamingInputResolver _input;
     private double _tzValue;
 
-    public VervoortSmoothedOscillatorState(InputName inputName = InputName.TypicalPrice, int length1 = 18,
+    public VervoortSmoothedOscillatorState(int length1 = 18,
         int length2 = 30, int length3 = 2, int smoothLength = 3, double stdDevMult = 2)
     {
         var resolvedLength1 = Math.Max(1, length1);
@@ -1230,7 +1223,7 @@ public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, 
         _lowWindow = new RollingWindowMin(resolvedLength2);
         _rbcMinWindow = new RollingWindowMin(resolvedLength2);
         _fastKSum = new RollingWindowSum(resolvedSmoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VervoortSmoothedOscillator;
@@ -1352,7 +1345,7 @@ public sealed class VervoortVolatilityBandsState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public VervoortVolatilityBandsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 8,
-        int length2 = 13, double devMult = 3.55, double lowBandMult = 0.9, InputName inputName = InputName.Close)
+        int length2 = 13, double devMult = 3.55, double lowBandMult = 0.9)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
@@ -1363,7 +1356,7 @@ public sealed class VervoortVolatilityBandsState : IStreamingIndicatorState, IDi
         _devHighMa = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
         _medianAvgSum = new RollingWindowSum(resolvedLength1);
         _typicalSum = new RollingWindowSum(resolvedLength2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VervoortVolatilityBands;
@@ -1441,10 +1434,10 @@ public sealed class VixTradingSystemState : IStreamingIndicatorState, IDisposabl
     private bool _hasPrev;
 
     public VixTradingSystemState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50,
-        double maxCount = 11, double minCount = -11, InputName inputName = InputName.Close)
+        double maxCount = 11, double minCount = -11)
     {
         _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _ = maxCount;
         _ = minCount;
     }
@@ -1502,12 +1495,12 @@ public sealed class VolatilityIndexDynamicAverageIndicatorState : IStreamingIndi
     private bool _hasPrev;
 
     public VolatilityIndexDynamicAverageIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 20, double alpha1 = 0.2, double alpha2 = 0.04, InputName inputName = InputName.Close)
+        int length = 20, double alpha1 = 0.2, double alpha2 = 0.04)
     {
         var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, resolved);
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _alpha1 = alpha1;
         _alpha2 = alpha2;
     }
@@ -1573,17 +1566,17 @@ public sealed class VolatilityMovingAverageState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
 
     public VolatilityMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        int lbLength = 10, int smoothLength = 3, InputName inputName = InputName.Close)
+        int lbLength = 10, int smoothLength = 3)
     {
         _length = Math.Max(1, length);
         _lbLength = Math.Max(1, lbLength);
         var resolvedSmooth = Math.Max(1, smoothLength);
         _sma = MovingAverageSmootherFactory.Create(maType, _lbLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _lbLength, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _lbLength);
         _kSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
         _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityMovingAverage;
@@ -1666,7 +1659,7 @@ public sealed class VolatilityRatioState : IStreamingIndicatorState, IDisposable
     private bool _hasWindow;
 
     public VolatilityRatioState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        double breakoutLevel = 0.5, InputName inputName = InputName.Close)
+        double breakoutLevel = 0.5)
     {
         _length = Math.Max(1, length);
         var windowLength = Math.Max(1, _length - 1);
@@ -1674,7 +1667,7 @@ public sealed class VolatilityRatioState : IStreamingIndicatorState, IDisposable
         _highWindow = new RollingWindowMax(windowLength);
         _lowWindow = new RollingWindowMin(windowLength);
         _values = new PooledRingBuffer<double>(_length + 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _ = breakoutLevel;
     }
 
@@ -1751,16 +1744,16 @@ public sealed class VolatilityWaveMovingAverageState : IStreamingIndicatorState,
     private readonly StreamingInputResolver _input;
 
     public VolatilityWaveMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20,
-        double kf = 2.5, InputName inputName = InputName.Close)
+        double kf = 2.5)
     {
         _length = Math.Max(1, length);
         _kf = kf;
         var s = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(_length)));
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, _length);
         _wmap1 = MovingAverageSmootherFactory.Create(maType, s);
         _wmap2 = MovingAverageSmootherFactory.Create(maType, s);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityWaveMovingAverage;
@@ -1826,10 +1819,10 @@ public sealed class VolumeAccumulationOscillatorState : IStreamingIndicatorState
     private readonly RollingWindowSum _vaoSum;
     private readonly StreamingInputResolver _input;
 
-    public VolumeAccumulationOscillatorState(int length = 14, InputName inputName = InputName.Close)
+    public VolumeAccumulationOscillatorState(int length = 14)
     {
         _vaoSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAccumulationOscillator;
@@ -1872,11 +1865,11 @@ public sealed class VolumeAccumulationPercentState : IStreamingIndicatorState, I
     private readonly RollingWindowSum _tvaSum;
     private readonly StreamingInputResolver _input;
 
-    public VolumeAccumulationPercentState(int length = 10, InputName inputName = InputName.Close)
+    public VolumeAccumulationPercentState(int length = 10)
     {
         _volumeSum = new RollingWindowSum(Math.Max(1, length));
         _tvaSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAccumulationPercent;
@@ -1925,14 +1918,13 @@ public sealed class VolumeAdaptiveBandsState : IStreamingIndicatorState, IDispos
     private double _prevDn;
     private bool _hasPrev;
 
-    public VolumeAdaptiveBandsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        InputName inputName = InputName.Close)
+    public VolumeAdaptiveBandsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100)
     {
         var resolved = Math.Max(1, length);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _upMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAdaptiveBands;
@@ -1999,14 +1991,14 @@ public sealed class VolumeAdjustedMovingAverageState : IStreamingIndicatorState,
     private readonly StreamingInputResolver _input;
 
     public VolumeAdjustedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double factor = 0.67, InputName inputName = InputName.Close)
+        double factor = 0.67)
     {
         var resolved = Math.Max(1, length);
         _factor = factor;
         _volumeSma = MovingAverageSmootherFactory.Create(maType, resolved);
         _volumeRatioSum = new RollingWindowSum(resolved);
         _priceVolumeRatioSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAdjustedMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch26.cs
+++ b/src/Streaming/StatefulIndicators.Batch26.cs
@@ -178,7 +178,7 @@ public sealed class UpsidePotentialRatioState : IStreamingIndicatorState, IDispo
     }
 }
 
-public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _length;
     private readonly int _varp;
@@ -188,7 +188,7 @@ public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDispos
     private readonly PooledRingBuffer<double> _highestValues;
     private readonly PooledRingBuffer<double> _lowestValues;
     private readonly PooledRingBuffer<double> _closeValues;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public ValueChartIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         InputName inputName = InputName.MedianPrice, int length = 5)
@@ -224,6 +224,9 @@ public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDispos
     }
 
     public IndicatorName Name => IndicatorName.ValueChartIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -960,13 +963,13 @@ public sealed class VerticalHorizontalMovingAverageState : IStreamingIndicatorSt
     }
 }
 
-public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _haMa1;
     private readonly IMovingAverageSmoother _haMa2;
     private readonly IMovingAverageSmoother _medianMa1;
     private readonly IMovingAverageSmoother _medianMa2;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevInput;
     private double _prevHao;
     private double _prevHac;
@@ -1010,6 +1013,9 @@ public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingInd
     }
 
     public IndicatorName Name => IndicatorName.VervoortHeikenAshiCandlestickOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1112,13 +1118,13 @@ public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingInd
     }
 }
 
-public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _tacMa1;
     private readonly IMovingAverageSmoother _tacMa2;
     private readonly IMovingAverageSmoother _thlMa1;
     private readonly IMovingAverageSmoother _thlMa2;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly double _factor;
     private double _prevInput;
     private double _prevHao;
@@ -1165,6 +1171,9 @@ public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStre
     }
 
     public IndicatorName Name => IndicatorName.VervoortHeikenAshiLongTermCandlestickOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1264,7 +1273,7 @@ public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStre
     }
 }
 
-public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _hacMa1;
     private readonly IMovingAverageSmoother _hacMa2;
@@ -1272,7 +1281,7 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
     private readonly IMovingAverageSmoother _wma;
     private readonly StandardDeviationVolatilityState _zlhaStdDev;
     private readonly StandardDeviationVolatilityState _percbStdDev;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly double _stdDevMult;
     private double _prevInput;
     private double _prevHao;
@@ -1313,6 +1322,9 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
     }
 
     public IndicatorName Name => IndicatorName.VervoortModifiedBollingerBandIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1385,7 +1397,7 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
     }
 }
 
-public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly double _stdDevMult;
     private readonly IMovingAverageSmoother _r1Sma;
@@ -1407,7 +1419,7 @@ public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, 
     private readonly RollingWindowMin _lowWindow;
     private readonly RollingWindowMin _rbcMinWindow;
     private readonly RollingWindowSum _fastKSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _tzValue;
 
     public VervoortSmoothedOscillatorState(InputName inputName = InputName.TypicalPrice, int length1 = 18,
@@ -1476,6 +1488,9 @@ public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, 
     }
 
     public IndicatorName Name => IndicatorName.VervoortSmoothedOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch26.cs
+++ b/src/Streaming/StatefulIndicators.Batch26.cs
@@ -22,19 +22,6 @@ public sealed class UpsideDownsideVolumeState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public UpsideDownsideVolumeState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _upSum = new RollingWindowSum(_length);
-        _downSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.UpsideDownsideVolume;
 
     public void Reset()
@@ -101,24 +88,6 @@ public sealed class UpsidePotentialRatioState : IStreamingIndicatorState, IDispo
         _values = new PooledRingBuffer<double>(_length + 1);
         _retValues = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public UpsidePotentialRatioState(int length, double bmk, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _ratio = 1d / _length;
-        double barMin = 60 * 24;
-        double minPerYr = 60 * 24 * 30 * 12;
-        var barsPerYr = minPerYr / barMin;
-        _bench = Math.Pow(1 + bmk, _length / barsPerYr) - 1;
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _retValues = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.UpsidePotentialRatio;
@@ -202,25 +171,6 @@ public sealed class ValueChartIndicatorState : IStreamingIndicatorState, IDispos
         _lowestValues = new PooledRingBuffer<double>(5);
         _closeValues = new PooledRingBuffer<double>(6);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ValueChartIndicatorState(MovingAvgType maType, InputName inputName, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _varp = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 5));
-        _ma = MovingAverageSmootherFactory.Create(maType, _length);
-        _highWindow = new RollingWindowMax(_varp);
-        _lowWindow = new RollingWindowMin(_varp);
-        _highestValues = new PooledRingBuffer<double>(5);
-        _lowestValues = new PooledRingBuffer<double>(5);
-        _closeValues = new PooledRingBuffer<double>(6);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.ValueChartIndicator;
@@ -326,16 +276,6 @@ public sealed class VanillaABCDPatternState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VanillaABCDPatternState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VanillaABCDPattern;
 
     public void Reset()
@@ -400,20 +340,6 @@ public sealed class VaradiOscillatorState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VaradiOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _ratioMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _order = new RollingOrderStatistic(_length);
-        _order.Add(0);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VaradiOscillator;
 
     public void Reset()
@@ -476,21 +402,6 @@ public sealed class VariableAdaptiveMovingAverageState : IStreamingIndicatorStat
         _highMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VariableAdaptiveMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _closeMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _openMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _highMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VariableAdaptiveMovingAverage;
@@ -560,18 +471,6 @@ public sealed class VariableIndexDynamicAverageState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VariableIndexDynamicAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = (double)2 / (Math.Max(1, length) + 1);
-        _cmo = new ChandeMomentumOscillatorState(maType, Math.Max(1, length), 3, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VariableIndexDynamicAverage;
 
     public void Reset()
@@ -633,22 +532,6 @@ public sealed class VariableLengthMovingAverageState : IStreamingIndicatorState,
         _sma = MovingAverageSmootherFactory.Create(maType, _maxLength);
         _stdDev = new StandardDeviationVolatilityState(maType, _maxLength, inputName);
         _input = new StreamingInputResolver(inputName, null);
-        _prevLength = _maxLength;
-    }
-
-    public VariableLengthMovingAverageState(MovingAvgType maType, int minLength, int maxLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _minLength = Math.Max(1, minLength);
-        _maxLength = Math.Max(_minLength, maxLength);
-        _sma = MovingAverageSmootherFactory.Create(maType, _maxLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _maxLength, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _prevLength = _maxLength;
     }
 
@@ -717,17 +600,6 @@ public sealed class VariableMovingAverageState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VariableMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new VariableMovingAverageEngine(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VariableMovingAverage;
 
     public void Reset()
@@ -788,31 +660,6 @@ public sealed class VariableMovingAverageBandsState : IStreamingIndicatorState, 
         }
 
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VariableMovingAverageBandsState(MovingAvgType maType, int length, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _mult = mult;
-        _useVariable = maType == MovingAvgType.VariableMovingAverage;
-        if (_useVariable)
-        {
-            _vmaEngine = new VariableMovingAverageEngine(length);
-            _atrEngine = new VariableMovingAverageEngine(length);
-        }
-        else
-        {
-            var resolved = Math.Max(1, length);
-            _ma = MovingAverageSmootherFactory.Create(maType, resolved);
-            _atrMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VariableMovingAverageBands;
@@ -894,21 +741,6 @@ public sealed class VerticalHorizontalMovingAverageState : IStreamingIndicatorSt
         _minWindow = new RollingWindowMin(_length);
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VerticalHorizontalMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _changeSum = new RollingWindowSum(_length);
-        _maxWindow = new RollingWindowMax(_length);
-        _minWindow = new RollingWindowMin(_length);
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VerticalHorizontalMovingAverage;
@@ -994,22 +826,6 @@ public sealed class VervoortHeikenAshiCandlestickOscillatorState : IStreamingInd
         _medianMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _medianMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VervoortHeikenAshiCandlestickOscillatorState(MovingAvgType maType, InputName inputName, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _haMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _haMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _medianMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _medianMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VervoortHeikenAshiCandlestickOscillator;
@@ -1153,23 +969,6 @@ public sealed class VervoortHeikenAshiLongTermCandlestickOscillatorState : IStre
         _factor = factor;
     }
 
-    public VervoortHeikenAshiLongTermCandlestickOscillatorState(MovingAvgType maType, InputName inputName, int length, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _tacMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _tacMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _thlMa1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _thlMa2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, selector);
-        _factor = factor;
-    }
-
     public IndicatorName Name => IndicatorName.VervoortHeikenAshiLongTermCandlestickOscillator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1303,24 +1102,6 @@ public sealed class VervoortModifiedBollingerBandIndicatorState : IStreamingIndi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VervoortModifiedBollingerBandIndicatorState(MovingAvgType maType, InputName inputName, int length1, int length2,
-        int smoothLength, double stdDevMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _stdDevMult = stdDevMult;
-        _hacMa1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _hacMa2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _zlhaMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, length1));
-        _zlhaStdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length1), _ => _zlhaTemaValue);
-        _percbStdDev = new StandardDeviationVolatilityState(maType, Math.Max(1, length2), _ => _percbValue);
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VervoortModifiedBollingerBandIndicator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1450,41 +1231,6 @@ public sealed class VervoortSmoothedOscillatorState : IStreamingIndicatorState, 
         _rbcMinWindow = new RollingWindowMin(resolvedLength2);
         _fastKSum = new RollingWindowSum(resolvedSmoothLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VervoortSmoothedOscillatorState(InputName inputName, int length1, int length2, int length3,
-        int smoothLength, double stdDevMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var resolvedLength3 = Math.Max(1, length3);
-        var resolvedSmoothLength = Math.Max(1, smoothLength);
-        _stdDevMult = stdDevMult;
-        _r1Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r2Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r3Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r4Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r5Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r6Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r7Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r8Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r9Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _r10Sma = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedLength3);
-        _ema1 = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolvedSmoothLength);
-        _ema2 = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, resolvedSmoothLength);
-        _tema = MovingAverageSmootherFactory.Create(MovingAvgType.TripleExponentialMovingAverage, resolvedSmoothLength);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolvedLength1, _ => _tzValue);
-        _wma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, resolvedLength1);
-        _highWindow = new RollingWindowMax(resolvedLength2);
-        _lowWindow = new RollingWindowMin(resolvedLength2);
-        _rbcMinWindow = new RollingWindowMin(resolvedLength2);
-        _fastKSum = new RollingWindowSum(resolvedSmoothLength);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VervoortSmoothedOscillator;
@@ -1620,26 +1366,6 @@ public sealed class VervoortVolatilityBandsState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VervoortVolatilityBandsState(MovingAvgType maType, int length1, int length2, double devMult,
-        double lowBandMult, InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _devMult = devMult;
-        _lowBandMult = lowBandMult;
-        _medianAvg = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _medianAvgEma = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _devHighMa = MovingAverageSmootherFactory.Create(maType, resolvedLength1);
-        _medianAvgSum = new RollingWindowSum(resolvedLength1);
-        _typicalSum = new RollingWindowSum(resolvedLength2);
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VervoortVolatilityBands;
 
     public void Reset()
@@ -1723,20 +1449,6 @@ public sealed class VixTradingSystemState : IStreamingIndicatorState, IDisposabl
         _ = minCount;
     }
 
-    public VixTradingSystemState(MovingAvgType maType, int length, double maxCount, double minCount,
-        InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, selector);
-        _ = maxCount;
-        _ = minCount;
-    }
-
     public IndicatorName Name => IndicatorName.VixTradingSystem;
 
     public void Reset()
@@ -1796,22 +1508,6 @@ public sealed class VolatilityIndexDynamicAverageIndicatorState : IStreamingIndi
         _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _alpha1 = alpha1;
-        _alpha2 = alpha2;
-    }
-
-    public VolatilityIndexDynamicAverageIndicatorState(MovingAvgType maType, int length, double alpha1, double alpha2,
-        InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, selector);
         _alpha1 = alpha1;
         _alpha2 = alpha2;
     }
@@ -1888,25 +1584,6 @@ public sealed class VolatilityMovingAverageState : IStreamingIndicatorState, IDi
         _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolatilityMovingAverageState(MovingAvgType maType, int length, int lbLength, int smoothLength, InputName inputName,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _lbLength = Math.Max(1, lbLength);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _sma = MovingAverageSmootherFactory.Create(maType, _lbLength);
-        _stdDev = new StandardDeviationVolatilityState(maType, _lbLength, selector);
-        _kSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _vmaSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityMovingAverage;
@@ -2001,24 +1678,6 @@ public sealed class VolatilityRatioState : IStreamingIndicatorState, IDisposable
         _ = breakoutLevel;
     }
 
-    public VolatilityRatioState(MovingAvgType maType, int length, double breakoutLevel, InputName inputName,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var windowLength = Math.Max(1, _length - 1);
-        _ema = MovingAverageSmootherFactory.Create(maType, _length);
-        _highWindow = new RollingWindowMax(windowLength);
-        _lowWindow = new RollingWindowMin(windowLength);
-        _values = new PooledRingBuffer<double>(_length + 2);
-        _input = new StreamingInputResolver(inputName, selector);
-        _ = breakoutLevel;
-    }
-
     public IndicatorName Name => IndicatorName.VolatilityRatio;
 
     public void Reset()
@@ -2104,24 +1763,6 @@ public sealed class VolatilityWaveMovingAverageState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolatilityWaveMovingAverageState(MovingAvgType maType, int length, double kf, InputName inputName,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _kf = kf;
-        var s = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(_length)));
-        _stdDev = new StandardDeviationVolatilityState(maType, _length, selector);
-        _wmap1 = MovingAverageSmootherFactory.Create(maType, s);
-        _wmap2 = MovingAverageSmootherFactory.Create(maType, s);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolatilityWaveMovingAverage;
 
     public void Reset()
@@ -2191,17 +1832,6 @@ public sealed class VolumeAccumulationOscillatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolumeAccumulationOscillatorState(int length, InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _vaoSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolumeAccumulationOscillator;
 
     public void Reset()
@@ -2247,18 +1877,6 @@ public sealed class VolumeAccumulationPercentState : IStreamingIndicatorState, I
         _volumeSum = new RollingWindowSum(Math.Max(1, length));
         _tvaSum = new RollingWindowSum(Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumeAccumulationPercentState(int length, InputName inputName, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _volumeSum = new RollingWindowSum(Math.Max(1, length));
-        _tvaSum = new RollingWindowSum(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAccumulationPercent;
@@ -2315,21 +1933,6 @@ public sealed class VolumeAdaptiveBandsState : IStreamingIndicatorState, IDispos
         _upMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumeAdaptiveBandsState(MovingAvgType maType, int length, InputName inputName,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _upMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAdaptiveBands;
@@ -2404,22 +2007,6 @@ public sealed class VolumeAdjustedMovingAverageState : IStreamingIndicatorState,
         _volumeRatioSum = new RollingWindowSum(resolved);
         _priceVolumeRatioSum = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumeAdjustedMovingAverageState(MovingAvgType maType, int length, double factor, InputName inputName,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _factor = factor;
-        _volumeSma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _volumeRatioSum = new RollingWindowSum(resolved);
-        _priceVolumeRatioSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumeAdjustedMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch27.cs
+++ b/src/Streaming/StatefulIndicators.Batch27.cs
@@ -1325,7 +1325,7 @@ public sealed class WindowedVolumeWeightedMovingAverageState : IStreamingIndicat
     }
 }
 
-public sealed class WoodieCommodityChannelIndexState : IStreamingIndicatorState, IDisposable
+public sealed class WoodieCommodityChannelIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly CommodityChannelIndexState _slowCci;
     private readonly CommodityChannelIndexState _fastCci;
@@ -1338,6 +1338,14 @@ public sealed class WoodieCommodityChannelIndexState : IStreamingIndicatorState,
     }
 
     public IndicatorName Name => IndicatorName.WoodieCommodityChannelIndex;
+
+    // No resolver of its own: the inner states that default to a typical or median price are the
+    // ones that must switch to reading the close when this state is wrapped.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_slowCci).ReadCloseAsInput();
+        ((ICustomInputConsumer)_fastCci).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch27.cs
+++ b/src/Streaming/StatefulIndicators.Batch27.cs
@@ -5,7 +5,7 @@ using OoplesFinance.StockIndicators.Helpers;
 
 namespace OoplesFinance.StockIndicators.Streaming;
 
-public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _length1;
     private readonly int _length2;
@@ -16,7 +16,7 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
     private readonly IMovingAverageSmoother _volumeMa;
     private readonly IMovingAverageSmoother _vfiMa;
     private readonly IMovingAverageSmoother _signalMa;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _inter;
     private double _prevValue;
     private double _prevVave;
@@ -59,6 +59,9 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
     }
 
     public IndicatorName Name => IndicatorName.VolumeFlowIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -124,7 +127,7 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
     }
 }
 
-public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _length;
     private readonly IMovingAverageSmoother _volumeMa;
@@ -132,7 +135,7 @@ public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorSt
     private readonly IMovingAverageSmoother _vpnSmooth;
     private readonly RollingWindowSum _vmpSum;
     private readonly RollingWindowSum _vmnSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevValue;
     private double _prevClose;
     private bool _hasPrev;
@@ -167,6 +170,9 @@ public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorSt
     }
 
     public IndicatorName Name => IndicatorName.VolumePositiveNegativeIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -355,9 +361,9 @@ public sealed class VolumePriceConfirmationIndicatorState : IStreamingIndicatorS
     }
 }
 
-public sealed class VolumeWeightedAveragePriceState : IStreamingIndicatorState
+public sealed class VolumeWeightedAveragePriceState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _cumVolume;
     private double _cumVolumePrice;
 
@@ -377,6 +383,9 @@ public sealed class VolumeWeightedAveragePriceState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedAveragePrice;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -922,13 +931,13 @@ public sealed class WamiOscillatorState : IStreamingIndicatorState, IDisposable
     }
 }
 
-public sealed class WaveTrendOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class WaveTrendOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _esaMa;
     private readonly IMovingAverageSmoother _dMa;
     private readonly IMovingAverageSmoother _tciMa;
     private readonly IMovingAverageSmoother _wt2Ma;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public WaveTrendOscillatorState(InputName inputName = InputName.FullTypicalPrice,
         MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 10, int length2 = 21,
@@ -957,6 +966,9 @@ public sealed class WaveTrendOscillatorState : IStreamingIndicatorState, IDispos
     }
 
     public IndicatorName Name => IndicatorName.WaveTrendOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1704,12 +1716,12 @@ public sealed class WoodiePivotPointsState : IStreamingIndicatorState
     }
 }
 
-public sealed class ZDistanceFromVwapState : IStreamingIndicatorState, IDisposable
+public sealed class ZDistanceFromVwapState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother? _meanMa;
     private readonly RollingVolumeWeightedMean _vwapMean;
     private readonly RollingZScore _zScore;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public ZDistanceFromVwapState(MovingAvgType maType = MovingAvgType.VolumeWeightedAveragePrice, int length = 20,
         InputName inputName = InputName.Close)
@@ -1734,6 +1746,9 @@ public sealed class ZDistanceFromVwapState : IStreamingIndicatorState, IDisposab
     }
 
     public IndicatorName Name => IndicatorName.ZDistanceFromVwap;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch27.cs
+++ b/src/Streaming/StatefulIndicators.Batch27.cs
@@ -38,26 +38,6 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolumeFlowIndicatorState(MovingAvgType maType, int length1, int length2, int signalLength,
-        int smoothLength, double coef, double vcoef, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _coef = coef;
-        _vcoef = vcoef;
-        _vcpSum = new RollingWindowSum(_length1);
-        _vinter = new StandardDeviationVolatilityState(maType, _length2, _ => _inter);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, _length1);
-        _vfiMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _signalMa = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolumeFlowIndicator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -150,23 +130,6 @@ public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorSt
         _vmpSum = new RollingWindowSum(_length);
         _vmnSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumePositiveNegativeIndicatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _atrMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _vpnSmooth = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _vmpSum = new RollingWindowSum(_length);
-        _vmnSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumePositiveNegativeIndicator;
@@ -269,29 +232,6 @@ public sealed class VolumePriceConfirmationIndicatorState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolumePriceConfirmationIndicatorState(MovingAvgType maType, int fastLength, int slowLength, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var resolved = Math.Max(1, length);
-        _vwmaFastSum = new RollingWindowSum(resolvedFast);
-        _vwmaSlowSum = new RollingWindowSum(resolvedSlow);
-        _vwmaFastVolMa = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedFast);
-        _vwmaSlowVolMa = MovingAverageSmootherFactory.Create(MovingAvgType.SimpleMovingAverage, resolvedSlow);
-        _volumeFastMa = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _volumeSlowMa = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _smaFast = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _smaSlow = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _vpciMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolumePriceConfirmationIndicator;
 
     public void Reset()
@@ -372,16 +312,6 @@ public sealed class VolumeWeightedAveragePriceState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolumeWeightedAveragePriceState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolumeWeightedAveragePrice;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -433,19 +363,6 @@ public sealed class VolumeWeightedMovingAverageState : IStreamingIndicatorState,
         _volumePriceSum = new RollingWindowSum(resolved);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumeWeightedMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _volumePriceSum = new RollingWindowSum(resolved);
-        _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedMovingAverage;
@@ -502,21 +419,6 @@ public sealed class VolumeWeightedRelativeStrengthIndexState : IStreamingIndicat
         _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _smoothMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolumeWeightedRelativeStrengthIndexState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _upMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _smoothMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedRelativeStrengthIndex;
@@ -586,19 +488,6 @@ public sealed class VortexBandsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VortexBandsState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _basisMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _diffMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VortexBands;
 
     public void Reset()
@@ -658,22 +547,6 @@ public sealed class VostroIndicatorState : IStreamingIndicatorState, IDisposable
         _rangeSum = new RollingWindowSum(_length1);
         _wma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VostroIndicatorState(MovingAvgType maType, int length1, int length2, double level,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _level = level;
-        _tempSum = new RollingWindowSum(_length1);
-        _rangeSum = new RollingWindowSum(_length1);
-        _wma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VostroIndicator;
@@ -764,26 +637,6 @@ public sealed class WaddahAttarExplosionState : IStreamingIndicatorState, IDispo
         _values = new PooledRingBuffer<double>(3);
     }
 
-    public WaddahAttarExplosionState(int fastLength, int slowLength, double sensitivity, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _bbLength = Math.Max(1, fastLength);
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _sensitivity = sensitivity;
-        _macd1 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
-        _macd2 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
-        _macd3 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
-        _macd4 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
-        _bbWindow = new RollingWindowStats(_bbLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(3);
-    }
-
     public IndicatorName Name => IndicatorName.WaddahAttarExplosion;
 
     public void Reset()
@@ -871,19 +724,6 @@ public sealed class WamiOscillatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WamiOscillatorState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _diffWma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, length2));
-        _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WamiOscillator;
 
     public void Reset()
@@ -950,21 +790,6 @@ public sealed class WaveTrendOscillatorState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WaveTrendOscillatorState(MovingAvgType maType, int length1, int length2, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _esaMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _dMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _tciMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _wt2Ma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WaveTrendOscillator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1022,17 +847,6 @@ public sealed class WellesWilderSummationState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WellesWilderSummationState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WellesWilderSummation;
 
     public void Reset()
@@ -1085,24 +899,6 @@ public sealed class WellesWilderVolatilitySystemState : IStreamingIndicatorState
         _maxWindow = new RollingWindowMax(resolved2);
         _minWindow = new RollingWindowMin(resolved2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public WellesWilderVolatilitySystemState(MovingAvgType maType, int length1, int length2, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _factor = factor;
-        _atrMa = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _ema = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _maxWindow = new RollingWindowMax(resolved2);
-        _minWindow = new RollingWindowMin(resolved2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.WellesWilderVolatilitySystem;
@@ -1175,18 +971,6 @@ public sealed class WellRoundedMovingAverageState : IStreamingIndicatorState
         _length = Math.Max(1, length);
         _alpha = 2d / (_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public WellRoundedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _alpha = 2d / (_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.WellRoundedMovingAverage;
@@ -1407,28 +1191,6 @@ public sealed class WilsonRelativePriceChannelState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WilsonRelativePriceChannelState(MovingAvgType maType, int length, int smoothLength, double overbought,
-        double oversold, double upperNeutralZone, double lowerNeutralZone, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var smooth = Math.Max(1, smoothLength);
-        _overbought = overbought;
-        _oversold = oversold;
-        _upperNeutralZone = upperNeutralZone;
-        _lowerNeutralZone = lowerNeutralZone;
-        _rsi = new RsiState(maType, resolved);
-        _obSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
-        _osSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
-        _nzuSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
-        _nzlSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WilsonRelativePriceChannel;
 
     public void Reset()
@@ -1501,23 +1263,6 @@ public sealed class WindowedVolumeWeightedMovingAverageState : IStreamingIndicat
         _hanningWSum = new RollingWindowSum(_length);
         _hanningVWSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public WindowedVolumeWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _bartlettWSum = new RollingWindowSum(_length);
-        _bartlettVWSum = new RollingWindowSum(_length);
-        _blackmanWSum = new RollingWindowSum(_length);
-        _blackmanVWSum = new RollingWindowSum(_length);
-        _hanningWSum = new RollingWindowSum(_length);
-        _hanningVWSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.WindowedVolumeWeightedMovingAverage;
@@ -1596,18 +1341,6 @@ public sealed class WoodieCommodityChannelIndexState : IStreamingIndicatorState,
     {
         _slowCci = new CommodityChannelIndexState(InputName.TypicalPrice, maType, Math.Max(1, slowLength), 0.015);
         _fastCci = new CommodityChannelIndexState(InputName.TypicalPrice, maType, Math.Max(1, fastLength), 0.015);
-    }
-
-    public WoodieCommodityChannelIndexState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _slowCci = new CommodityChannelIndexState(InputName.Close, maType, Math.Max(1, slowLength), 0.015, selector);
-        _fastCci = new CommodityChannelIndexState(InputName.Close, maType, Math.Max(1, fastLength), 0.015, selector);
     }
 
     public IndicatorName Name => IndicatorName.WoodieCommodityChannelIndex;
@@ -1729,12 +1462,6 @@ public sealed class ZDistanceFromVwapState : IStreamingIndicatorState, IDisposab
     {
     }
 
-    public ZDistanceFromVwapState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-        : this(maType, length, new StreamingInputResolver(InputName.Close,
-            selector ?? throw new ArgumentNullException(nameof(selector))))
-    {
-    }
-
     private ZDistanceFromVwapState(MovingAvgType maType, int length, StreamingInputResolver input)
     {
         var resolved = Math.Max(1, length);
@@ -1799,22 +1526,6 @@ public sealed class ZeroLagExponentialMovingAverageState : IStreamingIndicatorSt
         _ema1 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ZeroLagExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedType = maType == MovingAvgType.ZeroLagExponentialMovingAverage
-            ? MovingAvgType.ExponentialMovingAverage
-            : maType;
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLagExponentialMovingAverage;
@@ -1883,26 +1594,6 @@ public sealed class ZeroLagSmoothedCycleState : IStreamingIndicatorState, IDispo
         _lcoSum = new RollingWindowSum(_length1);
         _lcoSmaSum = new RollingWindowSum(_length1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ZeroLagSmoothedCycleState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _length1 = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
-        _linreg = new LinearRegressionState(_length, selector);
-        _linregAx1 = new LinearRegressionState(_length, _ => _ax1Value);
-        _linregLx1 = new LinearRegressionState(_length, _ => _lx1Value);
-        _linregAx2 = new LinearRegressionState(_length, _ => _ax2Value);
-        _linregLx2 = new LinearRegressionState(_length, _ => _lx2Value);
-        _linregAx3 = new LinearRegressionState(_length, _ => _ax3Value);
-        _lcoSum = new RollingWindowSum(_length1);
-        _lcoSmaSum = new RollingWindowSum(_length1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLagSmoothedCycle;
@@ -1989,22 +1680,6 @@ public sealed class ZeroLagTripleExponentialMovingAverageState : IStreamingIndic
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ZeroLagTripleExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedType = maType == MovingAvgType.ZeroLagTripleExponentialMovingAverage
-            ? MovingAvgType.TripleExponentialMovingAverage
-            : maType;
-        var resolved = Math.Max(1, length);
-        _tma1 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _tma2 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ZeroLagTripleExponentialMovingAverage;
 
     public void Reset()
@@ -2058,21 +1733,6 @@ public sealed class ZeroLowLagMovingAverageState : IStreamingIndicatorState, IDi
         _aValues = new PooledRingBuffer<double>(_length + 1);
         _bValues = new PooledRingBuffer<double>(_lbLength + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ZeroLowLagMovingAverageState(int length, double lag, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _lbLength = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
-        _lag = lag;
-        _aValues = new PooledRingBuffer<double>(_length + 1);
-        _bValues = new PooledRingBuffer<double>(_lbLength + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLowLagMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch27.cs
+++ b/src/Streaming/StatefulIndicators.Batch27.cs
@@ -22,8 +22,7 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
     private double _prevVave;
     private bool _hasPrev;
 
-    public VolumeFlowIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.TypicalPrice, int length1 = 130, int length2 = 30,
+    public VolumeFlowIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 130, int length2 = 30,
         int signalLength = 5, int smoothLength = 3, double coef = 0.2, double vcoef = 2.5)
     {
         _length1 = Math.Max(1, length1);
@@ -35,7 +34,7 @@ public sealed class VolumeFlowIndicatorState : IStreamingIndicatorState, IDispos
         _volumeMa = MovingAverageSmootherFactory.Create(maType, _length1);
         _vfiMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _signalMa = MovingAverageSmootherFactory.Create(MovingAvgType.ExponentialMovingAverage, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeFlowIndicator;
@@ -120,8 +119,7 @@ public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorSt
     private double _prevClose;
     private bool _hasPrev;
 
-    public VolumePositiveNegativeIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        InputName inputName = InputName.TypicalPrice, int length = 30, int smoothLength = 3)
+    public VolumePositiveNegativeIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 30, int smoothLength = 3)
     {
         _length = Math.Max(1, length);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, _length);
@@ -129,7 +127,7 @@ public sealed class VolumePositiveNegativeIndicatorState : IStreamingIndicatorSt
         _vpnSmooth = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _vmpSum = new RollingWindowSum(_length);
         _vmnSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumePositiveNegativeIndicator;
@@ -215,7 +213,7 @@ public sealed class VolumePriceConfirmationIndicatorState : IStreamingIndicatorS
     private readonly StreamingInputResolver _input;
 
     public VolumePriceConfirmationIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 5,
-        int slowLength = 20, int length = 8, InputName inputName = InputName.Close)
+        int slowLength = 20, int length = 8)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -229,7 +227,7 @@ public sealed class VolumePriceConfirmationIndicatorState : IStreamingIndicatorS
         _smaFast = MovingAverageSmootherFactory.Create(maType, resolvedFast);
         _smaSlow = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _vpciMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumePriceConfirmationIndicator;
@@ -307,9 +305,9 @@ public sealed class VolumeWeightedAveragePriceState : IStreamingIndicatorState, 
     private double _cumVolume;
     private double _cumVolumePrice;
 
-    public VolumeWeightedAveragePriceState(InputName inputName = InputName.TypicalPrice)
+    public VolumeWeightedAveragePriceState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedAveragePrice;
@@ -356,13 +354,12 @@ public sealed class VolumeWeightedMovingAverageState : IStreamingIndicatorState,
     private readonly IMovingAverageSmoother _volumeMa;
     private readonly StreamingInputResolver _input;
 
-    public VolumeWeightedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public VolumeWeightedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _volumePriceSum = new RollingWindowSum(resolved);
         _volumeMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedMovingAverage;
@@ -412,13 +409,13 @@ public sealed class VolumeWeightedRelativeStrengthIndexState : IStreamingIndicat
     private bool _hasPrev;
 
     public VolumeWeightedRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 10,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         var resolved = Math.Max(1, length);
         _upMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _downMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _smoothMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolumeWeightedRelativeStrengthIndex;
@@ -479,13 +476,12 @@ public sealed class VortexBandsState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _diffMa;
     private readonly StreamingInputResolver _input;
 
-    public VortexBandsState(MovingAvgType maType = MovingAvgType.McNichollMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public VortexBandsState(MovingAvgType maType = MovingAvgType.McNichollMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _basisMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _diffMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VortexBands;
@@ -539,14 +535,14 @@ public sealed class VostroIndicatorState : IStreamingIndicatorState, IDisposable
     private double _prevIBuff112;
 
     public VostroIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length1 = 5,
-        int length2 = 100, double level = 8, InputName inputName = InputName.Close)
+        int length2 = 100, double level = 8)
     {
         _length1 = Math.Max(1, length1);
         _level = level;
         _tempSum = new RollingWindowSum(_length1);
         _rangeSum = new RollingWindowSum(_length1);
         _wma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VostroIndicator;
@@ -621,8 +617,7 @@ public sealed class WaddahAttarExplosionState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public WaddahAttarExplosionState(int fastLength = 20, int slowLength = 40, double sensitivity = 150,
-        InputName inputName = InputName.Close)
+    public WaddahAttarExplosionState(int fastLength = 20, int slowLength = 40, double sensitivity = 150)
     {
         _bbLength = Math.Max(1, fastLength);
         var resolvedFast = Math.Max(1, fastLength);
@@ -633,7 +628,7 @@ public sealed class WaddahAttarExplosionState : IStreamingIndicatorState, IDispo
         _macd3 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
         _macd4 = new MacdEngine(MovingAvgType.ExponentialMovingAverage, resolvedFast, resolvedSlow, 9);
         _bbWindow = new RollingWindowStats(_bbLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -716,12 +711,12 @@ public sealed class WamiOscillatorState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public WamiOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 13,
-        int length2 = 4, InputName inputName = InputName.Close)
+        int length2 = 4)
     {
         _diffWma = MovingAverageSmootherFactory.Create(MovingAvgType.WeightedMovingAverage, Math.Max(1, length2));
         _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WamiOscillator;
@@ -779,15 +774,14 @@ public sealed class WaveTrendOscillatorState : IStreamingIndicatorState, IDispos
     private readonly IMovingAverageSmoother _wt2Ma;
     private StreamingInputResolver _input;
 
-    public WaveTrendOscillatorState(InputName inputName = InputName.FullTypicalPrice,
-        MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 10, int length2 = 21,
+    public WaveTrendOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 10, int length2 = 21,
         int smoothLength = 4)
     {
         _esaMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _dMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _tciMa = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _wt2Ma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.WaveTrendOscillator;
@@ -841,10 +835,10 @@ public sealed class WellesWilderSummationState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private double _prevSum;
 
-    public WellesWilderSummationState(int length = 14, InputName inputName = InputName.Close)
+    public WellesWilderSummationState(int length = 14)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WellesWilderSummation;
@@ -889,7 +883,7 @@ public sealed class WellesWilderVolatilitySystemState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public WellesWilderVolatilitySystemState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 63,
-        int length2 = 21, double factor = 3, InputName inputName = InputName.Close)
+        int length2 = 21, double factor = 3)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -898,7 +892,7 @@ public sealed class WellesWilderVolatilitySystemState : IStreamingIndicatorState
         _ema = MovingAverageSmootherFactory.Create(maType, resolved1);
         _maxWindow = new RollingWindowMax(resolved2);
         _minWindow = new RollingWindowMin(resolved2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WellesWilderVolatilitySystem;
@@ -966,11 +960,11 @@ public sealed class WellRoundedMovingAverageState : IStreamingIndicatorState
     private double _prevYEma;
     private bool _hasPrev;
 
-    public WellRoundedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public WellRoundedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _alpha = 2d / (_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WellRoundedMovingAverage;
@@ -1175,7 +1169,7 @@ public sealed class WilsonRelativePriceChannelState : IStreamingIndicatorState, 
 
     public WilsonRelativePriceChannelState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 34,
         int smoothLength = 1, double overbought = 70, double oversold = 30, double upperNeutralZone = 55,
-        double lowerNeutralZone = 45, InputName inputName = InputName.Close)
+        double lowerNeutralZone = 45)
     {
         var resolved = Math.Max(1, length);
         var smooth = Math.Max(1, smoothLength);
@@ -1188,7 +1182,7 @@ public sealed class WilsonRelativePriceChannelState : IStreamingIndicatorState, 
         _osSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
         _nzuSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
         _nzlSmooth = MovingAverageSmootherFactory.Create(maType, smooth);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WilsonRelativePriceChannel;
@@ -1253,7 +1247,7 @@ public sealed class WindowedVolumeWeightedMovingAverageState : IStreamingIndicat
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public WindowedVolumeWeightedMovingAverageState(int length = 100, InputName inputName = InputName.Close)
+    public WindowedVolumeWeightedMovingAverageState(int length = 100)
     {
         _length = Math.Max(1, length);
         _bartlettWSum = new RollingWindowSum(_length);
@@ -1262,7 +1256,7 @@ public sealed class WindowedVolumeWeightedMovingAverageState : IStreamingIndicat
         _blackmanVWSum = new RollingWindowSum(_length);
         _hanningWSum = new RollingWindowSum(_length);
         _hanningVWSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WindowedVolumeWeightedMovingAverage;
@@ -1339,8 +1333,8 @@ public sealed class WoodieCommodityChannelIndexState : IStreamingIndicatorState,
     public WoodieCommodityChannelIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
         int fastLength = 6, int slowLength = 14)
     {
-        _slowCci = new CommodityChannelIndexState(InputName.TypicalPrice, maType, Math.Max(1, slowLength), 0.015);
-        _fastCci = new CommodityChannelIndexState(InputName.TypicalPrice, maType, Math.Max(1, fastLength), 0.015);
+        _slowCci = new CommodityChannelIndexState(maType, Math.Max(1, slowLength), 0.015);
+        _fastCci = new CommodityChannelIndexState(maType, Math.Max(1, fastLength), 0.015);
     }
 
     public IndicatorName Name => IndicatorName.WoodieCommodityChannelIndex;
@@ -1456,9 +1450,8 @@ public sealed class ZDistanceFromVwapState : IStreamingIndicatorState, IDisposab
     private readonly RollingZScore _zScore;
     private StreamingInputResolver _input;
 
-    public ZDistanceFromVwapState(MovingAvgType maType = MovingAvgType.VolumeWeightedAveragePrice, int length = 20,
-        InputName inputName = InputName.Close)
-        : this(maType, length, new StreamingInputResolver(inputName, null))
+    public ZDistanceFromVwapState(MovingAvgType maType = MovingAvgType.VolumeWeightedAveragePrice, int length = 20)
+        : this(maType, length, new StreamingInputResolver(InputName.Close, null))
     {
     }
 
@@ -1516,8 +1509,7 @@ public sealed class ZeroLagExponentialMovingAverageState : IStreamingIndicatorSt
     private readonly IMovingAverageSmoother _ema2;
     private readonly StreamingInputResolver _input;
 
-    public ZeroLagExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public ZeroLagExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         var resolvedType = maType == MovingAvgType.ZeroLagExponentialMovingAverage
             ? MovingAvgType.ExponentialMovingAverage
@@ -1525,7 +1517,7 @@ public sealed class ZeroLagExponentialMovingAverageState : IStreamingIndicatorSt
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLagExponentialMovingAverage;
@@ -1581,11 +1573,11 @@ public sealed class ZeroLagSmoothedCycleState : IStreamingIndicatorState, IDispo
     private double _lx2Value;
     private double _ax3Value;
 
-    public ZeroLagSmoothedCycleState(int length = 100, InputName inputName = InputName.Close)
+    public ZeroLagSmoothedCycleState(int length = 100)
     {
         _length = Math.Max(1, length);
         _length1 = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
-        _linreg = new LinearRegressionState(_length, inputName);
+        _linreg = new LinearRegressionState(_length);
         _linregAx1 = new LinearRegressionState(_length, _ => _ax1Value);
         _linregLx1 = new LinearRegressionState(_length, _ => _lx1Value);
         _linregAx2 = new LinearRegressionState(_length, _ => _ax2Value);
@@ -1593,7 +1585,7 @@ public sealed class ZeroLagSmoothedCycleState : IStreamingIndicatorState, IDispo
         _linregAx3 = new LinearRegressionState(_length, _ => _ax3Value);
         _lcoSum = new RollingWindowSum(_length1);
         _lcoSmaSum = new RollingWindowSum(_length1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLagSmoothedCycle;
@@ -1668,8 +1660,7 @@ public sealed class ZeroLagTripleExponentialMovingAverageState : IStreamingIndic
     private readonly IMovingAverageSmoother _tma2;
     private readonly StreamingInputResolver _input;
 
-    public ZeroLagTripleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public ZeroLagTripleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.TripleExponentialMovingAverage, int length = 14)
     {
         var resolvedType = maType == MovingAvgType.ZeroLagTripleExponentialMovingAverage
             ? MovingAvgType.TripleExponentialMovingAverage
@@ -1677,7 +1668,7 @@ public sealed class ZeroLagTripleExponentialMovingAverageState : IStreamingIndic
         var resolved = Math.Max(1, length);
         _tma1 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
         _tma2 = MovingAverageSmootherFactory.Create(resolvedType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLagTripleExponentialMovingAverage;
@@ -1725,14 +1716,14 @@ public sealed class ZeroLowLagMovingAverageState : IStreamingIndicatorState, IDi
     private int _index;
     private double _prevA;
 
-    public ZeroLowLagMovingAverageState(int length = 50, double lag = 1.4, InputName inputName = InputName.Close)
+    public ZeroLowLagMovingAverageState(int length = 50, double lag = 1.4)
     {
         _length = Math.Max(1, length);
         _lbLength = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
         _lag = lag;
         _aValues = new PooledRingBuffer<double>(_length + 1);
         _bValues = new PooledRingBuffer<double>(_lbLength + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZeroLowLagMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch28.cs
+++ b/src/Streaming/StatefulIndicators.Batch28.cs
@@ -11,13 +11,12 @@ public sealed class ZScoreState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private double _inputValue;
 
-    public ZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public ZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _meanMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _inputValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZScore;
@@ -66,13 +65,13 @@ public sealed class ZweigMarketBreadthIndicatorState : IStreamingIndicatorState,
     private bool _hasPrev;
 
     public ZweigMarketBreadthIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 10, InputName inputName = InputName.Close)
+        int length = 10)
     {
         var resolved = Math.Max(1, length);
         _advances = new RollingWindowSum(resolved);
         _declines = new RollingWindowSum(resolved);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ZweigMarketBreadthIndicator;

--- a/src/Streaming/StatefulIndicators.Batch28.cs
+++ b/src/Streaming/StatefulIndicators.Batch28.cs
@@ -20,19 +20,6 @@ public sealed class ZScoreState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ZScoreState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _inputValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ZScore;
 
     public void Reset()
@@ -86,20 +73,6 @@ public sealed class ZweigMarketBreadthIndicatorState : IStreamingIndicatorState,
         _declines = new RollingWindowSum(resolved);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ZweigMarketBreadthIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _advances = new RollingWindowSum(resolved);
-        _declines = new RollingWindowSum(resolved);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ZweigMarketBreadthIndicator;

--- a/src/Streaming/StatefulIndicators.Batch29.cs
+++ b/src/Streaming/StatefulIndicators.Batch29.cs
@@ -27,10 +27,9 @@ public sealed class SchaffTrendCycleShkState : IStreamingIndicatorState, IDispos
     private bool _hasPrev;
 
     public SchaffTrendCycleShkState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 23, int slowLength = 50, int cycleLength = 10, int d1Length = 3, int d2Length = 3,
-        InputName inputName = InputName.Close)
+        int fastLength = 23, int slowLength = 50, int cycleLength = 10, int d1Length = 3, int d2Length = 3)
         : this(maType, fastLength, slowLength, cycleLength, d1Length, d2Length,
-            new StreamingInputResolver(inputName, null))
+            new StreamingInputResolver(InputName.Close, null))
     {
     }
 
@@ -144,8 +143,8 @@ public sealed class UtBotAlertsState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public UtBotAlertsState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 10,
-        double keyValue = 1, InputName inputName = InputName.Close)
-        : this(maType, length, keyValue, new StreamingInputResolver(inputName, null))
+        double keyValue = 1)
+        : this(maType, length, keyValue, new StreamingInputResolver(InputName.Close, null))
     {
     }
 

--- a/src/Streaming/StatefulIndicators.Batch29.cs
+++ b/src/Streaming/StatefulIndicators.Batch29.cs
@@ -34,14 +34,6 @@ public sealed class SchaffTrendCycleShkState : IStreamingIndicatorState, IDispos
     {
     }
 
-    public SchaffTrendCycleShkState(MovingAvgType maType, int fastLength, int slowLength, int cycleLength,
-        int d1Length, int d2Length, Func<OhlcvBar, double> selector)
-        : this(maType, fastLength, slowLength, cycleLength, d1Length, d2Length,
-            new StreamingInputResolver(InputName.Close,
-                selector ?? throw new ArgumentNullException(nameof(selector))))
-    {
-    }
-
     private SchaffTrendCycleShkState(MovingAvgType maType, int fastLength, int slowLength, int cycleLength,
         int d1Length, int d2Length, StreamingInputResolver input)
     {
@@ -154,14 +146,6 @@ public sealed class UtBotAlertsState : IStreamingIndicatorState, IDisposable
     public UtBotAlertsState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 10,
         double keyValue = 1, InputName inputName = InputName.Close)
         : this(maType, length, keyValue, new StreamingInputResolver(inputName, null))
-    {
-    }
-
-    public UtBotAlertsState(MovingAvgType maType, int length, double keyValue,
-        Func<OhlcvBar, double> selector)
-        : this(maType, length, keyValue,
-            new StreamingInputResolver(InputName.Close,
-                selector ?? throw new ArgumentNullException(nameof(selector))))
     {
     }
 

--- a/src/Streaming/StatefulIndicators.Batch5.cs
+++ b/src/Streaming/StatefulIndicators.Batch5.cs
@@ -36,25 +36,6 @@ public sealed class CoralTrendIndicatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public CoralTrendIndicatorState(int length, double cd, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var di = ((double)(resolved - 1) / 2) + 1;
-        _c1 = 2 / (di + 1);
-        _c2 = 1 - _c1;
-        var cdSquared = cd * cd;
-        _cdCube = cdSquared * cd;
-        _c3 = 3 * (cdSquared + _cdCube);
-        _c4 = -3 * ((2 * cdSquared) + cd + _cdCube);
-        _c5 = (3 * cd) + 1 + _cdCube + (3 * cdSquared);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.CoralTrendIndicator;
 
     public void Reset()
@@ -121,22 +102,6 @@ public sealed class DecisionPointPriceMomentumOscillatorState : IStreamingIndica
         _smPmol = (double)2 / resolved2;
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DecisionPointPriceMomentumOscillatorState(MovingAvgType maType, int length1, int length2, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _smPmol2 = (double)2 / resolved1;
-        _smPmol = (double)2 / resolved2;
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DecisionPointPriceMomentumOscillator;
@@ -536,19 +501,6 @@ public sealed class DemarkReversalPointsState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DemarkReversalPointsState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _values = new PooledRingBuffer<double>(_length1 + _length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DemarkReversalPoints;
 
     public void Reset()
@@ -608,18 +560,6 @@ public sealed class DemarkSetupIndicatorState : IStreamingIndicatorState, IDispo
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length * 2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DemarkSetupIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DemarkSetupIndicator;
@@ -689,19 +629,6 @@ public sealed class DiNapoliMovingAverageConvergenceDivergenceState : IStreaming
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DiNapoliMovingAverageConvergenceDivergenceState(double lc, double sc, double sp, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _scAlpha = 2 / (1 + sc);
-        _lcAlpha = 2 / (1 + lc);
-        _spAlpha = 2 / (1 + sp);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DiNapoliMovingAverageConvergenceDivergence;
 
     public void Reset()
@@ -761,19 +688,6 @@ public sealed class DiNapoliPercentagePriceOscillatorState : IStreamingIndicator
         _lcAlpha = 2 / (1 + lc);
         _spAlpha = 2 / (1 + sp);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DiNapoliPercentagePriceOscillatorState(double lc, double sc, double sp, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _scAlpha = 2 / (1 + sc);
-        _lcAlpha = 2 / (1 + lc);
-        _spAlpha = 2 / (1 + sp);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DiNapoliPercentagePriceOscillator;
@@ -838,22 +752,6 @@ public sealed class DiNapoliPreferredStochasticOscillatorState : IStreamingIndic
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DiNapoliPreferredStochasticOscillatorState(int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _length3 = Math.Max(1, length3);
-        var resolved1 = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved1);
-        _lowWindow = new RollingWindowMin(resolved1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DiNapoliPreferredStochasticOscillator;
 
     public void Reset()
@@ -911,18 +809,6 @@ public sealed class DistanceWeightedMovingAverageState : IStreamingIndicatorStat
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DistanceWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DistanceWeightedMovingAverage;
@@ -1101,19 +987,6 @@ public sealed class DoubleExponentialMovingAverageState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DoubleExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DoubleExponentialMovingAverage;
 
     public void Reset()
@@ -1161,18 +1034,6 @@ public sealed class DoubleExponentialSmoothingState : IStreamingIndicatorState
         _alpha = alpha;
         _gamma = gamma;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DoubleExponentialSmoothingState(double alpha, double gamma, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = alpha;
-        _gamma = gamma;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DoubleExponentialSmoothing;
@@ -1233,27 +1094,6 @@ public sealed class DoubleSmoothedRelativeStrengthIndexState : IStreamingIndicat
         _botSmoother2 = MovingAverageSmootherFactory.Create(maType, resolved3);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved3);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DoubleSmoothedRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        _maxWindow = new RollingWindowMax(resolved1);
-        _minWindow = new RollingWindowMin(resolved1);
-        _topSmoother1 = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _topSmoother2 = MovingAverageSmootherFactory.Create(maType, resolved3);
-        _botSmoother1 = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _botSmoother2 = MovingAverageSmootherFactory.Create(maType, resolved3);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DoubleSmoothedRelativeStrengthIndex;
@@ -1335,25 +1175,6 @@ public sealed class DoubleSmoothedStochasticState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DoubleSmoothedStochasticState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved1);
-        _lowWindow = new RollingWindowMin(resolved1);
-        _ssNum = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ssDenom = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _dsNum = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _dsDenom = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DoubleSmoothedStochastic;
 
     public void Reset()
@@ -1424,22 +1245,6 @@ public sealed class DoubleStochasticOscillatorState : IStreamingIndicatorState, 
         _slowK = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _stochastic = new StochasticOscillatorState(maType, resolved, 3, 3, inputName);
-    }
-
-    public DoubleStochasticOscillatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(resolved);
-        _minWindow = new RollingWindowMin(resolved);
-        _slowK = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _stochastic = new StochasticOscillatorState(maType, resolved, 3, 3, selector);
     }
 
     public IndicatorName Name => IndicatorName.DoubleStochasticOscillator;

--- a/src/Streaming/StatefulIndicators.Batch5.cs
+++ b/src/Streaming/StatefulIndicators.Batch5.cs
@@ -22,7 +22,7 @@ public sealed class CoralTrendIndicatorState : IStreamingIndicatorState
     private double _i6;
     private readonly StreamingInputResolver _input;
 
-    public CoralTrendIndicatorState(int length = 21, double cd = 0.4, InputName inputName = InputName.Close)
+    public CoralTrendIndicatorState(int length = 21, double cd = 0.4)
     {
         var resolved = Math.Max(1, length);
         var di = ((double)(resolved - 1) / 2) + 1;
@@ -33,7 +33,7 @@ public sealed class CoralTrendIndicatorState : IStreamingIndicatorState
         _c3 = 3 * (cdSquared + _cdCube);
         _c4 = -3 * ((2 * cdSquared) + cd + _cdCube);
         _c5 = (3 * cd) + 1 + _cdCube + (3 * cdSquared);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CoralTrendIndicator;
@@ -94,14 +94,14 @@ public sealed class DecisionPointPriceMomentumOscillatorState : IStreamingIndica
     private bool _hasPrev;
 
     public DecisionPointPriceMomentumOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 35, int length2 = 20, int signalLength = 10, InputName inputName = InputName.Close)
+        int length1 = 35, int length2 = 20, int signalLength = 10)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
         _smPmol2 = (double)2 / resolved1;
         _smPmol = (double)2 / resolved2;
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DecisionPointPriceMomentumOscillator;
@@ -493,12 +493,12 @@ public sealed class DemarkReversalPointsState : IStreamingIndicatorState, IDispo
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public DemarkReversalPointsState(int length1 = 9, int length2 = 4, InputName inputName = InputName.Close)
+    public DemarkReversalPointsState(int length1 = 9, int length2 = 4)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
         _values = new PooledRingBuffer<double>(_length1 + _length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DemarkReversalPoints;
@@ -555,11 +555,11 @@ public sealed class DemarkSetupIndicatorState : IStreamingIndicatorState, IDispo
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public DemarkSetupIndicatorState(int length = 4, InputName inputName = InputName.Close)
+    public DemarkSetupIndicatorState(int length = 4)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DemarkSetupIndicator;
@@ -620,13 +620,12 @@ public sealed class DiNapoliMovingAverageConvergenceDivergenceState : IStreaming
     private double _slow;
     private double _signal;
 
-    public DiNapoliMovingAverageConvergenceDivergenceState(double lc = 17.5185, double sc = 8.3896, double sp = 9.0503,
-        InputName inputName = InputName.Close)
+    public DiNapoliMovingAverageConvergenceDivergenceState(double lc = 17.5185, double sc = 8.3896, double sp = 9.0503)
     {
         _scAlpha = 2 / (1 + sc);
         _lcAlpha = 2 / (1 + lc);
         _spAlpha = 2 / (1 + sp);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DiNapoliMovingAverageConvergenceDivergence;
@@ -681,13 +680,12 @@ public sealed class DiNapoliPercentagePriceOscillatorState : IStreamingIndicator
     private double _slow;
     private double _signal;
 
-    public DiNapoliPercentagePriceOscillatorState(double lc = 17.5185, double sc = 8.3896, double sp = 9.0503,
-        InputName inputName = InputName.Close)
+    public DiNapoliPercentagePriceOscillatorState(double lc = 17.5185, double sc = 8.3896, double sp = 9.0503)
     {
         _scAlpha = 2 / (1 + sc);
         _lcAlpha = 2 / (1 + lc);
         _spAlpha = 2 / (1 + sp);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DiNapoliPercentagePriceOscillator;
@@ -741,15 +739,14 @@ public sealed class DiNapoliPreferredStochasticOscillatorState : IStreamingIndic
     private double _r;
     private double _s;
 
-    public DiNapoliPreferredStochasticOscillatorState(int length1 = 8, int length2 = 3, int length3 = 3,
-        InputName inputName = InputName.Close)
+    public DiNapoliPreferredStochasticOscillatorState(int length1 = 8, int length2 = 3, int length3 = 3)
     {
         _length2 = Math.Max(1, length2);
         _length3 = Math.Max(1, length3);
         var resolved1 = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved1);
         _lowWindow = new RollingWindowMin(resolved1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DiNapoliPreferredStochasticOscillator;
@@ -804,11 +801,11 @@ public sealed class DistanceWeightedMovingAverageState : IStreamingIndicatorStat
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public DistanceWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public DistanceWeightedMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DistanceWeightedMovingAverage;
@@ -978,13 +975,12 @@ public sealed class DoubleExponentialMovingAverageState : IStreamingIndicatorSta
     private readonly IMovingAverageSmoother _ema2;
     private readonly StreamingInputResolver _input;
 
-    public DoubleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public DoubleExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _ema1 = MovingAverageSmootherFactory.Create(maType, resolved);
         _ema2 = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DoubleExponentialMovingAverage;
@@ -1029,11 +1025,11 @@ public sealed class DoubleExponentialSmoothingState : IStreamingIndicatorState
     private double _prevS;
     private double _prevS2;
 
-    public DoubleExponentialSmoothingState(double alpha = 0.01, double gamma = 0.9, InputName inputName = InputName.Close)
+    public DoubleExponentialSmoothingState(double alpha = 0.01, double gamma = 0.9)
     {
         _alpha = alpha;
         _gamma = gamma;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DoubleExponentialSmoothing;
@@ -1081,7 +1077,7 @@ public sealed class DoubleSmoothedRelativeStrengthIndexState : IStreamingIndicat
     private readonly StreamingInputResolver _input;
 
     public DoubleSmoothedRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 2, int length2 = 5, int length3 = 25, InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 5, int length3 = 25)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -1093,7 +1089,7 @@ public sealed class DoubleSmoothedRelativeStrengthIndexState : IStreamingIndicat
         _botSmoother1 = MovingAverageSmootherFactory.Create(maType, resolved2);
         _botSmoother2 = MovingAverageSmootherFactory.Create(maType, resolved3);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DoubleSmoothedRelativeStrengthIndex;
@@ -1162,7 +1158,7 @@ public sealed class DoubleSmoothedStochasticState : IStreamingIndicatorState, ID
     private readonly StreamingInputResolver _input;
 
     public DoubleSmoothedStochasticState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 2,
-        int length2 = 3, int length3 = 15, int length4 = 3, InputName inputName = InputName.Close)
+        int length2 = 3, int length3 = 15, int length4 = 3)
     {
         var resolved1 = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved1);
@@ -1172,7 +1168,7 @@ public sealed class DoubleSmoothedStochasticState : IStreamingIndicatorState, ID
         _dsNum = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _dsDenom = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DoubleSmoothedStochastic;
@@ -1237,14 +1233,14 @@ public sealed class DoubleStochasticOscillatorState : IStreamingIndicatorState, 
     private readonly StochasticOscillatorState _stochastic;
 
     public DoubleStochasticOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         var resolved = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(resolved);
         _minWindow = new RollingWindowMin(resolved);
         _slowK = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _stochastic = new StochasticOscillatorState(maType, resolved, 3, 3, inputName);
+        _stochastic = new StochasticOscillatorState(maType, resolved, 3, 3);
     }
 
     public IndicatorName Name => IndicatorName.DoubleStochasticOscillator;

--- a/src/Streaming/StatefulIndicators.Batch6.cs
+++ b/src/Streaming/StatefulIndicators.Batch6.cs
@@ -146,51 +146,6 @@ public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDispos
         _value70Window = new RollingWindowSum(Math.Max(1, _length));
     }
 
-    public ConfluenceIndicatorState(MovingAvgType maType, InputName inputName, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stl = (int)Math.Ceiling((_length * 2) - 1 - 0.5m);
-        _itl = (int)Math.Ceiling((_stl * 2) - 1 - 0.5m);
-        _ltl = (int)Math.Ceiling((_itl * 2) - 1 - 0.5m);
-        _hoff = (int)Math.Ceiling(((double)_length / 2) - 0.5);
-        _soff = (int)Math.Ceiling(((double)_stl / 2) - 0.5);
-        _ioff = (int)Math.Ceiling(((double)_itl / 2) - 0.5);
-        _hLength = MathHelper.MinOrMax(_length - 1);
-        _sLength = _stl - 1;
-        _iLength = _itl - 1;
-        _lLength = _ltl - 1;
-
-        _hAvg = MovingAverageSmootherFactory.Create(maType, _length);
-        _sAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _stl));
-        _iAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _itl));
-        _lAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _ltl));
-        _h2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _hLength));
-        _s2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _sLength));
-        _i2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _iLength));
-        _l2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _lLength));
-        _ftpAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _lLength));
-        _input = new StreamingInputResolver(inputName, selector);
-
-        var maxOffset = Math.Max(Math.Max(_hoff, _soff), _ioff);
-        var capacity = Math.Max(1, maxOffset);
-        _hAvgValues = new PooledRingBuffer<double>(capacity);
-        _sAvgValues = new PooledRingBuffer<double>(capacity);
-        _iAvgValues = new PooledRingBuffer<double>(capacity);
-        _lAvgValues = new PooledRingBuffer<double>(capacity);
-        _value5Values = new PooledRingBuffer<double>(capacity);
-        _value6Values = new PooledRingBuffer<double>(capacity);
-        _value7Values = new PooledRingBuffer<double>(capacity);
-        _sumValues = new PooledRingBuffer<double>(capacity);
-        _errSumWindow = new RollingWindowSum(Math.Max(1, _soff));
-        _value70Window = new RollingWindowSum(Math.Max(1, _length));
-    }
-
     public IndicatorName Name => IndicatorName.ConfluenceIndicator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -428,28 +383,6 @@ public sealed class DampedSineWaveWeightedFilterState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DampedSineWaveWeightedFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _weights = new double[_length];
-        double sum = 0;
-        for (var j = 1; j <= _length; j++)
-        {
-            var w = Math.Sin(MathHelper.MinOrMax(2 * Math.PI * ((double)j / _length), 0.99, 0.01)) / j;
-            _weights[j - 1] = w;
-            sum += w;
-        }
-
-        _weightSum = sum;
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DampedSineWaveWeightedFilter;
 
     public void Reset()
@@ -525,21 +458,6 @@ public sealed class DecisionPointBreadthSwenlinTradingOscillatorState : IStreami
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DecisionPointBreadthSwenlinTradingOscillatorState(MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _firstSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _secondSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DecisionPointBreadthSwenlinTradingOscillator;
 
     public void Reset()
@@ -603,17 +521,6 @@ public sealed class DominantCycleTunedRelativeStrengthIndexState : IStreamingInd
     {
         _periodState = new AdaptiveCyberCyclePeriodState(length, 0.07);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DominantCycleTunedRelativeStrengthIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _periodState = new AdaptiveCyberCyclePeriodState(length, 0.07);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DominantCycleTunedRelativeStrengthIndex;
@@ -692,22 +599,6 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
         _highs = new PooledRingBuffer<double>(resolved);
         _lows = new PooledRingBuffer<double>(resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _length2 = length2;
-    }
-
-    public DrunkardWalkState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _highs = new PooledRingBuffer<double>(resolved);
-        _lows = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _length2 = length2;
     }
 
@@ -803,19 +694,6 @@ public sealed class DynamicallyAdjustableFilterState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DynamicallyAdjustableFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _srcWindow = new RollingWindowSum(_length);
-        _srcDevWindow = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DynamicallyAdjustableFilter;
 
     public void Reset()
@@ -890,21 +768,6 @@ public sealed class DynamicallyAdjustableMovingAverageState : IStreamingIndicato
         _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _fastLength, inputName);
         _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _slowLength, _ => _fastStdDevValue);
         _input = new StreamingInputResolver(inputName, null);
-        _kValues = new PooledRingBuffer<double>(_slowLength);
-    }
-
-    public DynamicallyAdjustableMovingAverageState(int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _slowLength = Math.Max(1, slowLength);
-        _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _fastLength, selector);
-        _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _slowLength, _ => _fastStdDevValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _kValues = new PooledRingBuffer<double>(_slowLength);
     }
 
@@ -987,26 +850,6 @@ public sealed class DynamicMomentumIndexState : IStreamingIndicatorState, IDispo
         _stdDevState = new StandardDeviationVolatilityState(maType, Math.Max(1, length1), inputName);
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _input = new StreamingInputResolver(inputName, null);
-        _gains = new PooledRingBuffer<double>(capacity);
-        _losses = new PooledRingBuffer<double>(capacity);
-        _dmiValues = new PooledRingBuffer<double>(capacity);
-    }
-
-    public DynamicMomentumIndexState(MovingAvgType maType, int length1, int length2, int length3, int upLimit,
-        int dnLimit, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length3 = Math.Max(1, length3);
-        _upLimit = Math.Max(1, upLimit);
-        _dnLimit = Math.Max(1, dnLimit);
-        var capacity = Math.Max(1, Math.Max(_upLimit, _dnLimit));
-        _stdDevState = new StandardDeviationVolatilityState(maType, Math.Max(1, length1), selector);
-        _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _gains = new PooledRingBuffer<double>(capacity);
         _losses = new PooledRingBuffer<double>(capacity);
         _dmiValues = new PooledRingBuffer<double>(capacity);
@@ -1114,21 +957,6 @@ public sealed class DynamicMomentumOscillatorState : IStreamingIndicatorState, I
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DynamicMomentumOscillatorState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DynamicMomentumOscillator;
@@ -1256,18 +1084,6 @@ public sealed class EarningSupportResistanceLevelsState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EarningSupportResistanceLevelsState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _inputValues = new PooledRingBuffer<double>(2);
-        _lowValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EarningSupportResistanceLevels;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1337,19 +1153,6 @@ public sealed class EdgePreservingFilterState : IStreamingIndicatorState, IDispo
         _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _regressionInput);
         _maxWindow = new RollingWindowMax(Math.Max(2, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EdgePreservingFilterState(MovingAvgType maType, int length, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _regressionInput);
-        _maxWindow = new RollingWindowMax(Math.Max(2, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EdgePreservingFilter;
@@ -1435,19 +1238,6 @@ public sealed class EfficientAutoLineState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EfficientAutoLineState(int length, double fastAlpha, double slowAlpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _er = new EfficiencyRatioState(Math.Max(1, length));
-        _fastAlpha = fastAlpha;
-        _slowAlpha = slowAlpha;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EfficientAutoLine;
 
     public void Reset()
@@ -1507,19 +1297,6 @@ public sealed class EfficientPriceState : IStreamingIndicatorState, IDisposable
         _er = new EfficiencyRatioState(_length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EfficientPriceState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _er = new EfficiencyRatioState(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EfficientPrice;
@@ -1585,21 +1362,6 @@ public sealed class EfficientTrendStepChannelState : IStreamingIndicatorState, I
         _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage,
             Math.Max(1, slowLength), _ => _stdDevInput);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EfficientTrendStepChannelState(int length, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _er = new EfficiencyRatioState(Math.Max(1, length));
-        _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage,
-            Math.Max(1, fastLength), _ => _stdDevInput);
-        _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage,
-            Math.Max(1, slowLength), _ => _stdDevInput);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EfficientTrendStepChannel;
@@ -1676,22 +1438,6 @@ public sealed class Ehlers2PoleButterworthFilterV1State : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Ehlers2PoleButterworthFilterV1State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * 1.25 * Math.PI / resolved, 0.99, 0.01));
-        _c2 = b;
-        _c3 = -a * a;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Ehlers2PoleButterworthFilterV1;
 
     public void Reset()
@@ -1748,23 +1494,6 @@ public sealed class Ehlers2PoleButterworthFilterV2State : IStreamingIndicatorSta
         _c3 = -a * a;
         _c1 = (1 - b + (a * a)) / 4;
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(3);
-    }
-
-    public Ehlers2PoleButterworthFilterV2State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / resolved, 0.99, 0.01));
-        _c2 = b;
-        _c3 = -a * a;
-        _c1 = (1 - b + (a * a)) / 4;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -1837,22 +1566,6 @@ public sealed class Ehlers2PoleSuperSmootherFilterV1State : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Ehlers2PoleSuperSmootherFilterV1State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / resolved, 0.99, 0.01));
-        _coef2 = b1;
-        _coef3 = -a1 * a1;
-        _coef1 = 1 - _coef2 - _coef3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Ehlers2PoleSuperSmootherFilterV1;
 
     public void Reset()
@@ -1910,22 +1623,6 @@ public sealed class Ehlers2PoleSuperSmootherFilterV2State : IStreamingIndicatorS
         _c3 = -a * a;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public Ehlers2PoleSuperSmootherFilterV2State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / resolved, 0.99, 0.01));
-        _c2 = b;
-        _c3 = -a * a;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers2PoleSuperSmootherFilterV2;

--- a/src/Streaming/StatefulIndicators.Batch6.cs
+++ b/src/Streaming/StatefulIndicators.Batch6.cs
@@ -106,8 +106,7 @@ public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDispos
     private double _prevMom;
     private double _prevValue70;
 
-    public ConfluenceIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.FullTypicalPrice, int length = 10)
+    public ConfluenceIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10)
     {
         _length = Math.Max(1, length);
         _stl = (int)Math.Ceiling((_length * 2) - 1 - 0.5m);
@@ -130,7 +129,7 @@ public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDispos
         _i2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _iLength));
         _l2Avg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _lLength));
         _ftpAvg = MovingAverageSmootherFactory.Create(maType, Math.Max(1, _lLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
 
         var maxOffset = Math.Max(Math.Max(_hoff, _soff), _ioff);
         var capacity = Math.Max(1, maxOffset);
@@ -366,7 +365,7 @@ public sealed class DampedSineWaveWeightedFilterState : IStreamingIndicatorState
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public DampedSineWaveWeightedFilterState(int length = 50, InputName inputName = InputName.Close)
+    public DampedSineWaveWeightedFilterState(int length = 50)
     {
         _length = Math.Max(1, length);
         _weights = new double[_length];
@@ -380,7 +379,7 @@ public sealed class DampedSineWaveWeightedFilterState : IStreamingIndicatorState
 
         _weightSum = sum;
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DampedSineWaveWeightedFilter;
@@ -449,13 +448,13 @@ public sealed class DecisionPointBreadthSwenlinTradingOscillatorState : IStreami
     private bool _hasPrev;
 
     public DecisionPointBreadthSwenlinTradingOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 5, InputName inputName = InputName.Close)
+        int length = 5)
     {
         var resolved = Math.Max(1, length);
         _firstSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _secondSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DecisionPointBreadthSwenlinTradingOscillator;
@@ -517,10 +516,10 @@ public sealed class DominantCycleTunedRelativeStrengthIndexState : IStreamingInd
     private double _prevB;
     private bool _hasPrev;
 
-    public DominantCycleTunedRelativeStrengthIndexState(int length = 5, InputName inputName = InputName.Close)
+    public DominantCycleTunedRelativeStrengthIndexState(int length = 5)
     {
         _periodState = new AdaptiveCyberCyclePeriodState(length, 0.07);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DominantCycleTunedRelativeStrengthIndex;
@@ -591,14 +590,14 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
     private double _prevAtrDn;
     private bool _hasPrev;
 
-    public DrunkardWalkState(int length1 = 80, int length2 = 14, InputName inputName = InputName.Close)
+    public DrunkardWalkState(int length1 = 80, int length2 = 14)
     {
         var resolved = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _highs = new PooledRingBuffer<double>(resolved);
         _lows = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _length2 = length2;
     }
 
@@ -686,12 +685,12 @@ public sealed class DynamicallyAdjustableFilterState : IStreamingIndicatorState,
     private double _prevK;
     private bool _hasPrev;
 
-    public DynamicallyAdjustableFilterState(int length = 14, InputName inputName = InputName.Close)
+    public DynamicallyAdjustableFilterState(int length = 14)
     {
         _length = Math.Max(1, length);
         _srcWindow = new RollingWindowSum(_length);
         _srcDevWindow = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DynamicallyAdjustableFilter;
@@ -760,14 +759,13 @@ public sealed class DynamicallyAdjustableMovingAverageState : IStreamingIndicato
     private double _tempSum;
     private double _fastStdDevValue;
 
-    public DynamicallyAdjustableMovingAverageState(int fastLength = 6, int slowLength = 200,
-        InputName inputName = InputName.Close)
+    public DynamicallyAdjustableMovingAverageState(int fastLength = 6, int slowLength = 200)
     {
         _fastLength = Math.Max(1, fastLength);
         _slowLength = Math.Max(1, slowLength);
-        _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _fastLength, inputName);
+        _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _fastLength);
         _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _slowLength, _ => _fastStdDevValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _kValues = new PooledRingBuffer<double>(_slowLength);
     }
 
@@ -841,15 +839,15 @@ public sealed class DynamicMomentumIndexState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public DynamicMomentumIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 5,
-        int length2 = 10, int length3 = 14, int upLimit = 30, int dnLimit = 5, InputName inputName = InputName.Close)
+        int length2 = 10, int length3 = 14, int upLimit = 30, int dnLimit = 5)
     {
         _length3 = Math.Max(1, length3);
         _upLimit = Math.Max(1, upLimit);
         _dnLimit = Math.Max(1, dnLimit);
         var capacity = Math.Max(1, Math.Max(_upLimit, _dnLimit));
-        _stdDevState = new StandardDeviationVolatilityState(maType, Math.Max(1, length1), inputName);
+        _stdDevState = new StandardDeviationVolatilityState(maType, Math.Max(1, length1));
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _gains = new PooledRingBuffer<double>(capacity);
         _losses = new PooledRingBuffer<double>(capacity);
         _dmiValues = new PooledRingBuffer<double>(capacity);
@@ -949,14 +947,14 @@ public sealed class DynamicMomentumOscillatorState : IStreamingIndicatorState, I
     private bool _hasStoch;
 
     public DynamicMomentumOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 10,
-        int length2 = 20, InputName inputName = InputName.Close)
+        int length2 = 20)
     {
         var resolved = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DynamicMomentumOscillator;
@@ -1077,11 +1075,11 @@ public sealed class EarningSupportResistanceLevelsState : IStreamingIndicatorSta
     private double _prevClose;
     private bool _hasPrev;
 
-    public EarningSupportResistanceLevelsState(InputName inputName = InputName.MedianPrice)
+    public EarningSupportResistanceLevelsState()
     {
         _inputValues = new PooledRingBuffer<double>(2);
         _lowValues = new PooledRingBuffer<double>(2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.EarningSupportResistanceLevels;
@@ -1147,12 +1145,12 @@ public sealed class EdgePreservingFilterState : IStreamingIndicatorState, IDispo
     private bool _hasPrev;
 
     public EdgePreservingFilterState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200,
-        int smoothLength = 50, InputName inputName = InputName.Close)
+        int smoothLength = 50)
     {
         _sma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _regression = new LinearRegressionState(Math.Max(1, smoothLength), _ => _regressionInput);
         _maxWindow = new RollingWindowMax(Math.Max(2, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EdgePreservingFilter;
@@ -1229,13 +1227,12 @@ public sealed class EfficientAutoLineState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
     private int _index;
 
-    public EfficientAutoLineState(int length = 19, double fastAlpha = 0.0001, double slowAlpha = 0.005,
-        InputName inputName = InputName.Close)
+    public EfficientAutoLineState(int length = 19, double fastAlpha = 0.0001, double slowAlpha = 0.005)
     {
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _fastAlpha = fastAlpha;
         _slowAlpha = slowAlpha;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EfficientAutoLine;
@@ -1291,12 +1288,12 @@ public sealed class EfficientPriceState : IStreamingIndicatorState, IDisposable
     private double _chgErSum;
     private int _index;
 
-    public EfficientPriceState(int length = 50, InputName inputName = InputName.Close)
+    public EfficientPriceState(int length = 50)
     {
         _length = Math.Max(1, length);
         _er = new EfficiencyRatioState(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EfficientPrice;
@@ -1353,15 +1350,14 @@ public sealed class EfficientTrendStepChannelState : IStreamingIndicatorState, I
     private double _prevA;
     private bool _hasPrev;
 
-    public EfficientTrendStepChannelState(int length = 100, int fastLength = 50, int slowLength = 200,
-        InputName inputName = InputName.Close)
+    public EfficientTrendStepChannelState(int length = 100, int fastLength = 50, int slowLength = 200)
     {
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _fastStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage,
             Math.Max(1, fastLength), _ => _stdDevInput);
         _slowStdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage,
             Math.Max(1, slowLength), _ => _stdDevInput);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EfficientTrendStepChannel;
@@ -1427,7 +1423,7 @@ public sealed class Ehlers2PoleButterworthFilterV1State : IStreamingIndicatorSta
     private double _prevFilter2;
     private bool _hasPrev;
 
-    public Ehlers2PoleButterworthFilterV1State(int length = 10, InputName inputName = InputName.Close)
+    public Ehlers2PoleButterworthFilterV1State(int length = 10)
     {
         var resolved = Math.Max(1, length);
         var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
@@ -1435,7 +1431,7 @@ public sealed class Ehlers2PoleButterworthFilterV1State : IStreamingIndicatorSta
         _c2 = b;
         _c3 = -a * a;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers2PoleButterworthFilterV1;
@@ -1485,7 +1481,7 @@ public sealed class Ehlers2PoleButterworthFilterV2State : IStreamingIndicatorSta
     private double _prevFilter2;
     private int _index;
 
-    public Ehlers2PoleButterworthFilterV2State(int length = 15, InputName inputName = InputName.Close)
+    public Ehlers2PoleButterworthFilterV2State(int length = 15)
     {
         var resolved = Math.Max(1, length);
         var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
@@ -1493,7 +1489,7 @@ public sealed class Ehlers2PoleButterworthFilterV2State : IStreamingIndicatorSta
         _c2 = b;
         _c3 = -a * a;
         _c1 = (1 - b + (a * a)) / 4;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -1555,7 +1551,7 @@ public sealed class Ehlers2PoleSuperSmootherFilterV1State : IStreamingIndicatorS
     private double _prevFilter2;
     private int _index;
 
-    public Ehlers2PoleSuperSmootherFilterV1State(int length = 15, InputName inputName = InputName.Close)
+    public Ehlers2PoleSuperSmootherFilterV1State(int length = 15)
     {
         var resolved = Math.Max(1, length);
         var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
@@ -1563,7 +1559,7 @@ public sealed class Ehlers2PoleSuperSmootherFilterV1State : IStreamingIndicatorS
         _coef2 = b1;
         _coef3 = -a1 * a1;
         _coef1 = 1 - _coef2 - _coef3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers2PoleSuperSmootherFilterV1;
@@ -1614,7 +1610,7 @@ public sealed class Ehlers2PoleSuperSmootherFilterV2State : IStreamingIndicatorS
     private double _prevValue;
     private bool _hasPrev;
 
-    public Ehlers2PoleSuperSmootherFilterV2State(int length = 10, InputName inputName = InputName.Close)
+    public Ehlers2PoleSuperSmootherFilterV2State(int length = 10)
     {
         var resolved = Math.Max(1, length);
         var a = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / resolved, -0.01, -0.99));
@@ -1622,7 +1618,7 @@ public sealed class Ehlers2PoleSuperSmootherFilterV2State : IStreamingIndicatorS
         _c2 = b;
         _c3 = -a * a;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers2PoleSuperSmootherFilterV2;

--- a/src/Streaming/StatefulIndicators.Batch6.cs
+++ b/src/Streaming/StatefulIndicators.Batch6.cs
@@ -676,7 +676,7 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _lows;
     private readonly StreamingInputResolver _input;
     private readonly int _length2;
-    private double _prevClose;
+    private double _prevValue;
     private double _prevAtrUp;
     private double _prevAtrDn;
     private bool _hasPrev;
@@ -716,7 +716,7 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
         _lowWindow.Reset();
         _highs.Clear();
         _lows.Clear();
-        _prevClose = 0;
+        _prevValue = 0;
         _prevAtrUp = 0;
         _prevAtrDn = 0;
         _hasPrev = false;
@@ -724,10 +724,17 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
 
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
-        var prevClose = _hasPrev ? _prevClose : 0;
+        // The batch takes the true-range previous value from the SELECTED input series, not from
+        // close: CalculateDrunkardWalk reads inputList out of GetInputValuesList and passes
+        // inputList[i - 1] - or inputList[i] on the first bar - to CalculateTrueRange, while the
+        // high and low come from highList/lowList. This state accepted an InputName and a selector,
+        // built a resolver from them, and then never read it, so anything but the default input
+        // silently disagreed with the batch. Highs and lows stay on the bar, as they do there.
+        var value = _input.GetValue(bar);
+        var prevValue = _hasPrev ? _prevValue : value;
         var highestHigh = isFinal ? _highWindow.Add(bar.High, out _) : _highWindow.Preview(bar.High, out _);
         var lowestLow = isFinal ? _lowWindow.Add(bar.Low, out _) : _lowWindow.Preview(bar.Low, out _);
-        var tr = CalculationsHelper.CalculateTrueRange(bar.High, bar.Low, prevClose);
+        var tr = CalculationsHelper.CalculateTrueRange(bar.High, bar.Low, prevValue);
         var dnRun = StreamingWindowMath.LastOffset(_highs, bar.High, highestHigh);
         var upRun = StreamingWindowMath.LastOffset(_lows, bar.Low, lowestLow);
 
@@ -747,7 +754,7 @@ public sealed class DrunkardWalkState : IStreamingIndicatorState, IDisposable
         {
             _highs.TryAdd(bar.High, out _);
             _lows.TryAdd(bar.Low, out _);
-            _prevClose = bar.Close;
+            _prevValue = value;
             _prevAtrUp = atrUp;
             _prevAtrDn = atrDn;
             _hasPrev = true;

--- a/src/Streaming/StatefulIndicators.Batch6.cs
+++ b/src/Streaming/StatefulIndicators.Batch6.cs
@@ -69,7 +69,7 @@ public sealed class ComparePriceMomentumOscillatorState : IMultiSeriesIndicatorS
     }
 }
 
-public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _length;
     private readonly int _stl;
@@ -82,7 +82,7 @@ public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDispos
     private readonly int _sLength;
     private readonly int _iLength;
     private readonly int _lLength;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly IMovingAverageSmoother _hAvg;
     private readonly IMovingAverageSmoother _sAvg;
     private readonly IMovingAverageSmoother _iAvg;
@@ -192,6 +192,9 @@ public sealed class ConfluenceIndicatorState : IStreamingIndicatorState, IDispos
     }
 
     public IndicatorName Name => IndicatorName.ConfluenceIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -1238,11 +1241,11 @@ public sealed class DynamicPivotPointsState : IStreamingIndicatorState
     }
 }
 
-public sealed class EarningSupportResistanceLevelsState : IStreamingIndicatorState, IDisposable
+public sealed class EarningSupportResistanceLevelsState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly PooledRingBuffer<double> _inputValues;
     private readonly PooledRingBuffer<double> _lowValues;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevClose;
     private bool _hasPrev;
 
@@ -1266,6 +1269,9 @@ public sealed class EarningSupportResistanceLevelsState : IStreamingIndicatorSta
     }
 
     public IndicatorName Name => IndicatorName.EarningSupportResistanceLevels;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch7.cs
+++ b/src/Streaming/StatefulIndicators.Batch7.cs
@@ -18,7 +18,7 @@ public sealed class Ehlers3PoleSuperSmootherFilterState : IStreamingIndicatorSta
     private double _prevFilter3;
     private int _index;
 
-    public Ehlers3PoleSuperSmootherFilterState(int length = 20, InputName inputName = InputName.Close)
+    public Ehlers3PoleSuperSmootherFilterState(int length = 20)
     {
         var resolved = Math.Max(1, length);
         var arg = MathHelper.MinOrMax(Math.PI / resolved, 0.99, 0.01);
@@ -29,7 +29,7 @@ public sealed class Ehlers3PoleSuperSmootherFilterState : IStreamingIndicatorSta
         _coef3 = -(c1 + (b1 * c1));
         _coef4 = c1 * c1;
         _coef1 = 1 - _coef2 - _coef3 - _coef4;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers3PoleSuperSmootherFilter;
@@ -84,7 +84,7 @@ public sealed class Ehlers3PoleButterworthFilterV1State : IStreamingIndicatorSta
     private double _prevFilter2;
     private double _prevFilter3;
 
-    public Ehlers3PoleButterworthFilterV1State(int length = 10, InputName inputName = InputName.Close)
+    public Ehlers3PoleButterworthFilterV1State(int length = 10)
     {
         var resolved = Math.Max(1, length);
         var a = MathHelper.Exp(MathHelper.MinOrMax(-Math.PI / resolved, -0.01, -0.99));
@@ -94,7 +94,7 @@ public sealed class Ehlers3PoleButterworthFilterV1State : IStreamingIndicatorSta
         _coef3 = -(c + (b * c));
         _coef4 = c * c;
         _coef1 = 1 - _coef2 - _coef3 - _coef4;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Ehlers3PoleButterworthFilterV1;
@@ -147,7 +147,7 @@ public sealed class Ehlers3PoleButterworthFilterV2State : IStreamingIndicatorSta
     private double _prevFilter3;
     private int _index;
 
-    public Ehlers3PoleButterworthFilterV2State(int length = 15, InputName inputName = InputName.Close)
+    public Ehlers3PoleButterworthFilterV2State(int length = 15)
     {
         var resolved = Math.Max(1, length);
         var a1 = MathHelper.Exp(MathHelper.MinOrMax(-Math.PI / resolved, -0.01, -0.99));
@@ -157,7 +157,7 @@ public sealed class Ehlers3PoleButterworthFilterV2State : IStreamingIndicatorSta
         _coef3 = -(c1 + (b1 * c1));
         _coef4 = c1 * c1;
         _coef1 = (1 - b1 + c1) * (1 - c1) / 8;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -224,10 +224,10 @@ public sealed class EhlersAdaptiveCyberCycleState : IStreamingIndicatorState, ID
     private double _prevAc2;
     private int _index;
 
-    public EhlersAdaptiveCyberCycleState(int length = 5, double alpha = 0.07, InputName inputName = InputName.Close)
+    public EhlersAdaptiveCyberCycleState(int length = 5, double alpha = 0.07)
     {
         _periodState = new AdaptiveCyberCyclePeriodState(length, alpha);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(4);
         _smooth = new PooledRingBuffer<double>(3);
     }
@@ -296,11 +296,11 @@ public sealed class EhlersAdaptiveCenterOfGravityOscillatorState : IStreamingInd
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersAdaptiveCenterOfGravityOscillatorState(int length = 5, InputName inputName = InputName.Close)
+    public EhlersAdaptiveCenterOfGravityOscillatorState(int length = 5)
     {
         var resolved = Math.Max(1, length);
         _periodState = new AdaptiveCyberCyclePeriodState(resolved, 0.07);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(Math.Max(64, resolved * 2));
     }
 
@@ -370,11 +370,11 @@ public sealed class EhlersAdaptiveLaguerreFilterState : IStreamingIndicatorState
     private double _prevAlpha;
     private bool _hasPrev;
 
-    public EhlersAdaptiveLaguerreFilterState(int length1 = 14, int length2 = 5, InputName inputName = InputName.Close)
+    public EhlersAdaptiveLaguerreFilterState(int length1 = 14, int length2 = 5)
     {
         _length1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _diffMax = new RollingWindowMax(_length1);
         _diffMin = new RollingWindowMin(_length1);
         _midValues = new PooledRingBuffer<double>(resolved2);
@@ -467,13 +467,13 @@ public sealed class EhlersAllPassPhaseShifterState : IStreamingIndicatorState, I
     private double _prevPhaser1;
     private double _prevPhaser2;
 
-    public EhlersAllPassPhaseShifterState(int length = 20, double qq = 0.5, InputName inputName = InputName.Close)
+    public EhlersAllPassPhaseShifterState(int length = 20, double qq = 0.5)
     {
         _a2 = qq != 0 && length != 0 ? -2 * Math.Cos(2 * Math.PI / length) / qq : 0;
         _a3 = qq != 0 ? MathHelper.Pow(1 / qq, 2) : 0;
         _b2 = length != 0 ? -2 * qq * Math.Cos(2 * Math.PI / length) : 0;
         _b3 = MathHelper.Pow(qq, 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
     }
 
@@ -526,10 +526,9 @@ public sealed class EhlersMotherOfAdaptiveMovingAveragesState : IStreamingIndica
     private readonly StreamingInputResolver _input;
     private readonly EhlersMotherOfAdaptiveMovingAveragesEngine _engine;
 
-    public EhlersMotherOfAdaptiveMovingAveragesState(double fastAlpha = 0.5, double slowAlpha = 0.05,
-        InputName inputName = InputName.Close)
+    public EhlersMotherOfAdaptiveMovingAveragesState(double fastAlpha = 0.5, double slowAlpha = 0.05)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new EhlersMotherOfAdaptiveMovingAveragesEngine(fastAlpha, slowAlpha);
     }
 
@@ -578,11 +577,11 @@ public sealed class EhlersAdaptiveRelativeStrengthIndexV1State : IStreamingIndic
     private readonly PooledRingBuffer<double> _values;
     private double _prevArsiEma1;
 
-    public EhlersAdaptiveRelativeStrengthIndexV1State(double cycPart = 0.5, InputName inputName = InputName.Close)
+    public EhlersAdaptiveRelativeStrengthIndexV1State(double cycPart = 0.5)
     {
         _cycPart = cycPart;
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(64);
     }
 
@@ -788,12 +787,12 @@ public sealed class EhlersAdaptiveCommodityChannelIndexV1State : IStreamingIndic
     private readonly PooledRingBuffer<double> _values;
     private double _prevAcciEma1;
 
-    public EhlersAdaptiveCommodityChannelIndexV1State(InputName inputName = InputName.TypicalPrice, double cycPart = 1,
+    public EhlersAdaptiveCommodityChannelIndexV1State(double cycPart = 1,
         double constant = 0.015)
     {
         _cycPart = cycPart;
         _constant = constant;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _values = new PooledRingBuffer<double>(64);
     }
@@ -975,9 +974,9 @@ public sealed class EhlersImpulseResponseState : IStreamingIndicatorState, IDisp
     private readonly EhlersImpulseResponseEngine _engine;
 
     public EhlersImpulseResponseState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length = 20, double bw = 1, InputName inputName = InputName.Close)
+        int length = 20, double bw = 1)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new EhlersImpulseResponseEngine(maType, length, bw);
     }
 
@@ -1019,10 +1018,10 @@ public sealed class EhlersAnticipateIndicatorState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _filters;
 
     public EhlersAnticipateIndicatorState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length = 14, double bw = 1, InputName inputName = InputName.Close)
+        int length = 14, double bw = 1)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _engine = new EhlersImpulseResponseEngine(maType, length, bw);
         _filters = new PooledRingBuffer<double>(_length);
     }
@@ -1111,7 +1110,10 @@ public sealed class EhlersRoofingFilterV2State : IStreamingIndicatorState, IDisp
     private double _prevFilter1;
     private double _prevFilter2;
 
-    public EhlersRoofingFilterV2State(int upperLength = 80, int lowerLength = 40, InputName inputName = InputName.Close)
+    // Internal: the library composes this state on a named input other than its own default -
+    // a volatility of volume, a relative volatility of the high and of the low. Every parameter is
+    // required, so this can never be chosen in place of the public constructor.
+    internal EhlersRoofingFilterV2State(int upperLength, int lowerLength, InputName inputName)
     {
         var upper = Math.Max(1, upperLength);
         var lower = Math.Max(1, lowerLength);
@@ -1124,6 +1126,22 @@ public sealed class EhlersRoofingFilterV2State : IStreamingIndicatorState, IDisp
         _c3 = -1 * a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
+        _values = new PooledRingBuffer<double>(2);
+    }
+
+    public EhlersRoofingFilterV2State(int upperLength = 80, int lowerLength = 40)
+    {
+        var upper = Math.Max(1, upperLength);
+        var lower = Math.Max(1, lowerLength);
+        var alphaArg = Math.Min(MathHelper.Sqrt2 * Math.PI / upper, 0.99);
+        var alphaCos = Math.Cos(alphaArg);
+        _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
+        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / lower);
+        var b1 = 2 * a1 * Math.Cos(Math.Min(MathHelper.Sqrt2 * Math.PI / lower, 0.99));
+        _c2 = b1;
+        _c3 = -1 * a1 * a1;
+        _c1 = 1 - _c2 - _c3;
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch7.cs
+++ b/src/Streaming/StatefulIndicators.Batch7.cs
@@ -32,25 +32,6 @@ public sealed class Ehlers3PoleSuperSmootherFilterState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Ehlers3PoleSuperSmootherFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var arg = MathHelper.MinOrMax(Math.PI / resolved, 0.99, 0.01);
-        var a1 = MathHelper.Exp(-arg);
-        var b1 = 2 * a1 * Math.Cos(1.738 * arg);
-        var c1 = a1 * a1;
-        _coef2 = b1 + c1;
-        _coef3 = -(c1 + (b1 * c1));
-        _coef4 = c1 * c1;
-        _coef1 = 1 - _coef2 - _coef3 - _coef4;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Ehlers3PoleSuperSmootherFilter;
 
     public void Reset()
@@ -116,24 +97,6 @@ public sealed class Ehlers3PoleButterworthFilterV1State : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Ehlers3PoleButterworthFilterV1State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a = MathHelper.Exp(MathHelper.MinOrMax(-Math.PI / resolved, -0.01, -0.99));
-        var b = 2 * a * Math.Cos(MathHelper.MinOrMax(1.738 * Math.PI / resolved, 0.99, 0.01));
-        var c = a * a;
-        _coef2 = b + c;
-        _coef3 = -(c + (b * c));
-        _coef4 = c * c;
-        _coef1 = 1 - _coef2 - _coef3 - _coef4;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Ehlers3PoleButterworthFilterV1;
 
     public void Reset()
@@ -195,25 +158,6 @@ public sealed class Ehlers3PoleButterworthFilterV2State : IStreamingIndicatorSta
         _coef4 = c1 * c1;
         _coef1 = (1 - b1 + c1) * (1 - c1) / 8;
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(3);
-    }
-
-    public Ehlers3PoleButterworthFilterV2State(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var a1 = MathHelper.Exp(MathHelper.MinOrMax(-Math.PI / resolved, -0.01, -0.99));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(1.738 * Math.PI / resolved, 0.99, 0.01));
-        var c1 = a1 * a1;
-        _coef2 = b1 + c1;
-        _coef3 = -(c1 + (b1 * c1));
-        _coef4 = c1 * c1;
-        _coef1 = (1 - b1 + c1) * (1 - c1) / 8;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(3);
     }
 
@@ -284,19 +228,6 @@ public sealed class EhlersAdaptiveCyberCycleState : IStreamingIndicatorState, ID
     {
         _periodState = new AdaptiveCyberCyclePeriodState(length, alpha);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(4);
-        _smooth = new PooledRingBuffer<double>(3);
-    }
-
-    public EhlersAdaptiveCyberCycleState(int length, double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _periodState = new AdaptiveCyberCyclePeriodState(length, alpha);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(4);
         _smooth = new PooledRingBuffer<double>(3);
     }
@@ -373,19 +304,6 @@ public sealed class EhlersAdaptiveCenterOfGravityOscillatorState : IStreamingInd
         _values = new PooledRingBuffer<double>(Math.Max(64, resolved * 2));
     }
 
-    public EhlersAdaptiveCenterOfGravityOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _periodState = new AdaptiveCyberCyclePeriodState(resolved, 0.07);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(Math.Max(64, resolved * 2));
-    }
-
     public IndicatorName Name => IndicatorName.EhlersAdaptiveCenterOfGravityOscillator;
 
     public void Reset()
@@ -457,23 +375,6 @@ public sealed class EhlersAdaptiveLaguerreFilterState : IStreamingIndicatorState
         _length1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
         _input = new StreamingInputResolver(inputName, null);
-        _diffMax = new RollingWindowMax(_length1);
-        _diffMin = new RollingWindowMin(_length1);
-        _midValues = new PooledRingBuffer<double>(resolved2);
-        _medianScratch = new double[resolved2];
-        _prevAlpha = (double)2 / (_length1 + 1);
-    }
-
-    public EhlersAdaptiveLaguerreFilterState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _diffMax = new RollingWindowMax(_length1);
         _diffMin = new RollingWindowMin(_length1);
         _midValues = new PooledRingBuffer<double>(resolved2);
@@ -576,21 +477,6 @@ public sealed class EhlersAllPassPhaseShifterState : IStreamingIndicatorState, I
         _values = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersAllPassPhaseShifterState(int length, double qq, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _a2 = qq != 0 && length != 0 ? -2 * Math.Cos(2 * Math.PI / length) / qq : 0;
-        _a3 = qq != 0 ? MathHelper.Pow(1 / qq, 2) : 0;
-        _b2 = length != 0 ? -2 * qq * Math.Cos(2 * Math.PI / length) : 0;
-        _b3 = MathHelper.Pow(qq, 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersAllPassPhaseShifter;
 
     public void Reset()
@@ -647,18 +533,6 @@ public sealed class EhlersMotherOfAdaptiveMovingAveragesState : IStreamingIndica
         _engine = new EhlersMotherOfAdaptiveMovingAveragesEngine(fastAlpha, slowAlpha);
     }
 
-    public EhlersMotherOfAdaptiveMovingAveragesState(double fastAlpha, double slowAlpha,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _engine = new EhlersMotherOfAdaptiveMovingAveragesEngine(fastAlpha, slowAlpha);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersMotherOfAdaptiveMovingAverages;
 
     public void Reset()
@@ -709,19 +583,6 @@ public sealed class EhlersAdaptiveRelativeStrengthIndexV1State : IStreamingIndic
         _cycPart = cycPart;
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(64);
-    }
-
-    public EhlersAdaptiveRelativeStrengthIndexV1State(double cycPart, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _cycPart = cycPart;
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(64);
     }
 
@@ -937,21 +798,6 @@ public sealed class EhlersAdaptiveCommodityChannelIndexV1State : IStreamingIndic
         _values = new PooledRingBuffer<double>(64);
     }
 
-    public EhlersAdaptiveCommodityChannelIndexV1State(InputName inputName, double cycPart, double constant,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _cycPart = cycPart;
-        _constant = constant;
-        _input = new StreamingInputResolver(inputName, selector);
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _values = new PooledRingBuffer<double>(64);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersAdaptiveCommodityChannelIndexV1;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -1135,17 +981,6 @@ public sealed class EhlersImpulseResponseState : IStreamingIndicatorState, IDisp
         _engine = new EhlersImpulseResponseEngine(maType, length, bw);
     }
 
-    public EhlersImpulseResponseState(MovingAvgType maType, int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _engine = new EhlersImpulseResponseEngine(maType, length, bw);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersImpulseResponse;
 
     public void Reset()
@@ -1188,19 +1023,6 @@ public sealed class EhlersAnticipateIndicatorState : IStreamingIndicatorState, I
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _engine = new EhlersImpulseResponseEngine(maType, length, bw);
-        _filters = new PooledRingBuffer<double>(_length);
-    }
-
-    public EhlersAnticipateIndicatorState(MovingAvgType maType, int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _engine = new EhlersImpulseResponseEngine(maType, length, bw);
         _filters = new PooledRingBuffer<double>(_length);
     }
@@ -1305,7 +1127,7 @@ public sealed class EhlersRoofingFilterV2State : IStreamingIndicatorState, IDisp
         _values = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersRoofingFilterV2State(int upperLength, int lowerLength, Func<OhlcvBar, double> selector)
+    internal EhlersRoofingFilterV2State(int upperLength, int lowerLength, Func<OhlcvBar, double> selector)
     {
         if (selector == null)
         {

--- a/src/Streaming/StatefulIndicators.Batch7.cs
+++ b/src/Streaming/StatefulIndicators.Batch7.cs
@@ -918,11 +918,11 @@ public sealed class EhlersAdaptiveStochasticIndicatorV1State : IStreamingIndicat
     }
 }
 
-public sealed class EhlersAdaptiveCommodityChannelIndexV1State : IStreamingIndicatorState, IDisposable
+public sealed class EhlersAdaptiveCommodityChannelIndexV1State : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly double _cycPart;
     private readonly double _constant;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly EhlersMotherOfAdaptiveMovingAveragesEngine _mama;
     private readonly PooledRingBuffer<double> _values;
     private double _prevAcciEma1;
@@ -953,6 +953,9 @@ public sealed class EhlersAdaptiveCommodityChannelIndexV1State : IStreamingIndic
     }
 
     public IndicatorName Name => IndicatorName.EhlersAdaptiveCommodityChannelIndexV1;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch7.cs
+++ b/src/Streaming/StatefulIndicators.Batch7.cs
@@ -316,7 +316,7 @@ public sealed class EhlersAdaptiveCenterOfGravityOscillatorState : IStreamingInd
     {
         var value = _input.GetValue(bar);
         var period = _periodState.Next(value, isFinal);
-        var intPeriod = (int)Math.Ceiling(period / 2);
+        var intPeriod = MathHelper.CeilingCycle(period / 2);
         double num = 0;
         double denom = 0;
         for (var j = 0; j < intPeriod; j++)
@@ -1308,6 +1308,7 @@ public sealed class EhlersAutoCorrelationPeriodogramState : IStreamingIndicatorS
     private readonly EhlersAutoCorrelationIndicatorState _corrState;
     private readonly PooledRingBuffer<double> _corrValues;
     private readonly double[] _rArray;
+    private readonly double[] _rNext;
 
     public EhlersAutoCorrelationPeriodogramState(int length1 = 48, int length2 = 10, int length3 = 3)
     {
@@ -1317,6 +1318,7 @@ public sealed class EhlersAutoCorrelationPeriodogramState : IStreamingIndicatorS
         _corrState = new EhlersAutoCorrelationIndicatorState(_length1, _length2);
         _corrValues = new PooledRingBuffer<double>(_length1);
         _rArray = new double[_length1 + 1];
+        _rNext = new double[_length1 + 1];
     }
 
     public IndicatorName Name => IndicatorName.EhlersAutoCorrelationPeriodogram;
@@ -1345,20 +1347,18 @@ public sealed class EhlersAutoCorrelationPeriodogramState : IStreamingIndicatorS
             }
 
             var sqSum = MathHelper.Pow(cosPart, 2) + MathHelper.Pow(sinPart, 2);
-            var prevR = _rArray[j];
-            var r = (0.2 * MathHelper.Pow(sqSum, 2)) + (0.8 * prevR);
-            if (isFinal)
-            {
-                _rArray[j] = r;
-            }
+            var r = (0.2 * MathHelper.Pow(sqSum, 2)) + (0.8 * _rArray[j]);
+            _rNext[j] = r;
             maxPwr = Math.Max(r, maxPwr);
         }
 
+        // The powers are normalised by this bar's maximum, so they must be this bar's powers too. Reading
+        // _rArray here made a preview divide the previous bar's powers by the current bar's maximum.
         double spx = 0;
         double sp = 0;
         for (var j = _length2; j <= _length1; j++)
         {
-            var pwr = maxPwr != 0 ? _rArray[j] / maxPwr : 0;
+            var pwr = maxPwr != 0 ? _rNext[j] / maxPwr : 0;
             if (pwr >= 0.5)
             {
                 spx += j * pwr;
@@ -1371,6 +1371,7 @@ public sealed class EhlersAutoCorrelationPeriodogramState : IStreamingIndicatorS
         if (isFinal)
         {
             _corrValues.TryAdd(corr, out _);
+            Array.Copy(_rNext, _rArray, _rArray.Length);
         }
 
         IReadOnlyDictionary<string, double>? outputs = null;
@@ -1445,7 +1446,7 @@ public sealed class EhlersAdaptiveRelativeStrengthIndexV2State : IStreamingIndic
         domCyc = MathHelper.MinOrMax(domCyc, _length1, _length2);
         var roofingFilter = _roofingFilter.Update(bar, isFinal, includeOutputs: false).Value;
 
-        var length = (int)Math.Ceiling(domCyc / 2);
+        var length = MathHelper.CeilingCycle(domCyc / 2);
         double upChg = 0;
         double dnChg = 0;
         for (var j = 0; j < length; j++)
@@ -1602,7 +1603,7 @@ public sealed class EhlersAdaptiveStochasticIndicatorV2State : IStreamingIndicat
         domCyc = MathHelper.MinOrMax(domCyc, _length1, _length2);
         var roofingFilter = _roofingFilter.Update(bar, isFinal, includeOutputs: false).Value;
 
-        var length = (int)Math.Ceiling(domCyc);
+        var length = MathHelper.CeilingCycle(domCyc);
         var highest = roofingFilter;
         var lowest = roofingFilter;
         // Match batch: only look back at values that exist (j <= count of stored values)
@@ -1758,7 +1759,7 @@ public sealed class EhlersAdaptiveCommodityChannelIndexV2State : IStreamingIndic
         var domCyc = _periodogram.Update(bar, isFinal, includeOutputs: false).Value;
         domCyc = MathHelper.MinOrMax(domCyc, _length1, _length2);
         var roofingFilter = _roofingFilter.Update(bar, isFinal, includeOutputs: false).Value;
-        var cycLength = (int)Math.Ceiling(domCyc);
+        var cycLength = MathHelper.CeilingCycle(domCyc);
 
         var tempSum = isFinal ? _tempSum.Add(roofingFilter, cycLength) : _tempSum.Preview(roofingFilter, cycLength);
         var count = cycLength > 0 ? Math.Min(cycLength, _index + 1) : 0;

--- a/src/Streaming/StatefulIndicators.Batch8.cs
+++ b/src/Streaming/StatefulIndicators.Batch8.cs
@@ -1357,7 +1357,7 @@ public sealed class EhlersConvolutionIndicatorState : IStreamingIndicatorState
     }
 }
 
-public sealed class EhlersCommodityChannelIndexInverseFisherTransformState : IStreamingIndicatorState, IDisposable
+public sealed class EhlersCommodityChannelIndexInverseFisherTransformState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly CommodityChannelIndexState _cciState;
     private readonly IMovingAverageSmoother _signalSmoother;
@@ -1383,6 +1383,13 @@ public sealed class EhlersCommodityChannelIndexInverseFisherTransformState : ISt
     }
 
     public IndicatorName Name => IndicatorName.EhlersCommodityChannelIndexInverseFisherTransform;
+
+    // No resolver of its own: the input was handed to these inner states, so they are the
+    // ones that must switch to reading the close.
+    void ICustomInputConsumer.ReadCloseAsInput()
+    {
+        ((ICustomInputConsumer)_cciState).ReadCloseAsInput();
+    }
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.Batch8.cs
+++ b/src/Streaming/StatefulIndicators.Batch8.cs
@@ -21,19 +21,6 @@ public sealed class EhlersCorrelationTrendIndicatorState : IStreamingIndicatorSt
         _values = new PooledRingBuffer<double>(_length);
     }
 
-    public EhlersCorrelationTrendIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        (_sy, _syy) = BuildYAxisSums(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersCorrelationTrendIndicator;
 
     public void Reset()
@@ -113,19 +100,6 @@ public sealed class EhlersCenterofGravityOscillatorState : IStreamingIndicatorSt
         _values = new PooledRingBuffer<double>(_length);
     }
 
-    public EhlersCenterofGravityOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _halfLength = (_length + 1) / 2.0;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersCenterofGravityOscillator;
 
     public void Reset()
@@ -193,23 +167,6 @@ public sealed class EhlersDecyclerOscillatorV1State : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersDecyclerOscillatorV1State(int fastLength, int slowLength, double fastMult, double slowMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastMult = fastMult;
-        _slowMult = slowMult;
-        _fastHp = new HighPassFilterV1Engine(fastLength, 1);
-        _slowHp = new HighPassFilterV1Engine(slowLength, 1);
-        _fastDecHp = new HighPassFilterV1Engine(fastLength, 0.5);
-        _slowDecHp = new HighPassFilterV1Engine(slowLength, 0.5);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDecyclerOscillatorV1;
 
     public void Reset()
@@ -261,19 +218,6 @@ public sealed class EhlersDecyclerOscillatorV2State : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersDecyclerOscillatorV2State(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastHp = new HighPassFilterV2Engine(maType, fastLength);
-        _slowHp = new HighPassFilterV2Engine(maType, slowLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDecyclerOscillatorV2;
 
     public void Reset()
@@ -323,20 +267,6 @@ public sealed class EhlersDecyclerState : IStreamingIndicatorState
         var alphaCos = Math.Cos(alphaArg);
         _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersDecyclerState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var alphaArg = Math.Min(2 * Math.PI / resolved, 0.99);
-        var alphaCos = Math.Cos(alphaArg);
-        _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersDecycler;
@@ -394,21 +324,6 @@ public sealed class EhlersCorrelationCycleIndicatorState : IStreamingIndicatorSt
         _negSinValues = new double[_length];
         (_sy, _syy, _nsy, _nsyy) = BuildTrigonometricSums(_length, _cosValues, _negSinValues);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
-    public EhlersCorrelationCycleIndicatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _cosValues = new double[_length];
-        _negSinValues = new double[_length];
-        (_sy, _syy, _nsy, _nsyy) = BuildTrigonometricSums(_length, _cosValues, _negSinValues);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length);
     }
 
@@ -822,24 +737,6 @@ public sealed class EhlersBandPassFilterV1State : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersBandPassFilterV1State(int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var twoPiPrd1 = MathHelper.MinOrMax(0.25 * bw * 2 * Math.PI / resolved, 0.99, 0.01);
-        var twoPiPrd2 = MathHelper.MinOrMax(1.5 * bw * 2 * Math.PI / resolved, 0.99, 0.01);
-        _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01));
-        var gamma = 1 / Math.Cos(MathHelper.MinOrMax(2 * Math.PI * bw / resolved, 0.99, 0.01));
-        _alpha1 = gamma - MathHelper.Sqrt(MathHelper.Pow(gamma, 2) - 1);
-        _alpha2 = (Math.Cos(twoPiPrd1) + Math.Sin(twoPiPrd1) - 1) / Math.Cos(twoPiPrd1);
-        _alpha3 = (Math.Cos(twoPiPrd2) + Math.Sin(twoPiPrd2) - 1) / Math.Cos(twoPiPrd2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersBandPassFilterV1;
 
     public void Reset()
@@ -923,20 +820,6 @@ public sealed class EhlersBandPassFilterV2State : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersBandPassFilterV2State(int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _l1 = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01));
-        var g1 = Math.Cos(MathHelper.MinOrMax(bw * 2 * Math.PI / resolved, 0.99, 0.01));
-        _s1 = (1 / g1) - MathHelper.Sqrt((1 / MathHelper.Pow(g1, 2)) - 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersBandPassFilterV2;
 
     public void Reset()
@@ -998,20 +881,6 @@ public sealed class EhlersCycleBandPassFilterState : IStreamingIndicatorState
         var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / resolved, 0.99, 0.01));
         _alpha = gamma - MathHelper.Sqrt(MathHelper.Pow(gamma, 2) - 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersCycleBandPassFilterState(int length, double delta, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01));
-        var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / resolved, 0.99, 0.01));
-        _alpha = gamma - MathHelper.Sqrt(MathHelper.Pow(gamma, 2) - 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersCycleBandPassFilter;
@@ -1146,17 +1015,6 @@ public sealed class EhlersCyberCycleState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersCyberCycleState(double alpha, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _alpha = alpha;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersCyberCycle;
 
     public void Reset()
@@ -1242,25 +1100,6 @@ public sealed class EhlersConvolutionIndicatorState : IStreamingIndicatorState
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
-        _roofingValues = new List<double>(128);
-    }
-
-    public EhlersConvolutionIndicatorState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length3 = Math.Max(1, length3);
-        var piPrd = MathHelper.Sqrt2 * Math.PI / Math.Max(1, length1);
-        _alpha = (Math.Cos(piPrd) + Math.Sin(piPrd) - 1) / Math.Cos(piPrd);
-        var a1 = MathHelper.Exp(-MathHelper.Sqrt2 * Math.PI / Math.Max(1, length2));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.Sqrt2 * Math.PI / Math.Max(1, length2));
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _roofingValues = new List<double>(128);
     }
 
@@ -1370,18 +1209,6 @@ public sealed class EhlersCommodityChannelIndexInverseFisherTransformState : ISt
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
     }
 
-    public EhlersCommodityChannelIndexInverseFisherTransformState(InputName inputName, MovingAvgType maType,
-        int length, int signalLength, double constant, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _cciState = new CommodityChannelIndexState(inputName, maType, Math.Max(1, length), constant, selector);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-    }
-
     public IndicatorName Name => IndicatorName.EhlersCommodityChannelIndexInverseFisherTransform;
 
     // No resolver of its own: the input was handed to these inner states, so they are the
@@ -1445,21 +1272,6 @@ public sealed class EhlersAverageErrorFilterState : IStreamingIndicatorState
         _c3 = -1 * a1 * a1;
         _c1 = 1 - _c2 - _c3;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersAverageErrorFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / Math.Max(1, length), -0.01, -0.999));
-        var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / Math.Max(1, length), 0.99, 0.01));
-        _c2 = b1;
-        _c3 = -1 * a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersAverageErrorFilter;
@@ -1558,16 +1370,6 @@ public sealed class EhlersChebyshevLowPassFilterState : IStreamingIndicatorState
     public EhlersChebyshevLowPassFilterState(InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersChebyshevLowPassFilterState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersChebyshevLowPassFilter;
@@ -1753,18 +1555,6 @@ public sealed class EhlersBetterExponentialMovingAverageState : IStreamingIndica
         var val = length != 0 ? Math.Cos(2 * Math.PI / length) + Math.Sin(2 * Math.PI / length) : 0;
         _alpha = val != 0 ? MathHelper.MinOrMax((val - 1) / val, 0.99, 0.01) : 0.01;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersBetterExponentialMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var val = length != 0 ? Math.Cos(2 * Math.PI / length) + Math.Sin(2 * Math.PI / length) : 0;
-        _alpha = val != 0 ? MathHelper.MinOrMax((val - 1) / val, 0.99, 0.01) : 0.01;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersBetterExponentialMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch8.cs
+++ b/src/Streaming/StatefulIndicators.Batch8.cs
@@ -13,11 +13,11 @@ public sealed class EhlersCorrelationTrendIndicatorState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersCorrelationTrendIndicatorState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersCorrelationTrendIndicatorState(int length = 20)
     {
         _length = Math.Max(1, length);
         (_sy, _syy) = BuildYAxisSums(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
     }
 
@@ -92,11 +92,11 @@ public sealed class EhlersCenterofGravityOscillatorState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersCenterofGravityOscillatorState(int length = 10, InputName inputName = InputName.Close)
+    public EhlersCenterofGravityOscillatorState(int length = 10)
     {
         _length = Math.Max(1, length);
         _halfLength = (_length + 1) / 2.0;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
     }
 
@@ -156,7 +156,7 @@ public sealed class EhlersDecyclerOscillatorV1State : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public EhlersDecyclerOscillatorV1State(int fastLength = 100, int slowLength = 125,
-        double fastMult = 1.2, double slowMult = 1, InputName inputName = InputName.Close)
+        double fastMult = 1.2, double slowMult = 1)
     {
         _fastMult = fastMult;
         _slowMult = slowMult;
@@ -164,7 +164,7 @@ public sealed class EhlersDecyclerOscillatorV1State : IStreamingIndicatorState
         _slowHp = new HighPassFilterV1Engine(slowLength, 1);
         _fastDecHp = new HighPassFilterV1Engine(fastLength, 0.5);
         _slowDecHp = new HighPassFilterV1Engine(slowLength, 0.5);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersDecyclerOscillatorV1;
@@ -211,11 +211,11 @@ public sealed class EhlersDecyclerOscillatorV2State : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public EhlersDecyclerOscillatorV2State(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int fastLength = 10, int slowLength = 20, InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 20)
     {
         _fastHp = new HighPassFilterV2Engine(maType, fastLength);
         _slowHp = new HighPassFilterV2Engine(maType, slowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersDecyclerOscillatorV2;
@@ -260,13 +260,13 @@ public sealed class EhlersDecyclerState : IStreamingIndicatorState
     private double _prevDec;
     private int _index;
 
-    public EhlersDecyclerState(int length = 60, InputName inputName = InputName.Close)
+    public EhlersDecyclerState(int length = 60)
     {
         var resolved = Math.Max(1, length);
         var alphaArg = Math.Min(2 * Math.PI / resolved, 0.99);
         var alphaCos = Math.Cos(alphaArg);
         _alpha1 = alphaCos != 0 ? (alphaCos + Math.Sin(alphaArg) - 1) / alphaCos : 0;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersDecycler;
@@ -317,13 +317,13 @@ public sealed class EhlersCorrelationCycleIndicatorState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersCorrelationCycleIndicatorState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersCorrelationCycleIndicatorState(int length = 20)
     {
         _length = Math.Max(1, length);
         _cosValues = new double[_length];
         _negSinValues = new double[_length];
         (_sy, _syy, _nsy, _nsyy) = BuildTrigonometricSums(_length, _cosValues, _negSinValues);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
     }
 
@@ -724,7 +724,7 @@ public sealed class EhlersBandPassFilterV1State : IStreamingIndicatorState
     private double _prevTrigger;
     private int _index;
 
-    public EhlersBandPassFilterV1State(int length = 20, double bw = 0.3, InputName inputName = InputName.Close)
+    public EhlersBandPassFilterV1State(int length = 20, double bw = 0.3)
     {
         var resolved = Math.Max(1, length);
         var twoPiPrd1 = MathHelper.MinOrMax(0.25 * bw * 2 * Math.PI / resolved, 0.99, 0.01);
@@ -734,7 +734,7 @@ public sealed class EhlersBandPassFilterV1State : IStreamingIndicatorState
         _alpha1 = gamma - MathHelper.Sqrt(MathHelper.Pow(gamma, 2) - 1);
         _alpha2 = (Math.Cos(twoPiPrd1) + Math.Sin(twoPiPrd1) - 1) / Math.Cos(twoPiPrd1);
         _alpha3 = (Math.Cos(twoPiPrd2) + Math.Sin(twoPiPrd2) - 1) / Math.Cos(twoPiPrd2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersBandPassFilterV1;
@@ -811,13 +811,13 @@ public sealed class EhlersBandPassFilterV2State : IStreamingIndicatorState
     private double _prevBp2;
     private int _index;
 
-    public EhlersBandPassFilterV2State(int length = 20, double bw = 0.3, InputName inputName = InputName.Close)
+    public EhlersBandPassFilterV2State(int length = 20, double bw = 0.3)
     {
         var resolved = Math.Max(1, length);
         _l1 = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01));
         var g1 = Math.Cos(MathHelper.MinOrMax(bw * 2 * Math.PI / resolved, 0.99, 0.01));
         _s1 = (1 / g1) - MathHelper.Sqrt((1 / MathHelper.Pow(g1, 2)) - 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersBandPassFilterV2;
@@ -874,13 +874,13 @@ public sealed class EhlersCycleBandPassFilterState : IStreamingIndicatorState
     private double _prevBp2;
     private int _index;
 
-    public EhlersCycleBandPassFilterState(int length = 20, double delta = 0.1, InputName inputName = InputName.Close)
+    public EhlersCycleBandPassFilterState(int length = 20, double delta = 0.1)
     {
         var resolved = Math.Max(1, length);
         _beta = Math.Cos(MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01));
         var gamma = 1 / Math.Cos(MathHelper.MinOrMax(4 * Math.PI * delta / resolved, 0.99, 0.01));
         _alpha = gamma - MathHelper.Sqrt(MathHelper.Pow(gamma, 2) - 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersCycleBandPassFilter;
@@ -1009,10 +1009,10 @@ public sealed class EhlersCyberCycleState : IStreamingIndicatorState
     private double _prevCycle2;
     private int _index;
 
-    public EhlersCyberCycleState(double alpha = 0.07, InputName inputName = InputName.Close)
+    public EhlersCyberCycleState(double alpha = 0.07)
     {
         _alpha = alpha;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersCyberCycle;
@@ -1088,8 +1088,7 @@ public sealed class EhlersConvolutionIndicatorState : IStreamingIndicatorState
     private double _prevRoofingFilter2;
     private int _index;
 
-    public EhlersConvolutionIndicatorState(int length1 = 80, int length2 = 40, int length3 = 48,
-        InputName inputName = InputName.Close)
+    public EhlersConvolutionIndicatorState(int length1 = 80, int length2 = 40, int length3 = 48)
     {
         _length3 = Math.Max(1, length3);
         var piPrd = MathHelper.Sqrt2 * Math.PI / Math.Max(1, length1);
@@ -1099,7 +1098,7 @@ public sealed class EhlersConvolutionIndicatorState : IStreamingIndicatorState
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _roofingValues = new List<double>(128);
     }
 
@@ -1201,11 +1200,10 @@ public sealed class EhlersCommodityChannelIndexInverseFisherTransformState : ISt
     private readonly CommodityChannelIndexState _cciState;
     private readonly IMovingAverageSmoother _signalSmoother;
 
-    public EhlersCommodityChannelIndexInverseFisherTransformState(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20, int signalLength = 9,
+    public EhlersCommodityChannelIndexInverseFisherTransformState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20, int signalLength = 9,
         double constant = 0.015)
     {
-        _cciState = new CommodityChannelIndexState(inputName, maType, Math.Max(1, length), constant);
+        _cciState = new CommodityChannelIndexState(maType, Math.Max(1, length), constant);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
     }
 
@@ -1264,14 +1262,14 @@ public sealed class EhlersAverageErrorFilterState : IStreamingIndicatorState
     private double _prevSsf2;
     private int _index;
 
-    public EhlersAverageErrorFilterState(int length = 27, InputName inputName = InputName.Close)
+    public EhlersAverageErrorFilterState(int length = 27)
     {
         var a1 = MathHelper.Exp(MathHelper.MinOrMax(-MathHelper.Sqrt2 * Math.PI / Math.Max(1, length), -0.01, -0.999));
         var b1 = 2 * a1 * Math.Cos(MathHelper.MinOrMax(MathHelper.Sqrt2 * Math.PI / Math.Max(1, length), 0.99, 0.01));
         _c2 = b1;
         _c3 = -1 * a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersAverageErrorFilter;
@@ -1367,9 +1365,9 @@ public sealed class EhlersChebyshevLowPassFilterState : IStreamingIndicatorState
     private double _prevWave6_2;
     private int _index;
 
-    public EhlersChebyshevLowPassFilterState(InputName inputName = InputName.Close)
+    public EhlersChebyshevLowPassFilterState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersChebyshevLowPassFilter;
@@ -1550,11 +1548,11 @@ public sealed class EhlersBetterExponentialMovingAverageState : IStreamingIndica
     private double _prevEma;
     private int _index;
 
-    public EhlersBetterExponentialMovingAverageState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersBetterExponentialMovingAverageState(int length = 20)
     {
         var val = length != 0 ? Math.Cos(2 * Math.PI / length) + Math.Sin(2 * Math.PI / length) : 0;
         _alpha = val != 0 ? MathHelper.MinOrMax((val - 1) / val, 0.99, 0.01) : 0.01;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersBetterExponentialMovingAverage;

--- a/src/Streaming/StatefulIndicators.Batch9.cs
+++ b/src/Streaming/StatefulIndicators.Batch9.cs
@@ -87,12 +87,12 @@ public sealed class EhlersDeviationScaledMovingAverageState : IStreamingIndicato
     private readonly StreamingInputResolver _input;
 
     public EhlersDeviationScaledMovingAverageState(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV2,
-        int fastLength = 20, int slowLength = 40, InputName inputName = InputName.Close)
+        int fastLength = 20, int slowLength = 40)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
         _engine = new EhlersDeviationScaledMovingAverageEngine(maType, resolvedFast, resolvedSlow);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersDeviationScaledMovingAverage;
@@ -138,12 +138,12 @@ public sealed class EhlersDeviationScaledSuperSmootherState : IStreamingIndicato
     private int _index;
 
     public EhlersDeviationScaledSuperSmootherState(MovingAvgType maType = MovingAvgType.EhlersHannMovingAverage,
-        int length1 = 12, int length2 = 50, InputName inputName = InputName.Close)
+        int length1 = 12, int length2 = 50)
     {
         _length1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
         var hannLength = (int)Math.Ceiling(_length1 / 1.4);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = EhlersStreamingSmootherFactory.Create(maType, hannLength);
         _filtPowSum = new RollingWindowSum(resolvedLength2);
         _values = new PooledRingBuffer<double>(_length1);
@@ -227,15 +227,14 @@ public sealed class EhlersDiscreteFourierTransformState : IStreamingIndicatorSta
     private double _prevValue;
     private int _index;
 
-    public EhlersDiscreteFourierTransformState(int minLength = 8, int maxLength = 50, int length = 40,
-        InputName inputName = InputName.Close)
+    public EhlersDiscreteFourierTransformState(int minLength = 8, int maxLength = 50, int length = 40)
     {
         _minLength = Math.Max(1, minLength);
         _maxLength = Math.Max(maxLength, _minLength);
         var resolvedLength = Math.Max(1, length);
         var twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / resolvedLength, 0.99, 0.01);
         _alpha = (1 - Math.Sin(twoPiPrd)) / Math.Cos(twoPiPrd);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _hpValues = new PooledRingBuffer<double>(5);
         _cleanedValues = new PooledRingBuffer<double>(_maxLength);
         _powerValues = new PooledRingBuffer<double>(_maxLength);
@@ -341,12 +340,11 @@ public sealed class EhlersDiscreteFourierTransformSpectralEstimateState : IStrea
     private readonly PooledRingBuffer<double> _roofingValues;
     private readonly double[] _rArray;
 
-    public EhlersDiscreteFourierTransformSpectralEstimateState(int length1 = 48, int length2 = 10,
-        InputName inputName = InputName.Close)
+    public EhlersDiscreteFourierTransformSpectralEstimateState(int length1 = 48, int length2 = 10)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
-        _roofingFilter = new EhlersRoofingFilterV2State(_length1, _length2, inputName);
+        _roofingFilter = new EhlersRoofingFilterV2State(_length1, _length2);
         _roofingValues = new PooledRingBuffer<double>(_length1 + 1);
         _rArray = new double[_length1 + 1];
     }
@@ -428,10 +426,10 @@ public sealed class EhlersDistanceCoefficientFilterState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersDistanceCoefficientFilterState(int length = 14, InputName inputName = InputName.Close)
+    public EhlersDistanceCoefficientFilterState(int length = 14)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length * 2);
     }
 
@@ -499,14 +497,14 @@ public sealed class EhlersDominantCycleTunedBypassFilterState : IStreamingIndica
     private int _index;
 
     public EhlersDominantCycleTunedBypassFilterState(int minLength = 8, int maxLength = 50, int length1 = 40,
-        int length2 = 10, InputName inputName = InputName.Close)
+        int length2 = 10)
     {
         var resolvedMin = Math.Max(1, minLength);
         var resolvedMax = Math.Max(maxLength, resolvedMin);
         var resolvedLength1 = Math.Max(1, length1);
         var twoPiPer = MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01);
         _alpha1 = (1 - Math.Sin(twoPiPer)) / Math.Cos(twoPiPer);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _sdfb = new EhlersSpectrumDerivedFilterBankEngine(resolvedMin, resolvedMax, resolvedLength1, Math.Max(1, length2));
         _hpValues = new PooledRingBuffer<double>(5);
         _v1Values = new PooledRingBuffer<double>(2);
@@ -598,8 +596,7 @@ public sealed class EhlersDualDifferentiatorDominantCycleState : IStreamingIndic
     private double _prevDomCyc2;
     private int _index;
 
-    public EhlersDualDifferentiatorDominantCycleState(int length1 = 48, int length2 = 20, int length3 = 8,
-        InputName inputName = InputName.Close)
+    public EhlersDualDifferentiatorDominantCycleState(int length1 = 48, int length2 = 20, int length3 = 8)
     {
         _length1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
@@ -609,7 +606,7 @@ public sealed class EhlersDualDifferentiatorDominantCycleState : IStreamingIndic
         _c2 = b1;
         _c3 = -a1 * a1;
         _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV2State(_length1, resolvedLength2, inputName);
+        _roofingFilter = new EhlersRoofingFilterV2State(_length1, resolvedLength2);
         _realValues = new PooledRingBuffer<double>(2);
         _imagValues = new PooledRingBuffer<double>(2);
     }
@@ -692,11 +689,10 @@ public sealed class EhlersEarlyOnsetTrendIndicatorState : IStreamingIndicatorSta
     private double _peak;
     private bool _hasPeak;
 
-    public EhlersEarlyOnsetTrendIndicatorState(int length1 = 30, int length2 = 100, double k = 0.85,
-        InputName inputName = InputName.Close)
+    public EhlersEarlyOnsetTrendIndicatorState(int length1 = 30, int length2 = 100, double k = 0.85)
     {
         _k = k;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _hp = new HighPassFilterV1Engine(Math.Max(1, length2), 1);
         _smoother = new EhlersSuperSmootherFilterEngine(Math.Max(1, length1));
     }
@@ -752,10 +748,10 @@ public sealed class EhlersEnhancedSignalToNoiseRatioState : IStreamingIndicatorS
     private double _prevNoise;
     private double _prevSnr;
 
-    public EhlersEnhancedSignalToNoiseRatioState(int length = 6, InputName inputName = InputName.Close)
+    public EhlersEnhancedSignalToNoiseRatioState(int length = 6)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _smoothValues = new PooledRingBuffer<double>(2);
         _q3Values = new PooledRingBuffer<double>(50);
@@ -840,7 +836,7 @@ public sealed class EhlersEvenBetterSineWaveIndicatorState : IStreamingIndicator
     private double _prevFilt2;
     private int _index;
 
-    public EhlersEvenBetterSineWaveIndicatorState(int length1 = 40, int length2 = 10, InputName inputName = InputName.Close)
+    public EhlersEvenBetterSineWaveIndicatorState(int length1 = 40, int length2 = 10)
     {
         var resolvedLength1 = Math.Max(1, length1);
         var resolvedLength2 = Math.Max(1, length2);
@@ -851,7 +847,7 @@ public sealed class EhlersEvenBetterSineWaveIndicatorState : IStreamingIndicator
         _c2 = b;
         _c3 = -a2 * a2;
         _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersEvenBetterSineWaveIndicator;
@@ -909,11 +905,11 @@ public sealed class EhlersFilterState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersFilterState(int length1 = 15, int length2 = 5, InputName inputName = InputName.Close)
+    public EhlersFilterState(int length1 = 15, int length2 = 5)
     {
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length1 + _length2);
     }
 
@@ -978,8 +974,7 @@ public sealed class EhlersFiniteImpulseResponseFilterState : IStreamingIndicator
     private readonly PooledRingBuffer<double> _values;
 
     public EhlersFiniteImpulseResponseFilterState(double coef1 = 1, double coef2 = 3.5, double coef3 = 4.5,
-        double coef4 = 3, double coef5 = 0.5, double coef6 = -0.5, double coef7 = -1.5,
-        InputName inputName = InputName.Close)
+        double coef4 = 3, double coef5 = 0.5, double coef6 = -0.5, double coef7 = -1.5)
     {
         _coef1 = coef1;
         _coef2 = coef2;
@@ -989,7 +984,7 @@ public sealed class EhlersFiniteImpulseResponseFilterState : IStreamingIndicator
         _coef6 = coef6;
         _coef7 = coef7;
         _coefSum = coef1 + coef2 + coef3 + coef4 + coef5 + coef6 + coef7;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(6);
     }
 
@@ -1045,7 +1040,7 @@ public sealed class EhlersFisherizedDeviationScaledOscillatorState : IStreamingI
     private bool _hasPrev;
 
     public EhlersFisherizedDeviationScaledOscillatorState(MovingAvgType maType = MovingAvgType.EhlersDeviationScaledMovingAverage,
-        int fastLength = 20, int slowLength = 40, InputName inputName = InputName.Close)
+        int fastLength = 20, int slowLength = 40)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1059,7 +1054,7 @@ public sealed class EhlersFisherizedDeviationScaledOscillatorState : IStreamingI
             _smoother = EhlersStreamingSmootherFactory.Create(maType, resolvedFast);
         }
 
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersFisherizedDeviationScaledOscillator;
@@ -1124,12 +1119,12 @@ public sealed class EhlersFisherTransformState : IStreamingIndicatorState, IDisp
     private double _prevFisher;
     private bool _hasPrev;
 
-    public EhlersFisherTransformState(int length = 10, InputName inputName = InputName.Close)
+    public EhlersFisherTransformState(int length = 10)
     {
         var resolved = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(resolved);
         _minWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersFisherTransform;
@@ -1187,10 +1182,10 @@ public sealed class EhlersFMDemodulatorIndicatorState : IStreamingIndicatorState
     private readonly IMovingAverageSmoother _smoother;
 
     public EhlersFMDemodulatorIndicatorState(MovingAvgType maType = MovingAvgType.Ehlers2PoleSuperSmootherFilterV2,
-        int fastLength = 10, int slowLength = 30, InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 30)
     {
         _fastLength = Math.Max(1, fastLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _smoother = EhlersStreamingSmootherFactory.Create(maType, Math.Max(1, slowLength));
     }
 
@@ -1247,10 +1242,10 @@ public sealed class EhlersFourierSeriesAnalysisState : IStreamingIndicatorState,
     private readonly PooledRingBuffer<double> _waveValues;
     private int _index;
 
-    public EhlersFourierSeriesAnalysisState(int length = 20, double bw = 0.1, InputName inputName = InputName.Close)
+    public EhlersFourierSeriesAnalysisState(int length = 20, double bw = 0.1)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(2);
         _bp1Values = new PooledRingBuffer<double>(_length);
         _bp2Values = new PooledRingBuffer<double>(_length);
@@ -1387,7 +1382,7 @@ public sealed class EhlersFractalAdaptiveMovingAverageState : IStreamingIndicato
     private double _prevFilter;
     private bool _hasPrev;
 
-    public EhlersFractalAdaptiveMovingAverageState(int length = 20, InputName inputName = InputName.Close)
+    public EhlersFractalAdaptiveMovingAverageState(int length = 20)
     {
         _length = Math.Max(1, length);
         _halfP = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
@@ -1397,7 +1392,7 @@ public sealed class EhlersFractalAdaptiveMovingAverageState : IStreamingIndicato
         _lowWindow2 = new RollingWindowMin(_halfP);
         _laggedHighest2 = new PooledRingBuffer<double>(_halfP + 1);
         _laggedLowest2 = new PooledRingBuffer<double>(_halfP + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.EhlersFractalAdaptiveMovingAverage;
@@ -1485,7 +1480,7 @@ public sealed class EhlersGaussianFilterState : IStreamingIndicatorState, IDispo
     private readonly PooledRingBuffer<double> _gf3Values;
     private readonly PooledRingBuffer<double> _gf4Values;
 
-    public EhlersGaussianFilterState(int length = 14, InputName inputName = InputName.Close)
+    public EhlersGaussianFilterState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         var cosVal = MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01);
@@ -1497,7 +1492,7 @@ public sealed class EhlersGaussianFilterState : IStreamingIndicatorState, IDispo
         _alpha2 = -beta2 + MathHelper.Sqrt(MathHelper.Pow(beta2, 2) + (2 * beta2));
         _alpha3 = -beta3 + MathHelper.Sqrt(MathHelper.Pow(beta3, 2) + (2 * beta3));
         _alpha4 = -beta4 + MathHelper.Sqrt(MathHelper.Pow(beta4, 2) + (2 * beta4));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _gf1Values = new PooledRingBuffer<double>(4);
         _gf2Values = new PooledRingBuffer<double>(4);
         _gf3Values = new PooledRingBuffer<double>(4);
@@ -1576,11 +1571,11 @@ public sealed class EhlersHammingMovingAverageState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
     private readonly PooledRingBuffer<double> _values;
 
-    public EhlersHammingMovingAverageState(int length = 20, double pedestal = 3, InputName inputName = InputName.Close)
+    public EhlersHammingMovingAverageState(int length = 20, double pedestal = 3)
     {
         _length = Math.Max(1, length);
         _pedestal = pedestal;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _values = new PooledRingBuffer<double>(_length);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch9.cs
+++ b/src/Streaming/StatefulIndicators.Batch9.cs
@@ -95,20 +95,6 @@ public sealed class EhlersDeviationScaledMovingAverageState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersDeviationScaledMovingAverageState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _engine = new EhlersDeviationScaledMovingAverageEngine(maType, resolvedFast, resolvedSlow);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDeviationScaledMovingAverage;
 
     public void Reset()
@@ -158,23 +144,6 @@ public sealed class EhlersDeviationScaledSuperSmootherState : IStreamingIndicato
         var resolvedLength2 = Math.Max(1, length2);
         var hannLength = (int)Math.Ceiling(_length1 / 1.4);
         _input = new StreamingInputResolver(inputName, null);
-        _smoother = EhlersStreamingSmootherFactory.Create(maType, hannLength);
-        _filtPowSum = new RollingWindowSum(resolvedLength2);
-        _values = new PooledRingBuffer<double>(_length1);
-    }
-
-    public EhlersDeviationScaledSuperSmootherState(MovingAvgType maType, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var hannLength = (int)Math.Ceiling(_length1 / 1.4);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _smoother = EhlersStreamingSmootherFactory.Create(maType, hannLength);
         _filtPowSum = new RollingWindowSum(resolvedLength2);
         _values = new PooledRingBuffer<double>(_length1);
@@ -267,24 +236,6 @@ public sealed class EhlersDiscreteFourierTransformState : IStreamingIndicatorSta
         var twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / resolvedLength, 0.99, 0.01);
         _alpha = (1 - Math.Sin(twoPiPrd)) / Math.Cos(twoPiPrd);
         _input = new StreamingInputResolver(inputName, null);
-        _hpValues = new PooledRingBuffer<double>(5);
-        _cleanedValues = new PooledRingBuffer<double>(_maxLength);
-        _powerValues = new PooledRingBuffer<double>(_maxLength);
-    }
-
-    public EhlersDiscreteFourierTransformState(int minLength, int maxLength, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _minLength = Math.Max(1, minLength);
-        _maxLength = Math.Max(maxLength, _minLength);
-        var resolvedLength = Math.Max(1, length);
-        var twoPiPrd = MathHelper.MinOrMax(2 * Math.PI / resolvedLength, 0.99, 0.01);
-        _alpha = (1 - Math.Sin(twoPiPrd)) / Math.Cos(twoPiPrd);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _hpValues = new PooledRingBuffer<double>(5);
         _cleanedValues = new PooledRingBuffer<double>(_maxLength);
         _powerValues = new PooledRingBuffer<double>(_maxLength);
@@ -400,20 +351,6 @@ public sealed class EhlersDiscreteFourierTransformSpectralEstimateState : IStrea
         _rArray = new double[_length1 + 1];
     }
 
-    public EhlersDiscreteFourierTransformSpectralEstimateState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _roofingFilter = new EhlersRoofingFilterV2State(_length1, _length2, selector);
-        _roofingValues = new PooledRingBuffer<double>(_length1 + 1);
-        _rArray = new double[_length1 + 1];
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDiscreteFourierTransformSpectralEstimate;
 
     public void Reset()
@@ -498,18 +435,6 @@ public sealed class EhlersDistanceCoefficientFilterState : IStreamingIndicatorSt
         _values = new PooledRingBuffer<double>(_length * 2);
     }
 
-    public EhlersDistanceCoefficientFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(_length * 2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDistanceCoefficientFilter;
 
     public void Reset()
@@ -582,25 +507,6 @@ public sealed class EhlersDominantCycleTunedBypassFilterState : IStreamingIndica
         var twoPiPer = MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01);
         _alpha1 = (1 - Math.Sin(twoPiPer)) / Math.Cos(twoPiPer);
         _input = new StreamingInputResolver(inputName, null);
-        _sdfb = new EhlersSpectrumDerivedFilterBankEngine(resolvedMin, resolvedMax, resolvedLength1, Math.Max(1, length2));
-        _hpValues = new PooledRingBuffer<double>(5);
-        _v1Values = new PooledRingBuffer<double>(2);
-    }
-
-    public EhlersDominantCycleTunedBypassFilterState(int minLength, int maxLength, int length1, int length2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedMin = Math.Max(1, minLength);
-        var resolvedMax = Math.Max(maxLength, resolvedMin);
-        var resolvedLength1 = Math.Max(1, length1);
-        var twoPiPer = MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01);
-        _alpha1 = (1 - Math.Sin(twoPiPer)) / Math.Cos(twoPiPer);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _sdfb = new EhlersSpectrumDerivedFilterBankEngine(resolvedMin, resolvedMax, resolvedLength1, Math.Max(1, length2));
         _hpValues = new PooledRingBuffer<double>(5);
         _v1Values = new PooledRingBuffer<double>(2);
@@ -708,26 +614,6 @@ public sealed class EhlersDualDifferentiatorDominantCycleState : IStreamingIndic
         _imagValues = new PooledRingBuffer<double>(2);
     }
 
-    public EhlersDualDifferentiatorDominantCycleState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        _length3 = Math.Max(1, length3);
-        var a1 = MathHelper.Exp(-1.414 * Math.PI / resolvedLength2);
-        var b1 = 2 * a1 * Math.Cos(1.414 * Math.PI / resolvedLength2);
-        _c2 = b1;
-        _c3 = -a1 * a1;
-        _c1 = 1 - _c2 - _c3;
-        _roofingFilter = new EhlersRoofingFilterV2State(_length1, resolvedLength2, selector);
-        _realValues = new PooledRingBuffer<double>(2);
-        _imagValues = new PooledRingBuffer<double>(2);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersDualDifferentiatorDominantCycle;
 
     public void Reset()
@@ -815,19 +701,6 @@ public sealed class EhlersEarlyOnsetTrendIndicatorState : IStreamingIndicatorSta
         _smoother = new EhlersSuperSmootherFilterEngine(Math.Max(1, length1));
     }
 
-    public EhlersEarlyOnsetTrendIndicatorState(int length1, int length2, double k, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _k = k;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _hp = new HighPassFilterV1Engine(Math.Max(1, length2), 1);
-        _smoother = new EhlersSuperSmootherFilterEngine(Math.Max(1, length1));
-    }
-
     public IndicatorName Name => IndicatorName.EhlersEarlyOnsetTrendIndicator;
 
     public void Reset()
@@ -883,20 +756,6 @@ public sealed class EhlersEnhancedSignalToNoiseRatioState : IStreamingIndicatorS
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
-        _smoothValues = new PooledRingBuffer<double>(2);
-        _q3Values = new PooledRingBuffer<double>(50);
-    }
-
-    public EhlersEnhancedSignalToNoiseRatioState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _mama = new EhlersMotherOfAdaptiveMovingAveragesEngine(0.5, 0.05);
         _smoothValues = new PooledRingBuffer<double>(2);
         _q3Values = new PooledRingBuffer<double>(50);
@@ -995,25 +854,6 @@ public sealed class EhlersEvenBetterSineWaveIndicatorState : IStreamingIndicator
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersEvenBetterSineWaveIndicatorState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        var resolvedLength2 = Math.Max(1, length2);
-        var piHp = MathHelper.MinOrMax(2 * Math.PI / resolvedLength1, 0.99, 0.01);
-        _a1 = (1 - Math.Sin(piHp)) / Math.Cos(piHp);
-        var a2 = MathHelper.Exp(MathHelper.MinOrMax(-1.414 * Math.PI / resolvedLength2, -0.01, -0.99));
-        var b = 2 * a2 * Math.Cos(MathHelper.MinOrMax(1.414 * Math.PI / resolvedLength2, 0.99, 0.01));
-        _c2 = b;
-        _c3 = -a2 * a2;
-        _c1 = 1 - _c2 - _c3;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersEvenBetterSineWaveIndicator;
 
     public void Reset()
@@ -1074,19 +914,6 @@ public sealed class EhlersFilterState : IStreamingIndicatorState, IDisposable
         _length1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length1 + _length2);
-    }
-
-    public EhlersFilterState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length1 + _length2);
     }
 
@@ -1166,26 +993,6 @@ public sealed class EhlersFiniteImpulseResponseFilterState : IStreamingIndicator
         _values = new PooledRingBuffer<double>(6);
     }
 
-    public EhlersFiniteImpulseResponseFilterState(double coef1, double coef2, double coef3, double coef4,
-        double coef5, double coef6, double coef7, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _coef1 = coef1;
-        _coef2 = coef2;
-        _coef3 = coef3;
-        _coef4 = coef4;
-        _coef5 = coef5;
-        _coef6 = coef6;
-        _coef7 = coef7;
-        _coefSum = coef1 + coef2 + coef3 + coef4 + coef5 + coef6 + coef7;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _values = new PooledRingBuffer<double>(6);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersFiniteImpulseResponseFilter;
 
     public void Reset()
@@ -1253,29 +1060,6 @@ public sealed class EhlersFisherizedDeviationScaledOscillatorState : IStreamingI
         }
 
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public EhlersFisherizedDeviationScaledOscillatorState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        if (maType == MovingAvgType.EhlersDeviationScaledMovingAverage)
-        {
-            _edsmaEngine = new EhlersDeviationScaledMovingAverageEngine(MovingAvgType.Ehlers2PoleSuperSmootherFilterV2,
-                resolvedFast, resolvedSlow);
-        }
-        else
-        {
-            _smoother = EhlersStreamingSmootherFactory.Create(maType, resolvedFast);
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.EhlersFisherizedDeviationScaledOscillator;
@@ -1348,19 +1132,6 @@ public sealed class EhlersFisherTransformState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersFisherTransformState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(resolved);
-        _minWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersFisherTransform;
 
     public void Reset()
@@ -1423,19 +1194,6 @@ public sealed class EhlersFMDemodulatorIndicatorState : IStreamingIndicatorState
         _smoother = EhlersStreamingSmootherFactory.Create(maType, Math.Max(1, slowLength));
     }
 
-    public EhlersFMDemodulatorIndicatorState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _smoother = EhlersStreamingSmootherFactory.Create(maType, Math.Max(1, slowLength));
-    }
-
     public IndicatorName Name => IndicatorName.EhlersFMDemodulatorIndicator;
 
     public void Reset()
@@ -1493,37 +1251,6 @@ public sealed class EhlersFourierSeriesAnalysisState : IStreamingIndicatorState,
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(2);
-        _bp1Values = new PooledRingBuffer<double>(_length);
-        _bp2Values = new PooledRingBuffer<double>(_length);
-        _bp3Values = new PooledRingBuffer<double>(_length);
-        _q1Values = new PooledRingBuffer<double>(_length);
-        _q2Values = new PooledRingBuffer<double>(_length);
-        _q3Values = new PooledRingBuffer<double>(_length);
-        _waveValues = new PooledRingBuffer<double>(2);
-
-        _l1 = Math.Cos(2 * Math.PI / _length);
-        var g1 = Math.Cos(bw * 2 * Math.PI / _length);
-        _s1 = (1 / g1) - MathHelper.Sqrt((1 / (g1 * g1)) - 1);
-
-        _l2 = Math.Cos(2 * Math.PI / ((double)_length / 2));
-        var g2 = Math.Cos(bw * 2 * Math.PI / ((double)_length / 2));
-        _s2 = (1 / g2) - MathHelper.Sqrt((1 / (g2 * g2)) - 1);
-
-        _l3 = Math.Cos(2 * Math.PI / ((double)_length / 3));
-        var g3 = Math.Cos(bw * 2 * Math.PI / ((double)_length / 3));
-        _s3 = (1 / g3) - MathHelper.Sqrt((1 / (g3 * g3)) - 1);
-    }
-
-    public EhlersFourierSeriesAnalysisState(int length, double bw, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(2);
         _bp1Values = new PooledRingBuffer<double>(_length);
         _bp2Values = new PooledRingBuffer<double>(_length);
@@ -1673,24 +1400,6 @@ public sealed class EhlersFractalAdaptiveMovingAverageState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public EhlersFractalAdaptiveMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _halfP = MathHelper.MinOrMax((int)Math.Ceiling((double)_length / 2));
-        _highWindow1 = new RollingWindowMax(_length);
-        _lowWindow1 = new RollingWindowMin(_length);
-        _highWindow2 = new RollingWindowMax(_halfP);
-        _lowWindow2 = new RollingWindowMin(_halfP);
-        _laggedHighest2 = new PooledRingBuffer<double>(_halfP + 1);
-        _laggedLowest2 = new PooledRingBuffer<double>(_halfP + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersFractalAdaptiveMovingAverage;
 
     public void Reset()
@@ -1795,30 +1504,6 @@ public sealed class EhlersGaussianFilterState : IStreamingIndicatorState, IDispo
         _gf4Values = new PooledRingBuffer<double>(4);
     }
 
-    public EhlersGaussianFilterState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var cosVal = MathHelper.MinOrMax(2 * Math.PI / resolved, 0.99, 0.01);
-        var beta1 = (1 - Math.Cos(cosVal)) / (MathHelper.Pow(2, 1.0) - 1);
-        var beta2 = (1 - Math.Cos(cosVal)) / (MathHelper.Pow(2, 0.5) - 1);
-        var beta3 = (1 - Math.Cos(cosVal)) / (MathHelper.Pow(2, 1.0 / 3) - 1);
-        var beta4 = (1 - Math.Cos(cosVal)) / (MathHelper.Pow(2, 0.25) - 1);
-        _alpha1 = -beta1 + MathHelper.Sqrt(MathHelper.Pow(beta1, 2) + (2 * beta1));
-        _alpha2 = -beta2 + MathHelper.Sqrt(MathHelper.Pow(beta2, 2) + (2 * beta2));
-        _alpha3 = -beta3 + MathHelper.Sqrt(MathHelper.Pow(beta3, 2) + (2 * beta3));
-        _alpha4 = -beta4 + MathHelper.Sqrt(MathHelper.Pow(beta4, 2) + (2 * beta4));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _gf1Values = new PooledRingBuffer<double>(4);
-        _gf2Values = new PooledRingBuffer<double>(4);
-        _gf3Values = new PooledRingBuffer<double>(4);
-        _gf4Values = new PooledRingBuffer<double>(4);
-    }
-
     public IndicatorName Name => IndicatorName.EhlersGaussianFilter;
 
     public void Reset()
@@ -1896,19 +1581,6 @@ public sealed class EhlersHammingMovingAverageState : IStreamingIndicatorState, 
         _length = Math.Max(1, length);
         _pedestal = pedestal;
         _input = new StreamingInputResolver(inputName, null);
-        _values = new PooledRingBuffer<double>(_length);
-    }
-
-    public EhlersHammingMovingAverageState(int length, double pedestal, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _pedestal = pedestal;
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _values = new PooledRingBuffer<double>(_length);
     }
 

--- a/src/Streaming/StatefulIndicators.Batch9.cs
+++ b/src/Streaming/StatefulIndicators.Batch9.cs
@@ -1417,18 +1417,17 @@ public sealed class EhlersFractalAdaptiveMovingAverageState : IStreamingIndicato
         var highestHigh2 = isFinal ? _highWindow2.Add(bar.High, out _) : _highWindow2.Preview(bar.High, out _);
         var lowestLow2 = isFinal ? _lowWindow2.Add(bar.Low, out _) : _lowWindow2.Preview(bar.Low, out _);
 
-        // Add current values to lag buffers FIRST (batch computes all values first, then accesses lagged)
+        // The value halfP bars back, counting this bar (batch: lagIndex = Math.Max(i - halfP, 0)), read before
+        // this bar is committed so a preview and its commit read the same bar. Until halfP bars have passed
+        // the lag stays on the first bar, which is still the oldest in the buffer then.
+        var highestHigh3 = LaggedOrFirst(_laggedHighest2, highestHigh2);
+        var lowestLow3 = LaggedOrFirst(_laggedLowest2, lowestLow2);
+
         if (isFinal)
         {
             _laggedHighest2.TryAdd(highestHigh2, out _);
             _laggedLowest2.TryAdd(lowestLow2, out _);
         }
-
-        // Use lagged values from halfP bars ago (batch: lagIndex = Math.Max(i - halfP, 0))
-        // For first halfP bars, lagIndex stays at 0 (uses first bar's value)
-        // After that, the oldest value in the ring buffer is from halfP bars ago
-        var highestHigh3 = _laggedHighest2.Count > 0 ? _laggedHighest2[0] : highestHigh2;
-        var lowestLow3 = _laggedLowest2.Count > 0 ? _laggedLowest2[0] : lowestLow2;
 
         var n3 = (highestHigh1 - lowestLow1) / _length;
         var n1 = (highestHigh2 - lowestLow2) / _halfP;
@@ -1456,6 +1455,12 @@ public sealed class EhlersFractalAdaptiveMovingAverageState : IStreamingIndicato
 
         return new StreamingIndicatorStateResult(filter, outputs);
     }
+
+    /// <summary>The value halfP bars back counting the pending one, or the first value until there is one.</summary>
+    private double LaggedOrFirst(PooledRingBuffer<double> lagged, double pending) =>
+        lagged.Count >= _halfP
+            ? EhlersStreamingWindow.GetOffsetValue(lagged, pending, _halfP)
+            : lagged.Count > 0 ? lagged[0] : pending;
 
     public void Dispose()
     {

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -354,9 +354,9 @@ public sealed class HullMovingAverageState : IStreamingIndicatorState, IDisposab
 }
 
 
-public sealed class AveragePriceState : IStreamingIndicatorState, ICustomInputConsumer
+public sealed class AveragePriceState : IStreamingIndicatorState
 {
-    private StreamingInputResolver _input;
+    private readonly StreamingInputResolver _input;
 
     public AveragePriceState()
     {
@@ -374,9 +374,6 @@ public sealed class AveragePriceState : IStreamingIndicatorState, ICustomInputCo
     }
 
     public IndicatorName Name => IndicatorName.AveragePrice;
-
-    void ICustomInputConsumer.ReadCloseAsInput() =>
-        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -398,9 +395,9 @@ public sealed class AveragePriceState : IStreamingIndicatorState, ICustomInputCo
     }
 }
 
-public sealed class FullTypicalPriceState : IStreamingIndicatorState, ICustomInputConsumer
+public sealed class FullTypicalPriceState : IStreamingIndicatorState
 {
-    private StreamingInputResolver _input;
+    private readonly StreamingInputResolver _input;
 
     public FullTypicalPriceState()
     {
@@ -418,9 +415,6 @@ public sealed class FullTypicalPriceState : IStreamingIndicatorState, ICustomInp
     }
 
     public IndicatorName Name => IndicatorName.FullTypicalPrice;
-
-    void ICustomInputConsumer.ReadCloseAsInput() =>
-        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -442,9 +436,9 @@ public sealed class FullTypicalPriceState : IStreamingIndicatorState, ICustomInp
     }
 }
 
-public sealed class MedianPriceState : IStreamingIndicatorState, ICustomInputConsumer
+public sealed class MedianPriceState : IStreamingIndicatorState
 {
-    private StreamingInputResolver _input;
+    private readonly StreamingInputResolver _input;
 
     public MedianPriceState()
     {
@@ -462,9 +456,6 @@ public sealed class MedianPriceState : IStreamingIndicatorState, ICustomInputCon
     }
 
     public IndicatorName Name => IndicatorName.MedianPrice;
-
-    void ICustomInputConsumer.ReadCloseAsInput() =>
-        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -486,9 +477,9 @@ public sealed class MedianPriceState : IStreamingIndicatorState, ICustomInputCon
     }
 }
 
-public sealed class TypicalPriceState : IStreamingIndicatorState, ICustomInputConsumer
+public sealed class TypicalPriceState : IStreamingIndicatorState
 {
-    private StreamingInputResolver _input;
+    private readonly StreamingInputResolver _input;
 
     public TypicalPriceState()
     {
@@ -506,9 +497,6 @@ public sealed class TypicalPriceState : IStreamingIndicatorState, ICustomInputCo
     }
 
     public IndicatorName Name => IndicatorName.TypicalPrice;
-
-    void ICustomInputConsumer.ReadCloseAsInput() =>
-        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -530,9 +518,9 @@ public sealed class TypicalPriceState : IStreamingIndicatorState, ICustomInputCo
     }
 }
 
-public sealed class WeightedCloseState : IStreamingIndicatorState, ICustomInputConsumer
+public sealed class WeightedCloseState : IStreamingIndicatorState
 {
-    private StreamingInputResolver _input;
+    private readonly StreamingInputResolver _input;
 
     public WeightedCloseState()
     {
@@ -550,9 +538,6 @@ public sealed class WeightedCloseState : IStreamingIndicatorState, ICustomInputC
     }
 
     public IndicatorName Name => IndicatorName.WeightedClose;
-
-    void ICustomInputConsumer.ReadCloseAsInput() =>
-        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -9455,12 +9455,18 @@ public sealed class ArnaudLegouxMovingAverageState : IStreamingIndicatorState, I
             _window.TryAdd(value, out _);
         }
 
-        var count = _window.Count;
+        // A forming bar is the newest value of the window it would make, so a preview weights it too; the
+        // window without it made a preview of the first bar 0.
+        var pending = isFinal ? 0 : 1;
+        var count = Math.Min(_window.Count + pending, _length);
+        var committed = count - pending;
+        var first = _window.Count - committed;
         var missing = _length - count;
         double sum = 0;
-        for (var j = 0; j < _length; j++)
+        for (var j = missing; j < _length; j++)
         {
-            var val = j < missing ? 0 : _window[j - missing];
+            var index = j - missing;
+            var val = index < committed ? _window[first + index] : value;
             sum += val * _weights[j];
         }
 
@@ -9534,16 +9540,18 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable,
         var teeth = _teethSmoother.Next(value, isFinal);
         var lips = _lipsSmoother.Next(value, isFinal);
 
+        // Each line is its own value an offset of bars back, counting this bar, so it is read before this bar
+        // is committed; reading it after made a preview a bar late once the window was full.
+        var displacedJaw = EhlersStreamingWindow.GetOffsetValue(_jawWindow, jaw, _jawOffset);
+        var displacedTeeth = EhlersStreamingWindow.GetOffsetValue(_teethWindow, teeth, _teethOffset);
+        var displacedLips = EhlersStreamingWindow.GetOffsetValue(_lipsWindow, lips, _lipsOffset);
+
         if (isFinal)
         {
             _jawWindow.TryAdd(jaw, out _);
             _teethWindow.TryAdd(teeth, out _);
             _lipsWindow.TryAdd(lips, out _);
         }
-
-        var displacedJaw = _jawOffset == 0 ? jaw : _jawWindow.Count > _jawOffset ? _jawWindow[0] : 0;
-        var displacedTeeth = _teethOffset == 0 ? teeth : _teethWindow.Count > _teethOffset ? _teethWindow[0] : 0;
-        var displacedLips = _lipsOffset == 0 ? lips : _lipsWindow.Count > _lipsOffset ? _lipsWindow[0] : 0;
 
         IReadOnlyDictionary<string, double>? outputs = null;
         if (includeOutputs)
@@ -14105,7 +14113,7 @@ internal sealed class RollingPercentRank : IDisposable
     private readonly int _length;
     private readonly bool _useLinear;
     private readonly PooledRingBuffer<double> _window;
-    private OrderStatisticTree? _tree;
+    private OrderStatisticTree _tree = new();
     private bool _disposed;
 
     public RollingPercentRank(int length)
@@ -14113,10 +14121,6 @@ internal sealed class RollingPercentRank : IDisposable
         _length = Math.Max(1, length);
         _useLinear = _length <= RollingWindowSettings.SmallWindowThreshold;
         _window = new PooledRingBuffer<double>(_length);
-        if (!_useLinear)
-        {
-            _tree = new OrderStatisticTree();
-        }
     }
 
     public double Add(double value)
@@ -14125,9 +14129,20 @@ internal sealed class RollingPercentRank : IDisposable
         return MathHelper.MinOrMax((double)count / _length * 100, 100, 0);
     }
 
+    /// <summary>The rank <see cref="Add"/> would return for the value, without adding it.</summary>
+    /// <remarks>
+    /// Add ranks the value against the window it leaves behind, which no longer holds the oldest value once
+    /// the window is full. Counting the oldest here made a preview disagree with its own commit whenever
+    /// the value about to leave was at or below the new one.
+    /// </remarks>
     public double Preview(double value)
     {
         var count = CountLessThanOrEqual(value);
+        if (_window.Count == _length && _window[0] <= value)
+        {
+            count--;
+        }
+
         return MathHelper.MinOrMax((double)count / _length * 100, 100, 0);
     }
 
@@ -14170,10 +14185,10 @@ internal sealed class RollingPercentRank : IDisposable
 
         if (_window.TryAdd(value, out var removed))
         {
-            _tree!.Remove(removed);
+            _tree.Remove(removed);
         }
 
-        _tree!.Insert(value);
+        _tree.Insert(value);
         return Math.Max(0, _tree.CountLessThanOrEqual(value) - 1);
     }
 
@@ -14193,7 +14208,7 @@ internal sealed class RollingPercentRank : IDisposable
             return count;
         }
 
-        return _tree!.CountLessThanOrEqual(value);
+        return _tree.CountLessThanOrEqual(value);
     }
 }
 

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -4003,11 +4003,9 @@ public sealed class StochasticRelativeStrengthIndexState : IStreamingIndicatorSt
 
 public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState, IDisposable
 {
-    private readonly int _rocLength;
     private readonly RsiState _rsi;
     private readonly RsiState _streakRsi;
     private readonly RollingPercentRank _rocRank;
-    private readonly PooledRingBuffer<double> _rocWindow;
     private readonly StreamingInputResolver _input;
     private double _prevValue;
     private double _streak;
@@ -4016,11 +4014,9 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
     public ConnorsRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
         int length1 = 2, int length2 = 3, int length3 = 100)
     {
-        _rocLength = Math.Max(1, length3);
         _rsi = new RsiState(maType, Math.Max(1, length2));
         _streakRsi = new RsiState(maType, Math.Max(1, length1));
-        _rocRank = new RollingPercentRank(_rocLength);
-        _rocWindow = new PooledRingBuffer<double>(_rocLength);
+        _rocRank = new RollingPercentRank(Math.Max(1, length3));
         _input = new StreamingInputResolver(InputName.Close, null);
     }
 
@@ -4031,7 +4027,6 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
         _rsi.Reset();
         _streakRsi.Reset();
         _rocRank.Reset();
-        _rocWindow.Clear();
         _prevValue = 0;
         _streak = 0;
         _hasPrev = false;
@@ -4041,11 +4036,13 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
     {
         var currentValue = _input.GetValue(bar);
         var rsi = _rsi.Next(currentValue, isFinal);
-        var rocPrev = _rocWindow.Count >= _rocLength ? _rocWindow[0] : 0;
-        var roc = rocPrev != 0 ? (rsi - rocPrev) / rocPrev * 100 : 0;
+        var prevValue = _hasPrev ? _prevValue : 0;
+
+        // Connors ranks the one-bar rate of change of the price; this used to rank a length3-bar rate of change
+        // of the RSI, copying the batch.
+        var roc = prevValue != 0 ? (currentValue - prevValue) / prevValue * 100 : 0;
         var pctRank = isFinal ? _rocRank.Add(roc) : _rocRank.Preview(roc);
 
-        var prevValue = _hasPrev ? _prevValue : 0;
         var prevStreak = _streak;
         var streak = currentValue > prevValue
             ? prevStreak >= 0 ? prevStreak + 1 : 1
@@ -4061,7 +4058,6 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
             _prevValue = currentValue;
             _streak = streak;
             _hasPrev = true;
-            _rocWindow.TryAdd(rsi, out _);
         }
 
         IReadOnlyDictionary<string, double>? outputs = null;
@@ -4084,7 +4080,6 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
         _rsi.Dispose();
         _streakRsi.Dispose();
         _rocRank.Dispose();
-        _rocWindow.Dispose();
     }
 }
 
@@ -11478,12 +11473,14 @@ public sealed class CCTStochRelativeStrengthIndexState : IStreamingIndicatorStat
 
     public StreamingIndicatorStateResult Update(OhlcvBar bar, bool isFinal, bool includeOutputs)
     {
+        // Five RSIs of the source, one per length. Each used to take the previous one's output, copying a batch
+        // that read its own last result back as the input: the 21-bar RSI was an RSI of an RSI four deep.
         var value = _input.GetValue(bar);
         var rsi5 = _rsi5.Next(value, isFinal);
-        var rsi8 = _rsi8.Next(rsi5, isFinal);
-        var rsi13 = _rsi13.Next(rsi8, isFinal);
-        var rsi14 = _rsi14.Next(rsi13, isFinal);
-        var rsi21 = _rsi21.Next(rsi14, isFinal);
+        var rsi8 = _rsi8.Next(value, isFinal);
+        var rsi13 = _rsi13.Next(value, isFinal);
+        var rsi14 = _rsi14.Next(value, isFinal);
+        var rsi21 = _rsi21.Next(value, isFinal);
 
         var rsi21Len2Min = isFinal ? _rsi21Len2Min.Add(rsi21, out _) : _rsi21Len2Min.Preview(rsi21, out _);
         var rsi21Len2Max = isFinal ? _rsi21Len2Max.Add(rsi21, out _) : _rsi21Len2Max.Preview(rsi21, out _);
@@ -14138,7 +14135,7 @@ internal sealed class RollingPercentRank : IDisposable
     public double Preview(double value)
     {
         var count = CountLessThanOrEqual(value);
-        if (_window.Count == _length && _window[0] <= value)
+        if (_window.Count == _length && _window[0].CompareTo(value) <= 0)
         {
             count--;
         }
@@ -14174,7 +14171,7 @@ internal sealed class RollingPercentRank : IDisposable
             var count = 0;
             for (var i = 0; i < _window.Count; i++)
             {
-                if (_window[i] <= value)
+                if (_window[i].CompareTo(value) <= 0)
                 {
                     count++;
                 }
@@ -14199,7 +14196,7 @@ internal sealed class RollingPercentRank : IDisposable
             var count = 0;
             for (var i = 0; i < _window.Count; i++)
             {
-                if (_window[i] <= value)
+                if (_window[i].CompareTo(value) <= 0)
                 {
                     count++;
                 }

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -30,11 +30,11 @@ public sealed class SimpleMovingAverageState : IStreamingIndicatorState, IDispos
     private readonly RollingWindowSum _window;
     private readonly StreamingInputResolver _input;
 
-    public SimpleMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public SimpleMovingAverageState(int length = 14)
     {
         _length = Math.Max(1, length);
         _window = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SimpleMovingAverage;
@@ -74,10 +74,10 @@ public sealed class ExponentialMovingAverageState : IStreamingIndicatorState
     private readonly EmaState _ema;
     private readonly StreamingInputResolver _input;
 
-    public ExponentialMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public ExponentialMovingAverageState(int length = 14)
     {
         _ema = new EmaState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ExponentialMovingAverage;
@@ -108,10 +108,10 @@ public sealed class WeightedMovingAverageState : IStreamingIndicatorState, IDisp
     private readonly WmaState _wma;
     private readonly StreamingInputResolver _input;
 
-    public WeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public WeightedMovingAverageState(int length = 14)
     {
         _wma = new WmaState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WeightedMovingAverage;
@@ -147,10 +147,10 @@ public sealed class WellesWilderMovingAverageState : IStreamingIndicatorState
     private readonly WilderState _wilder;
     private readonly StreamingInputResolver _input;
 
-    public WellesWilderMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public WellesWilderMovingAverageState(int length = 14)
     {
         _wilder = new WilderState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WellesWilderMovingAverage;
@@ -182,13 +182,12 @@ public sealed class TriangularMovingAverageState : IStreamingIndicatorState, IDi
     private readonly IMovingAverageSmoother _secondary;
     private readonly StreamingInputResolver _input;
 
-    public TriangularMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public TriangularMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _primary = MovingAverageSmootherFactory.Create(maType, resolved);
         _secondary = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TriangularMovingAverage;
@@ -230,8 +229,7 @@ public sealed class HullMovingAverageState : IStreamingIndicatorState, IDisposab
     private readonly IMovingAverageSmoother _finalSmoother;
     private readonly StreamingInputResolver _input;
 
-    public HullMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public HullMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         var length2 = MathHelper.MinOrMax((int)Math.Round((double)resolved / 2));
@@ -239,7 +237,7 @@ public sealed class HullMovingAverageState : IStreamingIndicatorState, IDisposab
         _longSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _shortSmoother = MovingAverageSmootherFactory.Create(maType, length2);
         _finalSmoother = MovingAverageSmootherFactory.Create(maType, sqrtLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HullMovingAverage;
@@ -441,12 +439,12 @@ public sealed class MidpointState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowMin _minWindow;
     private readonly StreamingInputResolver _input;
 
-    public MidpointState(int length = 14, InputName inputName = InputName.Close)
+    public MidpointState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(resolved);
         _minWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Midpoint;
@@ -542,13 +540,13 @@ public sealed class AverageTrueRangeChannelState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public AverageTrueRangeChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double mult = 2.5, InputName inputName = InputName.Close)
+        double mult = 2.5)
     {
         var resolved = Math.Max(1, length);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AverageTrueRangeChannel;
@@ -609,13 +607,13 @@ public sealed class UniChannelState : IStreamingIndicatorState, IDisposable
     private readonly bool _type1;
 
     public UniChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10, double ubFac = 0.02,
-        double lbFac = 0.02, bool type1 = false, InputName inputName = InputName.Close)
+        double lbFac = 0.02, bool type1 = false)
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _ubFac = ubFac;
         _lbFac = lbFac;
         _type1 = type1;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UniChannel;
@@ -661,14 +659,14 @@ public sealed class PriceHeadleyAccelerationBandsState : IStreamingIndicatorStat
     private readonly double _factor;
 
     public PriceHeadleyAccelerationBandsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        double factor = 0.001, InputName inputName = InputName.Close)
+        double factor = 0.001)
     {
         var resolved = Math.Max(1, length);
         _upperSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowerSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceHeadleyAccelerationBands;
@@ -725,13 +723,13 @@ public sealed class PseudoPolynomialChannelState : IStreamingIndicatorState, IDi
     private int _count;
 
     public PseudoPolynomialChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double morph = 0.9, InputName inputName = InputName.Close)
+        double morph = 0.9)
     {
         _length = Math.Max(1, length);
         _morph = morph;
         _kSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _kWindow = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PseudoPolynomialChannel;
@@ -798,12 +796,12 @@ public sealed class ProjectedSupportAndResistanceState : IStreamingIndicatorStat
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public ProjectedSupportAndResistanceState(int length = 25, InputName inputName = InputName.Close)
+    public ProjectedSupportAndResistanceState(int length = 25)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ProjectedSupportAndResistance;
@@ -854,10 +852,10 @@ public sealed class ProjectionBandsState : IStreamingIndicatorState, IDisposable
     private readonly ProjectionBandsCalculator _calculator;
     private readonly StreamingInputResolver _input;
 
-    public ProjectionBandsState(int length = 14, InputName inputName = InputName.Close)
+    public ProjectionBandsState(int length = 14)
     {
         _calculator = new ProjectionBandsCalculator(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ProjectionBands;
@@ -899,11 +897,11 @@ public sealed class ProjectionOscillatorState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
 
     public ProjectionOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        int smoothLength = 4, InputName inputName = InputName.Close)
+        int smoothLength = 4)
     {
         _bands = new ProjectionBandsCalculator(length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ProjectionOscillator;
@@ -948,13 +946,12 @@ public sealed class ProjectionBandwidthState : IStreamingIndicatorState, IDispos
     private readonly IMovingAverageSmoother _signalSmoother;
     private readonly StreamingInputResolver _input;
 
-    public ProjectionBandwidthState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public ProjectionBandwidthState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14)
     {
         var resolvedLength = Math.Max(1, length);
         _bands = new ProjectionBandsCalculator(resolvedLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ProjectionBandwidth;
@@ -1001,14 +998,13 @@ public sealed class RootMovingAverageSquaredErrorBandsState : IStreamingIndicato
     private readonly double _stdDevFactor;
 
     public RootMovingAverageSquaredErrorBandsState(double stdDevFactor = 1,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _powSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RootMovingAverageSquaredErrorBands;
@@ -1059,7 +1055,7 @@ public sealed class MovingAverageBandsState : IStreamingIndicatorState, IDisposa
     private readonly double _mult;
 
     public MovingAverageBandsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 10,
-        int slowLength = 50, double mult = 1, InputName inputName = InputName.Close)
+        int slowLength = 50, double mult = 1)
     {
         var resolvedFast = Math.Max(1, fastLength);
         var resolvedSlow = Math.Max(1, slowLength);
@@ -1067,7 +1063,7 @@ public sealed class MovingAverageBandsState : IStreamingIndicatorState, IDisposa
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
         _sqSum = new RollingWindowSum(resolvedFast);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageBands;
@@ -1122,12 +1118,12 @@ public sealed class MovingAverageSupportResistanceState : IStreamingIndicatorSta
     private readonly double _supportLevel;
 
     public MovingAverageSupportResistanceState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10,
-        double factor = 2, InputName inputName = InputName.Close)
+        double factor = 2)
     {
         var resolved = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _supportLevel = 1 + (factor / 100);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageSupportResistance;
@@ -1176,11 +1172,11 @@ public sealed class MotionToAttractionChannelsState : IStreamingIndicatorState
     private double _prevBMa;
     private int _count;
 
-    public MotionToAttractionChannelsState(int length = 14, InputName inputName = InputName.Close)
+    public MotionToAttractionChannelsState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _alpha = (double)1 / resolved;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MotionToAttractionChannels;
@@ -1251,13 +1247,12 @@ public sealed class MeanAbsoluteErrorBandsState : IStreamingIndicatorState, IDis
     private int _count;
 
     public MeanAbsoluteErrorBandsState(double stdDevFactor = 1,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MeanAbsoluteErrorBands;
@@ -1313,14 +1308,13 @@ public sealed class MeanAbsoluteDeviationBandsState : IStreamingIndicatorState, 
     private readonly double _stdDevFactor;
 
     public MeanAbsoluteDeviationBandsState(double stdDevFactor = 2,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MeanAbsoluteDeviationBands;
@@ -1371,13 +1365,13 @@ public sealed class MovingAverageDisplacedEnvelopeState : IStreamingIndicatorSta
     private readonly double _pct;
 
     public MovingAverageDisplacedEnvelopeState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 9, int length2 = 13, double pct = 0.5, InputName inputName = InputName.Close)
+        int length1 = 9, int length2 = 13, double pct = 0.5)
     {
         _length2 = Math.Max(1, length2);
         _emaSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _emaWindow = new PooledRingBuffer<double>(_length2);
         _pct = pct;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageDisplacedEnvelope;
@@ -1434,14 +1428,14 @@ public sealed class VerticalHorizontalFilterState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public VerticalHorizontalFilterState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 18,
-        int signalLength = 6, InputName inputName = InputName.Close)
+        int signalLength = 6)
     {
         var resolved = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(resolved);
         _minWindow = new RollingWindowMin(resolved);
         _changeSum = new RollingWindowSum(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VerticalHorizontalFilter;
@@ -1508,14 +1502,13 @@ public sealed class SigmaSpikesState : IStreamingIndicatorState, IDisposable
     private double _prevStd;
     private bool _hasStd;
 
-    public SigmaSpikesState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public SigmaSpikesState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SigmaSpikes;
@@ -1585,7 +1578,7 @@ public sealed class StatisticalVolatilityState : IStreamingIndicatorState, IDisp
     private readonly double _annualSqrt;
 
     public StatisticalVolatilityState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 30,
-        int length2 = 253, InputName inputName = InputName.Close)
+        int length2 = 253)
     {
         var resolved = Math.Max(1, length1);
         _closeMax = new RollingWindowMax(resolved);
@@ -1593,7 +1586,7 @@ public sealed class StatisticalVolatilityState : IStreamingIndicatorState, IDisp
         _highMax = new RollingWindowMax(resolved);
         _lowMin = new RollingWindowMin(resolved);
         _volSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _annualSqrt = Math.Sqrt((double)length2 / resolved);
     }
 
@@ -1653,14 +1646,13 @@ public sealed class VolatilitySwitchIndicatorState : IStreamingIndicatorState, I
     private double _prevValue;
     private bool _hasPrev;
 
-    public VolatilitySwitchIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public VolatilitySwitchIndicatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolatilitySwitchIndicator;
@@ -1721,11 +1713,11 @@ public sealed class ExtendedRecursiveBandsState : IStreamingIndicatorState
     private double _prevB;
     private bool _hasPrev;
 
-    public ExtendedRecursiveBandsState(int length = 100, InputName inputName = InputName.Close)
+    public ExtendedRecursiveBandsState(int length = 100)
     {
         var resolved = Math.Max(1, length);
         _sc = (double)2 / (resolved + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ExtendedRecursiveBands;
@@ -1779,13 +1771,13 @@ public sealed class StollerAverageRangeChannelsState : IStreamingIndicatorState,
     private bool _hasPrev;
 
     public StollerAverageRangeChannelsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double atrMult = 2, InputName inputName = InputName.Close)
+        double atrMult = 2)
     {
         var resolved = Math.Max(1, length);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrMult = atrMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StollerAverageRangeChannels;
@@ -1846,7 +1838,7 @@ public sealed class Dema2LinesState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public Dema2LinesState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int fastLength = 10,
-        int slowLength = 40, InputName inputName = InputName.Close)
+        int slowLength = 40)
     {
         var fast = Math.Max(1, fastLength);
         var slow = Math.Max(1, slowLength);
@@ -1854,7 +1846,7 @@ public sealed class Dema2LinesState : IStreamingIndicatorState, IDisposable
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, slow);
         _fastDema = MovingAverageSmootherFactory.Create(maType, fast);
         _slowDema = MovingAverageSmootherFactory.Create(maType, slow);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Dema2Lines;
@@ -1907,15 +1899,14 @@ public sealed class DynamicSupportAndResistanceState : IStreamingIndicatorState,
     private double _prevValue;
     private bool _hasPrev;
 
-    public DynamicSupportAndResistanceState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 25,
-        InputName inputName = InputName.Close)
+    public DynamicSupportAndResistanceState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 25)
     {
         var resolved = Math.Max(1, length);
         _mult = MathHelper.Sqrt(resolved);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DynamicSupportAndResistance;
@@ -2039,11 +2030,11 @@ public sealed class PeriodicChannelState : IStreamingIndicatorState, IDisposable
     private double _absKDiffSum;
     private int _count;
 
-    public PeriodicChannelState(int length1 = 500, int length2 = 2, InputName inputName = InputName.Close)
+    public PeriodicChannelState(int length1 = 500, int length2 = 2)
     {
         _length1 = Math.Max(1, length1);
         _corrWindow = new RollingWindowCorrelation(Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PeriodicChannel;
@@ -2176,12 +2167,11 @@ public sealed class PriceLineChannelState : IStreamingIndicatorState, IDisposabl
     private int _count;
     private bool _hasPrev;
 
-    public PriceLineChannelState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 100,
-        InputName inputName = InputName.Close)
+    public PriceLineChannelState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 100)
     {
         _length = Math.Max(1, length);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceLineChannel;
@@ -2274,12 +2264,11 @@ public sealed class PriceCurveChannelState : IStreamingIndicatorState, IDisposab
     private int _lastBChangeIndex;
     private bool _hasPrev;
 
-    public PriceCurveChannelState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 100,
-        InputName inputName = InputName.Close)
+    public PriceCurveChannelState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 100)
     {
         _length = Math.Max(1, length);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _lastAChangeIndex = -1;
         _lastBChangeIndex = -1;
     }
@@ -2380,7 +2369,7 @@ public sealed class RangeBandsState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public RangeBandsState(double stdDevFactor = 1, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _length = Math.Max(1, length);
         _stdDevFactor = stdDevFactor;
@@ -2388,7 +2377,7 @@ public sealed class RangeBandsState : IStreamingIndicatorState, IDisposable
         var windowLength = Math.Max(2, _length);
         _maxWindow = new RollingWindowMax(windowLength);
         _minWindow = new RollingWindowMin(windowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RangeBands;
@@ -2439,9 +2428,9 @@ public sealed class RangeIdentifierState : IStreamingIndicatorState
     private double _prevDown;
     private bool _hasPrev;
 
-    public RangeIdentifierState(int length = 34, InputName inputName = InputName.Close)
+    public RangeIdentifierState(int length = 34)
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RangeIdentifier;
@@ -2490,10 +2479,10 @@ public sealed class LinearRegressionState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public LinearRegressionState(int length = 14, InputName inputName = InputName.Close)
+    public LinearRegressionState(int length = 14)
     {
         _regression = new RollingLeastSquares(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     internal LinearRegressionState(int length, Func<OhlcvBar, double> selector)
@@ -2560,9 +2549,9 @@ public sealed class StandardDeviationChannelState : IStreamingIndicatorState, ID
     private readonly double _stdDevMult;
     private double _regressionInput;
 
-    public StandardDeviationChannelState(int length = 40, double stdDevMult = 2, InputName inputName = InputName.Close)
+    public StandardDeviationChannelState(int length = 40, double stdDevMult = 2)
     {
-        _stdDevState = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, length, inputName);
+        _stdDevState = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, length);
         _regressionState = new LinearRegressionState(length, _ => _regressionInput);
         _stdDevMult = stdDevMult;
     }
@@ -2612,10 +2601,10 @@ public sealed class TimeSeriesForecastState : IStreamingIndicatorState, IDisposa
     private double _absDiffSum;
     private int _index;
 
-    public TimeSeriesForecastState(int length = 500, InputName inputName = InputName.Close)
+    public TimeSeriesForecastState(int length = 500)
     {
-        _regressionState = new LinearRegressionState(length, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _regressionState = new LinearRegressionState(length);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TimeSeriesForecast;
@@ -2675,11 +2664,11 @@ public sealed class SmartEnvelopeState : IStreamingIndicatorState
     private double _prevBSignal;
     private bool _hasPrev;
 
-    public SmartEnvelopeState(int length = 14, double factor = 1, InputName inputName = InputName.Close)
+    public SmartEnvelopeState(int length = 14, double factor = 1)
     {
         _length = Math.Max(1, length);
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SmartEnvelope;
@@ -2746,14 +2735,13 @@ public sealed class SupportResistanceState : IStreamingIndicatorState, IDisposab
     private double _prevSupp;
     private bool _hasPrev;
 
-    public SupportResistanceState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public SupportResistanceState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SupportResistance;
@@ -2825,8 +2813,7 @@ public sealed class StationaryExtrapolatedLevelsState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public StationaryExtrapolatedLevelsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200,
-        InputName inputName = InputName.Close)
+    public StationaryExtrapolatedLevelsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200)
     {
         _length = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, _length);
@@ -2835,7 +2822,7 @@ public sealed class StationaryExtrapolatedLevelsState : IStreamingIndicatorState
         _extMax2 = new RollingWindowMax(_length);
         _extMin2 = new RollingWindowMin(_length);
         _yBuffer = new PooledRingBuffer<double>(_length * 2 + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StationaryExtrapolatedLevels;
@@ -2913,7 +2900,7 @@ public sealed class ScalpersChannelState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public ScalpersChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 15,
-        int length2 = 20, InputName inputName = InputName.Close)
+        int length2 = 20)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -2921,7 +2908,7 @@ public sealed class ScalpersChannelState : IStreamingIndicatorState, IDisposable
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
         _highWindow = new RollingWindowMax(resolved1);
         _lowWindow = new RollingWindowMin(resolved1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ScalpersChannel;
@@ -2990,7 +2977,7 @@ public sealed class SmoothedVolatilityBandsState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public SmoothedVolatilityBandsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 20,
-        int length2 = 21, double deviation = 2.4, double bandAdjust = 0.9, InputName inputName = InputName.Close)
+        int length2 = 21, double deviation = 2.4, double bandAdjust = 0.9)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -3000,7 +2987,7 @@ public sealed class SmoothedVolatilityBandsState : IStreamingIndicatorState, IDi
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
         _deviation = deviation;
         _bandAdjust = bandAdjust;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.SmoothedVolatilityBands;
@@ -3062,12 +3049,12 @@ public sealed class MovingAverageEnvelopeState : IStreamingIndicatorState, IDisp
     private readonly double _mult;
 
     public MovingAverageEnvelopeState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        double mult = 0.025, InputName inputName = InputName.Close)
+        double mult = 0.025)
     {
         var resolved = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageEnvelope;
@@ -3116,11 +3103,11 @@ public sealed class LinearChannelsState : IStreamingIndicatorState
     private double _prevLower;
     private int _count;
 
-    public LinearChannelsState(int length = 14, double mult = 50, InputName inputName = InputName.Close)
+    public LinearChannelsState(int length = 14, double mult = 50)
     {
         _length = Math.Max(1, length);
         _mult = mult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.LinearChannels;
@@ -3181,13 +3168,13 @@ public sealed class NarrowSidewaysChannelState : IStreamingIndicatorState, IDisp
     private readonly double _stdDevMult;
 
     public NarrowSidewaysChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double stdDevMult = 3, InputName inputName = InputName.Close)
+        double stdDevMult = 3)
     {
         var resolved = Math.Max(1, length);
         _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new RollingStandardDeviation(resolved);
         _stdDevMult = stdDevMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.NarrowSidewaysChannel;
@@ -3236,10 +3223,10 @@ public sealed class RateOfChangeBandsState : IStreamingIndicatorState, IDisposab
     private readonly RollingWindowSum _rocSquaredSum;
 
     public RateOfChangeBandsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 12,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         _length = Math.Max(1, length);
-        _roc = new RateOfChangeState(_length, inputName);
+        _roc = new RateOfChangeState(_length);
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _rocSquaredSum = new RollingWindowSum(_length);
     }
@@ -3295,10 +3282,10 @@ public sealed class GChannelsState : IStreamingIndicatorState
     private double _prevB;
     private int _count;
 
-    public GChannelsState(int length = 100, InputName inputName = InputName.Close)
+    public GChannelsState(int length = 100)
     {
         _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GChannels;
@@ -3351,15 +3338,14 @@ public sealed class HighLowMovingAverageState : IStreamingIndicatorState, IDispo
     private readonly IMovingAverageSmoother _lowerSmoother;
     private readonly StreamingInputResolver _input;
 
-    public HighLowMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public HighLowMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _upperSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowerSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HighLowMovingAverage;
@@ -3412,13 +3398,13 @@ public sealed class HighLowBandsState : IStreamingIndicatorState, IDisposable
     private readonly double _pctShift;
 
     public HighLowBandsState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        double pctShift = 1, InputName inputName = InputName.Close)
+        double pctShift = 1)
     {
         var resolved = Math.Max(1, length);
         _firstSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _secondSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _pctShift = pctShift;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.HighLowBands;
@@ -3468,7 +3454,7 @@ public sealed class KeltnerChannelsState : IStreamingIndicatorState, IDisposable
     private bool _hasPrev;
 
     public KeltnerChannelsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 20,
-        int length2 = 10, double multFactor = 2, InputName inputName = InputName.Close,
+        int length2 = 10, double multFactor = 2,
         MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
     {
         // The ATR is smoothed with Wilder's method, matching the batch CalculateKeltnerChannels and the
@@ -3477,7 +3463,7 @@ public sealed class KeltnerChannelsState : IStreamingIndicatorState, IDisposable
         _atrSmoother = MovingAverageSmootherFactory.Create(atrMaType, Math.Max(1, length2));
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _mult = multFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public KeltnerChannelsState(MovingAvgType maType, int length1, int length2, double multFactor,
@@ -3556,12 +3542,12 @@ public sealed class DEnvelopeState : IStreamingIndicatorState
     private double _mt2;
     private double _ut2;
 
-    public DEnvelopeState(int length = 20, double devFactor = 2, InputName inputName = InputName.Close)
+    public DEnvelopeState(int length = 20, double devFactor = 2)
     {
         var resolved = Math.Max(1, length);
         _alpha = (double)2 / (resolved + 1);
         _devFactor = devFactor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DEnvelope;
@@ -3619,12 +3605,12 @@ public sealed class PriceChannelState : IStreamingIndicatorState, IDisposable
     private readonly double _pct;
 
     public PriceChannelState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 21,
-        double pct = 0.06, InputName inputName = InputName.Close)
+        double pct = 0.06)
     {
         var resolved = Math.Max(1, length);
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _pct = pct;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PriceChannel;
@@ -3668,13 +3654,12 @@ public sealed class MovingAverageChannelState : IStreamingIndicatorState, IDispo
     private readonly IMovingAverageSmoother _lowSmoother;
     private readonly StreamingInputResolver _input;
 
-    public MovingAverageChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public MovingAverageChannelState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageChannel;
@@ -3724,12 +3709,12 @@ public sealed class RelativeStrengthIndexState : IStreamingIndicatorState
     private double _prevClose;
     private bool _hasPrev;
 
-    public RelativeStrengthIndexState(int length = 14, int signalLength = 3, InputName inputName = InputName.Close)
+    public RelativeStrengthIndexState(int length = 14, int signalLength = 3)
     {
         _avgGain = new WilderState(length);
         _avgLoss = new WilderState(length);
         _signal = new WilderState(signalLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RelativeStrengthIndex;
@@ -3789,14 +3774,14 @@ public sealed class StochasticOscillatorState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
 
     public StochasticOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int smoothLength1 = 3, int smoothLength2 = 3, InputName inputName = InputName.Close)
+        int smoothLength1 = 3, int smoothLength2 = 3)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticOscillator;
@@ -3853,12 +3838,12 @@ public sealed class WilliamsRState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public WilliamsRState(int length = 14, InputName inputName = InputName.Close)
+    public WilliamsRState(int length = 14)
     {
         _length = Math.Max(1, length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.WilliamsR;
@@ -3906,12 +3891,11 @@ public sealed class CommodityChannelIndexState : IStreamingIndicatorState, IDisp
     private StreamingInputResolver _input;
     private readonly double _constant;
 
-    public CommodityChannelIndexState(InputName inputName = InputName.TypicalPrice,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20, double constant = 0.015)
+    public CommodityChannelIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20, double constant = 0.015)
     {
         _priceSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _meanDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
         _constant = constant;
     }
 
@@ -3965,7 +3949,7 @@ public sealed class StochasticRelativeStrengthIndexState : IStreamingIndicatorSt
     private readonly StreamingInputResolver _input;
 
     public StochasticRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14,
-        int smoothLength1 = 3, int smoothLength2 = 3, InputName inputName = InputName.Close)
+        int smoothLength1 = 3, int smoothLength2 = 3)
     {
         _length = Math.Max(1, length);
         _rsi = new RsiState(maType, _length);
@@ -3975,7 +3959,7 @@ public sealed class StochasticRelativeStrengthIndexState : IStreamingIndicatorSt
         _minWindow = new RollingWindowMin(_length);
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticRelativeStrengthIndex;
@@ -4043,14 +4027,14 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public ConnorsRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length1 = 2, int length2 = 3, int length3 = 100, InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 3, int length3 = 100)
     {
         _rocLength = Math.Max(1, length3);
         _rsi = new RsiState(maType, Math.Max(1, length2));
         _streakRsi = new RsiState(maType, Math.Max(1, length1));
         _rocRank = new RollingPercentRank(_rocLength);
         _rocWindow = new PooledRingBuffer<double>(_rocLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ConnorsRelativeStrengthIndex;
@@ -4129,11 +4113,10 @@ public sealed class StochasticConnorsRelativeStrengthIndexState : IStreamingIndi
     private readonly IMovingAverageSmoother _slowSmoother;
 
     public StochasticConnorsRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod,
-        int length1 = 2, int length2 = 3, int length3 = 100, int smoothLength1 = 3, int smoothLength2 = 3,
-        InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 3, int length3 = 100, int smoothLength1 = 3, int smoothLength2 = 3)
     {
         _length = Math.Max(1, length2);
-        _connors = new ConnorsRelativeStrengthIndexState(maType, length1, length2, length3, inputName);
+        _connors = new ConnorsRelativeStrengthIndexState(maType, length1, length2, length3);
         _inputHighWindow = new RollingWindowMax(2);
         _inputLowWindow = new RollingWindowMin(2);
         _maxWindow = new RollingWindowMax(_length);
@@ -4205,7 +4188,7 @@ public sealed class StochasticMomentumIndexState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
 
     public StochasticMomentumIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 2, int length2 = 8, int smoothLength1 = 5, int smoothLength2 = 5, InputName inputName = InputName.Close)
+        int length1 = 2, int length2 = 8, int smoothLength1 = 5, int smoothLength2 = 5)
     {
         _length = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(_length);
@@ -4215,7 +4198,7 @@ public sealed class StochasticMomentumIndexState : IStreamingIndicatorState, IDi
         _rangeSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _rangeSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StochasticMomentumIndex;
@@ -4283,13 +4266,12 @@ public sealed class MovingAverageConvergenceDivergenceState : IStreamingIndicato
     private readonly EmaState _signal;
     private readonly StreamingInputResolver _input;
 
-    public MovingAverageConvergenceDivergenceState(int fastLength = 12, int slowLength = 26, int signalLength = 9,
-        InputName inputName = InputName.Close)
+    public MovingAverageConvergenceDivergenceState(int fastLength = 12, int slowLength = 26, int signalLength = 9)
     {
         _fast = new EmaState(fastLength);
         _slow = new EmaState(slowLength);
         _signal = new EmaState(signalLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageConvergenceDivergence;
@@ -4332,11 +4314,11 @@ public sealed class AbsolutePriceOscillatorState : IStreamingIndicatorState, IDi
     private readonly StreamingInputResolver _input;
 
     public AbsolutePriceOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 10, int slowLength = 20, InputName inputName = InputName.Close)
+        int fastLength = 10, int slowLength = 20)
     {
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AbsolutePriceOscillator;
@@ -4381,13 +4363,12 @@ public sealed class PercentagePriceOscillatorState : IStreamingIndicatorState, I
     private readonly StreamingInputResolver _input;
 
     public PercentagePriceOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int fastLength = 12, int slowLength = 26, int signalLength = 9,
-        InputName inputName = InputName.Close)
+        int fastLength = 12, int slowLength = 26, int signalLength = 9)
     {
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.PercentagePriceOscillator;
@@ -4495,12 +4476,12 @@ public sealed class DonchianChannelsState : IStreamingIndicatorState, IDisposabl
     private readonly RollingWindowMin _lowWindow;
     private readonly StreamingInputResolver _input;
 
-    public DonchianChannelsState(int length = 20, InputName inputName = InputName.Close)
+    public DonchianChannelsState(int length = 20)
     {
         var resolved = Math.Max(1, length);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DonchianChannels;
@@ -4548,13 +4529,13 @@ public sealed class ClosedFormDistanceVolatilityState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public ClosedFormDistanceVolatilityState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, InputName inputName = InputName.Close)
+        int length = 14)
     {
         _length = Math.Max(1, length);
         _ema = MovingAverageSmootherFactory.Create(maType, _length);
         _highSum = new RollingWindowSum(_length);
         _lowSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ClosedFormDistanceVolatility;
@@ -4608,14 +4589,14 @@ public sealed class DonchianChannelWidthState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
 
     public DonchianChannelWidthState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        int smoothLength = 22, InputName inputName = InputName.Close)
+        int smoothLength = 22)
     {
         var resolved = Math.Max(1, length);
         _priceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _widthSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DonchianChannelWidth;
@@ -4669,11 +4650,10 @@ public sealed class HistoricalVolatilityState : IStreamingIndicatorState, IDispo
     private double _logReturn;
     private bool _hasPrev;
 
-    public HistoricalVolatilityState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public HistoricalVolatilityState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20)
     {
         _stdDev = new StandardDeviationVolatilityState(maType, length, _ => _logReturn);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _annualSqrt = MathHelper.Sqrt(365);
     }
 
@@ -4730,12 +4710,12 @@ public sealed class GarmanKlassVolatilityState : IStreamingIndicatorState, IDisp
     private int _index;
 
     public GarmanKlassVolatilityState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 14,
-        int signalLength = 7, InputName inputName = InputName.Close)
+        int signalLength = 7)
     {
         _length = Math.Max(1, length);
         _logSum = new RollingWindowSum(_length);
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _logCoeff = (2 * Math.Log(2)) - 1;
     }
 
@@ -4793,15 +4773,14 @@ public sealed class GopalakrishnanRangeIndexState : IStreamingIndicatorState, ID
     private readonly IMovingAverageSmoother _signal;
     private readonly StreamingInputResolver _input;
 
-    public GopalakrishnanRangeIndexState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 5,
-        InputName inputName = InputName.Close)
+    public GopalakrishnanRangeIndexState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 5)
     {
         var resolved = Math.Max(1, length);
         _logLength = Math.Log(resolved);
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.GopalakrishnanRangeIndex;
@@ -4858,7 +4837,7 @@ public sealed class HistoricalVolatilityPercentileState : IStreamingIndicatorSta
     private bool _hasPrev;
 
     public HistoricalVolatilityPercentileState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 21, int annualLength = 252, InputName inputName = InputName.Close)
+        int length = 21, int annualLength = 252)
     {
         _length = Math.Max(1, length);
         _annualLength = Math.Max(1, annualLength);
@@ -4866,7 +4845,7 @@ public sealed class HistoricalVolatilityPercentileState : IStreamingIndicatorSta
         _tempLogSum = new RollingWindowSum(_length);
         _devLogSqSum = new RollingWindowSum(_length);
         _signal = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _hvOrder = new RollingOrderStatistic(_annualLength);
     }
 
@@ -4946,8 +4925,7 @@ public sealed class FastZScoreState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
     private double _maValue;
 
-    public FastZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200,
-        InputName inputName = InputName.Close)
+    public FastZScoreState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 200)
     {
         var resolved = Math.Max(1, length);
         var length2 = MathHelper.MinOrMax((int)Math.Ceiling((double)resolved / 2));
@@ -4955,7 +4933,7 @@ public sealed class FastZScoreState : IStreamingIndicatorState, IDisposable
         _linregLong = new LinearRegressionState(resolved, _ => _maValue);
         _linregShort = new LinearRegressionState(length2, _ => _maValue);
         _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _maValue);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.FastZScore;
@@ -5011,13 +4989,13 @@ public sealed class ChoppinessIndexState : IStreamingIndicatorState, IDisposable
     private double _prevValue;
     private bool _hasPrev;
 
-    public ChoppinessIndexState(int length = 14, InputName inputName = InputName.Close)
+    public ChoppinessIndexState(int length = 14)
     {
         _length = Math.Max(1, length);
         _trSum = new RollingWindowSum(_length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChoppinessIndex;
@@ -5084,12 +5062,12 @@ public sealed class ChandeMomentumOscillatorState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public ChandeMomentumOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 14, int signalLength = 3, InputName inputName = InputName.Close)
+        int length = 14, int signalLength = 3)
     {
         _posSum = new RollingWindowSum(Math.Max(1, length));
         _negSum = new RollingWindowSum(Math.Max(1, length));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillator;
@@ -5285,13 +5263,13 @@ public sealed class BollingerBandsState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public BollingerBandsState(int length = 20, double stdDevMult = 2,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage, InputName inputName = InputName.Close)
+        MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
     {
         var resolved = Math.Max(1, length);
         _stdDevMult = stdDevMult;
         _middle = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBands;
@@ -5338,14 +5316,25 @@ public sealed class StandardDeviationVolatilityState : IStreamingIndicatorState,
     private readonly IMovingAverageSmoother _signalMa;
     private readonly StreamingInputResolver _input;
 
-    public StandardDeviationVolatilityState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    // Internal: the library composes this state on a named input other than its own default -
+    // a volatility of volume, a relative volatility of the high and of the low. Every parameter is
+    // required, so this can never be chosen in place of the public constructor.
+    internal StandardDeviationVolatilityState(MovingAvgType maType, int length, InputName inputName)
     {
         var resolved = Math.Max(1, length);
         _inputMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _varianceMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
+    }
+
+    public StandardDeviationVolatilityState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
+    {
+        var resolved = Math.Max(1, length);
+        _inputMa = MovingAverageSmootherFactory.Create(maType, resolved);
+        _varianceMa = MovingAverageSmootherFactory.Create(maType, resolved);
+        _signalMa = MovingAverageSmootherFactory.Create(maType, resolved);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     internal StandardDeviationVolatilityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
@@ -5410,14 +5399,13 @@ public sealed class StandardDeviationState : IStreamingIndicatorState, IDisposab
     private readonly IMovingAverageSmoother _signalMa;
     private readonly StreamingInputResolver _input;
 
-    public StandardDeviationState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public StandardDeviationState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _sumWindow = new RollingWindowSum(_length);
         _powMa = MovingAverageSmootherFactory.Create(maType, _length);
         _signalMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.StandardDeviation;
@@ -5469,12 +5457,11 @@ public sealed class UltimateVolatilityIndicatorState : IStreamingIndicatorState,
     private readonly RollingWindowSum _absSum;
     private readonly StreamingInputResolver _input;
 
-    public UltimateVolatilityIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public UltimateVolatilityIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _absSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.UltimateVolatilityIndicator;
@@ -5521,13 +5508,13 @@ public sealed class VolatilityBasedMomentumState : IStreamingIndicatorState, IDi
     private bool _hasPrev;
 
     public VolatilityBasedMomentumState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length1 = 22,
-        int length2 = 65, InputName inputName = InputName.Close)
+        int length2 = 65)
     {
         _length1 = Math.Max(1, length1);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
         _window = new PooledRingBuffer<double>(_length1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityBasedMomentum;
@@ -5591,11 +5578,11 @@ public sealed class VolatilityQualityIndexState : IStreamingIndicatorState, IDis
     private bool _hasPrev;
 
     public VolatilityQualityIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int fastLength = 9,
-        int slowLength = 200, InputName inputName = InputName.Close)
+        int slowLength = 200)
     {
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityQualityIndex;
@@ -5661,10 +5648,10 @@ public sealed class OnBalanceVolumeState : IStreamingIndicatorState
     private double _obv;
     private bool _hasPrev;
 
-    public OnBalanceVolumeState(int length = 20, InputName inputName = InputName.Close)
+    public OnBalanceVolumeState(int length = 20)
     {
         _signal = new EmaState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.OnBalanceVolume;
@@ -5771,12 +5758,12 @@ public sealed class MoneyFlowIndexState : IStreamingIndicatorState, IDisposable,
     private double _prevTypical;
     private bool _hasPrev;
 
-    public MoneyFlowIndexState(int length = 14, InputName inputName = InputName.TypicalPrice)
+    public MoneyFlowIndexState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _posSum = new RollingWindowSum(resolved);
         _negSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.MoneyFlowIndex;
@@ -5960,14 +5947,14 @@ public sealed class TrueStrengthIndexState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
 
     public TrueStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 25,
-        int length2 = 13, int signalLength = 7, InputName inputName = InputName.Close)
+        int length2 = 13, int signalLength = 7)
     {
         _pcSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _pcSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _absSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _absSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.TrueStrengthIndex;
@@ -6032,10 +6019,10 @@ public sealed class ElderRayIndexState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public ElderRayIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 13, InputName inputName = InputName.Close)
+        int length = 13)
     {
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ElderRayIndex;
@@ -6350,13 +6337,12 @@ public sealed class ChartmillValueIndicatorState : IStreamingIndicatorState, IDi
     private double _prevClose;
     private bool _hasPrev;
 
-    public ChartmillValueIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        InputName inputName = InputName.MedianPrice, int length = 5)
+    public ChartmillValueIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 5)
     {
         var resolved = Math.Max(1, length);
         _inputSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
         _lengthSqrt = MathHelper.Pow(resolved, 0.5);
     }
 
@@ -6512,13 +6498,12 @@ public sealed class DetrendedPriceOscillatorState : IStreamingIndicatorState, ID
     private readonly PooledRingBuffer<double> _window;
     private readonly int _prevPeriods;
 
-    public DetrendedPriceOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        InputName inputName = InputName.Close)
+    public DetrendedPriceOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20)
     {
         var resolved = Math.Max(1, length);
         _prevPeriods = MathHelper.MinOrMax((int)Math.Ceiling(((double)resolved / 2) + 1));
         _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _window = new PooledRingBuffer<double>(_prevPeriods);
     }
 
@@ -6652,14 +6637,14 @@ public sealed class AbsoluteStrengthMTFIndicatorState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public AbsoluteStrengthMTFIndicatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 50,
-        int smoothLength = 25, InputName inputName = InputName.Close)
+        int smoothLength = 25)
     {
         var resolvedLength = Math.Max(1, length);
         _price1 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _price2 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _bulls = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _bears = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AbsoluteStrengthMTFIndicator;
@@ -6720,11 +6705,11 @@ public sealed class AroonOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _window;
     private readonly StreamingInputResolver _input;
 
-    public AroonOscillatorState(int length = 25, InputName inputName = InputName.Close)
+    public AroonOscillatorState(int length = 25)
     {
         _length = Math.Max(1, length);
         _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AroonOscillator;
@@ -6976,14 +6961,13 @@ public sealed class ChopZoneState : IStreamingIndicatorState, IDisposable, ICust
     private double _prevEma;
     private bool _hasPrevEma;
 
-    public ChopZoneState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        InputName inputName = InputName.TypicalPrice, int length1 = 30, int length2 = 34)
+    public ChopZoneState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 30, int length2 = 34)
     {
         var resolved1 = Math.Max(1, length1);
         _highWindow = new RollingWindowMax(resolved1);
         _lowWindow = new RollingWindowMin(resolved1);
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.ChopZone;
@@ -7049,12 +7033,12 @@ public sealed class CenterOfLinearityState : IStreamingIndicatorState, IDisposab
     private bool _hasPrev;
     private int _index;
 
-    public CenterOfLinearityState(int length = 14, InputName inputName = InputName.Close)
+    public CenterOfLinearityState(int length = 14)
     {
         _length = Math.Max(1, length);
         _sumWindow = new RollingWindowSum(_length);
         _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CenterOfLinearity;
@@ -7164,9 +7148,9 @@ public sealed class CoppockCurveState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _smoother;
 
     public CoppockCurveState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 10, int fastLength = 11,
-        int slowLength = 14, InputName inputName = InputName.Close)
+        int slowLength = 14)
     {
-        _rocFast = new RateOfChangeState(Math.Max(1, fastLength), inputName);
+        _rocFast = new RateOfChangeState(Math.Max(1, fastLength));
         _slowLength = Math.Max(1, slowLength);
         _rocFastWindow = new PooledRingBuffer<double>(_slowLength);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
@@ -7330,13 +7314,12 @@ public sealed class DeltaMovingAverageState : IStreamingIndicatorState, IDisposa
     private readonly PooledRingBuffer<double> _openWindow;
     private readonly StreamingInputResolver _input;
 
-    public DeltaMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 10, int length2 = 5,
-        InputName inputName = InputName.Close)
+    public DeltaMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 10, int length2 = 5)
     {
         _length2 = Math.Max(1, length2);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _openWindow = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DeltaMovingAverage;
@@ -7453,13 +7436,13 @@ public sealed class DerivativeOscillatorState : IStreamingIndicatorState, IDispo
     private readonly StreamingInputResolver _input;
 
     public DerivativeOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 14, int length2 = 9,
-        int length3 = 5, int length4 = 3, InputName inputName = InputName.Close)
+        int length3 = 5, int length4 = 3)
     {
         _rsi = new RsiState(maType, Math.Max(1, length1));
         _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
         _sumWindow = new RollingWindowSum(Math.Max(1, length2));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DerivativeOscillator;
@@ -7515,7 +7498,7 @@ public sealed class DemandOscillatorState : IStreamingIndicatorState, IDisposabl
     private bool _hasPrev;
 
     public DemandOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 10, int length2 = 2,
-        int length3 = 20, InputName inputName = InputName.Close)
+        int length3 = 20)
     {
         var resolved2 = Math.Max(1, length2);
         _highWindow = new RollingWindowMax(resolved2);
@@ -7523,7 +7506,7 @@ public sealed class DemandOscillatorState : IStreamingIndicatorState, IDisposabl
         _rangeSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _doSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DemandOscillator;
@@ -7598,7 +7581,7 @@ public sealed class DoubleSmoothedMomentaState : IStreamingIndicatorState, IDisp
     private readonly StreamingInputResolver _input;
 
     public DoubleSmoothedMomentaState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 2, int length2 = 5,
-        int length3 = 25, InputName inputName = InputName.Close)
+        int length3 = 25)
     {
         var resolved1 = Math.Max(1, length1);
         _maxWindow = new RollingWindowMax(resolved1);
@@ -7608,7 +7591,7 @@ public sealed class DoubleSmoothedMomentaState : IStreamingIndicatorState, IDisp
         _botSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _botSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DoubleSmoothedMomenta;
@@ -7670,13 +7653,12 @@ public sealed class DidiIndexState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _longSma;
     private readonly StreamingInputResolver _input;
 
-    public DidiIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 3, int length2 = 8, int length3 = 20,
-        InputName inputName = InputName.Close)
+    public DidiIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length1 = 3, int length2 = 8, int length3 = 20)
     {
         _shortSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _mediumSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _longSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DidiIndex;
@@ -7724,10 +7706,10 @@ public sealed class DisparityIndexState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _smoother;
     private readonly StreamingInputResolver _input;
 
-    public DisparityIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14, InputName inputName = InputName.Close)
+    public DisparityIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DisparityIndex;
@@ -7907,14 +7889,14 @@ public sealed class DTOscillatorState : IStreamingIndicatorState, IDisposable
     private readonly StreamingInputResolver _input;
 
     public DTOscillatorState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length1 = 13, int length2 = 8,
-        int length3 = 5, int length4 = 3, InputName inputName = InputName.Close)
+        int length3 = 5, int length4 = 3)
     {
         _wima = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _maxWindow = new RollingWindowMax(Math.Max(1, length2));
         _minWindow = new RollingWindowMin(Math.Max(1, length2));
         _stoSum = new RollingWindowSum(Math.Max(1, length3));
         _skSum = new RollingWindowSum(Math.Max(1, length4));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.DTOscillator;
@@ -7969,11 +7951,11 @@ public sealed class RateOfChangeState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _window;
     private readonly StreamingInputResolver _input;
 
-    public RateOfChangeState(int length = 12, InputName inputName = InputName.Close)
+    public RateOfChangeState(int length = 12)
     {
         _length = Math.Max(1, length);
         _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.RateOfChange;
@@ -8023,12 +8005,12 @@ public sealed class UlcerIndexState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowSum _drawdownSum;
     private readonly StreamingInputResolver _input;
 
-    public UlcerIndexState(int length = 14, InputName inputName = InputName.Close)
+    public UlcerIndexState(int length = 14)
     {
         _length = Math.Max(1, length);
         _maxWindow = new RollingWindowMax(_length);
         _drawdownSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     internal UlcerIndexState(int length, Func<OhlcvBar, double> selector)
@@ -8172,13 +8154,13 @@ public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposab
     private readonly RollingWindowSum _slowSum;
     private StreamingInputResolver _input;
 
-    public AwesomeOscillatorState(int fastLength = 5, int slowLength = 34, InputName inputName = InputName.MedianPrice)
+    public AwesomeOscillatorState(int fastLength = 5, int slowLength = 34)
     {
         _fastLength = Math.Max(1, fastLength);
         _slowLength = Math.Max(1, slowLength);
         _fastSum = new RollingWindowSum(_fastLength);
         _slowSum = new RollingWindowSum(_slowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.AwesomeOscillator;
@@ -8232,8 +8214,7 @@ public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisp
     private readonly RollingWindowSum _smoothSum;
     private StreamingInputResolver _input;
 
-    public AcceleratorOscillatorState(int fastLength = 5, int slowLength = 34, int smoothLength = 5,
-        InputName inputName = InputName.MedianPrice)
+    public AcceleratorOscillatorState(int fastLength = 5, int slowLength = 34, int smoothLength = 5)
     {
         _fastLength = Math.Max(1, fastLength);
         _slowLength = Math.Max(1, slowLength);
@@ -8241,7 +8222,7 @@ public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisp
         _fastSum = new RollingWindowSum(_fastLength);
         _slowSum = new RollingWindowSum(_slowLength);
         _smoothSum = new RollingWindowSum(_smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.AcceleratorOscillator;
@@ -8301,12 +8282,12 @@ public sealed class TrixState : IStreamingIndicatorState
     private double _prevEma3;
     private bool _hasPrev;
 
-    public TrixState(int length = 15, InputName inputName = InputName.Close)
+    public TrixState(int length = 15)
     {
         _ema1 = new EmaState(length);
         _ema2 = new EmaState(length);
         _ema3 = new EmaState(length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.Trix;
@@ -8357,14 +8338,13 @@ public sealed class _1LCLeastSquaresMovingAverageState : IStreamingIndicatorStat
     private readonly StreamingInputResolver _input;
     private int _index;
 
-    public _1LCLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        InputName inputName = InputName.Close)
+    public _1LCLeastSquaresMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14)
     {
         _length = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _stdDev = new RollingStandardDeviation(_length);
         _correlation = new RollingWindowCorrelation(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName._1LCLeastSquaresMovingAverage;
@@ -8421,8 +8401,7 @@ public sealed class _3HMAState : IStreamingIndicatorState, IDisposable
     private readonly IMovingAverageSmoother _final;
     private readonly StreamingInputResolver _input;
 
-    public _3HMAState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 50,
-        InputName inputName = InputName.Close)
+    public _3HMAState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 50)
     {
         var p = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
         var p1 = MathHelper.MinOrMax((int)Math.Ceiling((double)p / 3));
@@ -8432,7 +8411,7 @@ public sealed class _3HMAState : IStreamingIndicatorState, IDisposable
         _wma2 = MovingAverageSmootherFactory.Create(maType, p2);
         _wma3 = MovingAverageSmootherFactory.Create(maType, p);
         _final = MovingAverageSmootherFactory.Create(maType, p);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName._3HMA;
@@ -8493,7 +8472,7 @@ public sealed class _4MovingAverageConvergenceDivergenceState : IStreamingIndica
 
     public _4MovingAverageConvergenceDivergenceState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 5,
         int length2 = 8, int length3 = 10, int length4 = 17, int length5 = 14, int length6 = 16,
-        double blueMult = 4.3, double yellowMult = 1.4, InputName inputName = InputName.Close)
+        double blueMult = 4.3, double yellowMult = 1.4)
     {
         var resolved1 = Math.Max(1, length1);
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved1);
@@ -8508,7 +8487,7 @@ public sealed class _4MovingAverageConvergenceDivergenceState : IStreamingIndica
         _signal4 = MovingAverageSmootherFactory.Create(maType, resolved1);
         _blueMult = blueMult;
         _yellowMult = yellowMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName._4MovingAverageConvergenceDivergence;
@@ -8604,7 +8583,7 @@ public sealed class _4PercentagePriceOscillatorState : IStreamingIndicatorState,
 
     public _4PercentagePriceOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length1 = 5,
         int length2 = 8, int length3 = 10, int length4 = 17, int length5 = 14, int length6 = 16,
-        double blueMult = 4.3, double yellowMult = 1.4, InputName inputName = InputName.Close)
+        double blueMult = 4.3, double yellowMult = 1.4)
     {
         var resolved1 = Math.Max(1, length1);
         _ema5 = MovingAverageSmootherFactory.Create(maType, resolved1);
@@ -8619,7 +8598,7 @@ public sealed class _4PercentagePriceOscillatorState : IStreamingIndicatorState,
         _signal4 = MovingAverageSmootherFactory.Create(maType, resolved1);
         _blueMult = blueMult;
         _yellowMult = yellowMult;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName._4PercentagePriceOscillator;
@@ -8713,8 +8692,7 @@ public sealed class AdaptiveMovingAverageState : IStreamingIndicatorState, IDisp
     private double _prevAma;
     private bool _hasPrev;
 
-    public AdaptiveMovingAverageState(int fastLength = 2, int slowLength = 14, int length = 14,
-        InputName inputName = InputName.Close)
+    public AdaptiveMovingAverageState(int fastLength = 2, int slowLength = 14, int length = 14)
     {
         _length = Math.Max(1, length);
         _fastAlpha = (double)2 / (Math.Max(1, fastLength) + 1);
@@ -8722,7 +8700,7 @@ public sealed class AdaptiveMovingAverageState : IStreamingIndicatorState, IDisp
         var windowLength = Math.Max(1, _length + 1);
         _highWindow = new RollingWindowMax(windowLength);
         _lowWindow = new RollingWindowMin(windowLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveMovingAverage;
@@ -8784,15 +8762,14 @@ public sealed class AdaptiveExponentialMovingAverageState : IStreamingIndicatorS
     private int _index;
     private bool _hasPrev;
 
-    public AdaptiveExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10,
-        InputName inputName = InputName.Close)
+    public AdaptiveExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 10)
     {
         _length = Math.Max(1, length);
         _mltp1 = (double)2 / (_length + 1);
         _sma = MovingAverageSmootherFactory.Create(maType, _length);
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveExponentialMovingAverage;
@@ -8852,11 +8829,10 @@ public sealed class AdaptiveAutonomousRecursiveMovingAverageState : IStreamingIn
     private readonly AdaptiveAutonomousRecursiveMovingAverageEngine _engine;
     private readonly StreamingInputResolver _input;
 
-    public AdaptiveAutonomousRecursiveMovingAverageState(int length = 14, double gamma = 3,
-        InputName inputName = InputName.Close)
+    public AdaptiveAutonomousRecursiveMovingAverageState(int length = 14, double gamma = 3)
     {
         _engine = new AdaptiveAutonomousRecursiveMovingAverageEngine(length, gamma);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveAutonomousRecursiveMovingAverage;
@@ -8907,12 +8883,12 @@ public sealed class AdaptiveLeastSquaresState : IStreamingIndicatorState, IDispo
     private int _index;
     private bool _hasPrev;
 
-    public AdaptiveLeastSquaresState(int length = 500, double smooth = 1.5, InputName inputName = InputName.Close)
+    public AdaptiveLeastSquaresState(int length = 500, double smooth = 1.5)
     {
         _length = Math.Max(1, length);
         _smooth = smooth;
         _trWindow = new RollingWindowMax(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveLeastSquares;
@@ -9018,9 +8994,9 @@ public sealed class AlphaDecreasingExponentialMovingAverageState : IStreamingInd
     private double _prevEma;
     private int _index;
 
-    public AlphaDecreasingExponentialMovingAverageState(InputName inputName = InputName.Close)
+    public AlphaDecreasingExponentialMovingAverageState()
     {
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AlphaDecreasingExponentialMovingAverage;
@@ -9066,7 +9042,7 @@ public sealed class AdaptivePriceZoneIndicatorState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public AdaptivePriceZoneIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int length = 20,
-        double pct = 2, InputName inputName = InputName.Close)
+        double pct = 2)
     {
         var nP = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(length)));
         _pct = pct;
@@ -9074,7 +9050,7 @@ public sealed class AdaptivePriceZoneIndicatorState : IStreamingIndicatorState, 
         _ema2 = MovingAverageSmootherFactory.Create(maType, nP);
         _xhlEma1 = MovingAverageSmootherFactory.Create(maType, nP);
         _xhlEma2 = MovingAverageSmootherFactory.Create(maType, nP);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptivePriceZoneIndicator;
@@ -9127,11 +9103,10 @@ public sealed class AdaptiveRelativeStrengthIndexState : IStreamingIndicatorStat
     private double _prevArsi;
     private bool _hasPrev;
 
-    public AdaptiveRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14,
-        InputName inputName = InputName.Close)
+    public AdaptiveRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14)
     {
         _rsi = new RsiState(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveRelativeStrengthIndex;
@@ -9186,8 +9161,7 @@ public sealed class AdaptiveStochasticState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
     private double _regressionInput;
 
-    public AdaptiveStochasticState(int length = 50, int fastLength = 50, int slowLength = 200,
-        InputName inputName = InputName.Close)
+    public AdaptiveStochasticState(int length = 50, int fastLength = 50, int slowLength = 200)
     {
         var resolvedLength = Math.Max(1, length);
         var resolvedFast = Math.Max(1, fastLength);
@@ -9199,7 +9173,7 @@ public sealed class AdaptiveStochasticState : IStreamingIndicatorState, IDisposa
         _fastMin = new RollingWindowMin(resolvedFast);
         _slowMax = new RollingWindowMax(resolvedSlow);
         _slowMin = new RollingWindowMin(resolvedSlow);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveStochastic;
@@ -9264,11 +9238,11 @@ public sealed class AdaptiveTrailingStopState : IStreamingIndicatorState, IDispo
     private double _prevOs;
     private bool _hasPrev;
 
-    public AdaptiveTrailingStopState(int length = 100, double factor = 3, InputName inputName = InputName.Close)
+    public AdaptiveTrailingStopState(int length = 100, double factor = 3)
     {
         _factor = factor;
         _er = new EfficiencyRatioState(Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveTrailingStop;
@@ -9339,11 +9313,10 @@ public sealed class AdaptiveAutonomousRecursiveTrailingStopState : IStreamingInd
     private double _prevOs;
     private bool _hasPrev;
 
-    public AdaptiveAutonomousRecursiveTrailingStopState(int length = 14, double gamma = 3,
-        InputName inputName = InputName.Close)
+    public AdaptiveAutonomousRecursiveTrailingStopState(int length = 14, double gamma = 3)
     {
         _engine = new AdaptiveAutonomousRecursiveMovingAverageEngine(length, gamma);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveAutonomousRecursiveTrailingStop;
@@ -9403,11 +9376,11 @@ public sealed class AhrensMovingAverageState : IStreamingIndicatorState, IDispos
     private double _prevAhma;
     private bool _hasPrev;
 
-    public AhrensMovingAverageState(int length = 9, InputName inputName = InputName.Close)
+    public AhrensMovingAverageState(int length = 9)
     {
         _length = Math.Max(1, length);
         _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AhrensMovingAverage;
@@ -9459,8 +9432,7 @@ public sealed class ArnaudLegouxMovingAverageState : IStreamingIndicatorState, I
     private readonly PooledRingBuffer<double> _window;
     private readonly StreamingInputResolver _input;
 
-    public ArnaudLegouxMovingAverageState(int length = 9, double offset = 0.85, int sigma = 6,
-        InputName inputName = InputName.Close)
+    public ArnaudLegouxMovingAverageState(int length = 9, double offset = 0.85, int sigma = 6)
     {
         _length = Math.Max(1, length);
         var m = offset * (_length - 1);
@@ -9478,7 +9450,7 @@ public sealed class ArnaudLegouxMovingAverageState : IStreamingIndicatorState, I
 
         _weightSum = weightSum;
         _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ArnaudLegouxMovingAverage;
@@ -9538,7 +9510,7 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable,
     private readonly PooledRingBuffer<double> _lipsWindow;
     private StreamingInputResolver _input;
 
-    public AlligatorIndexState(InputName inputName = InputName.MedianPrice, MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
+    public AlligatorIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
         int jawOffset = 8, int teethLength = 8, int teethOffset = 5, int lipsLength = 5, int lipsOffset = 3)
     {
         _jawOffset = Math.Max(0, jawOffset);
@@ -9550,7 +9522,7 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable,
         _jawWindow = new PooledRingBuffer<double>(_jawOffset + 1);
         _teethWindow = new PooledRingBuffer<double>(_teethOffset + 1);
         _lipsWindow = new PooledRingBuffer<double>(_lipsOffset + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.AlligatorIndex;
@@ -9620,14 +9592,14 @@ public sealed class AnchoredMomentumState : IStreamingIndicatorState, IDisposabl
     private readonly StreamingInputResolver _input;
 
     public AnchoredMomentumState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage, int smoothLength = 7,
-        int signalLength = 8, int momentumLength = 10, InputName inputName = InputName.Close)
+        int signalLength = 8, int momentumLength = 10)
     {
         _signalLength = Math.Max(1, signalLength);
         var p = MathHelper.MinOrMax((2 * momentumLength) + 1);
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _priceSum = new RollingWindowSum(p);
         _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AnchoredMomentum;
@@ -9680,12 +9652,12 @@ public sealed class ApirineSlowRelativeStrengthIndexState : IStreamingIndicatorS
     private readonly StreamingInputResolver _input;
 
     public ApirineSlowRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int length = 14,
-        int smoothLength = 6, InputName inputName = InputName.Close)
+        int smoothLength = 6)
     {
         _smooth = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _gain = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _loss = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ApirineSlowRelativeStrengthIndex;
@@ -9738,11 +9710,11 @@ public sealed class AsymmetricalRelativeStrengthIndexState : IStreamingIndicator
     private double _prevValue;
     private bool _hasPrev;
 
-    public AsymmetricalRelativeStrengthIndexState(int length = 14, InputName inputName = InputName.Close)
+    public AsymmetricalRelativeStrengthIndexState(int length = 14)
     {
         _length = Math.Max(1, length);
         _upCountSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AsymmetricalRelativeStrengthIndex;
@@ -9817,8 +9789,7 @@ public sealed class AtrFilteredExponentialMovingAverageState : IStreamingIndicat
     private bool _hasPrev;
 
     public AtrFilteredExponentialMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 45, int atrLength = 20, int stdDevLength = 10, int lbLength = 20, double min = 5,
-        InputName inputName = InputName.Close)
+        int length = 45, int atrLength = 20, int stdDevLength = 10, int lbLength = 20, double min = 5)
     {
         _length = Math.Max(1, length);
         _stdDevLength = Math.Max(1, stdDevLength);
@@ -9835,7 +9806,7 @@ public sealed class AtrFilteredExponentialMovingAverageState : IStreamingIndicat
         _atrValSum = new RollingCumulativeSum();
         _stdDevMin = new RollingWindowMin(Math.Max(1, lbLength));
         _min = min;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AtrFilteredExponentialMovingAverage;
@@ -9914,7 +9885,7 @@ public sealed class AutoDispersionBandsState : IStreamingIndicatorState, IDispos
     private int _index;
 
     public AutoDispersionBandsState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 90,
-        int smoothLength = 140, InputName inputName = InputName.Close)
+        int smoothLength = 140)
     {
         _length = Math.Max(1, length);
         _x2Sum = new RollingWindowSum(_length);
@@ -9925,7 +9896,7 @@ public sealed class AutoDispersionBandsState : IStreamingIndicatorState, IDispos
         _bSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _lowerSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AutoDispersionBands;
@@ -10008,16 +9979,15 @@ public sealed class AutoFilterState : IStreamingIndicatorState, IDisposable
     private double _xValue;
     private bool _hasPrev;
 
-    public AutoFilterState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 500,
-        InputName inputName = InputName.Close)
+    public AutoFilterState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 500)
     {
         var resolved = Math.Max(1, length);
         _yMa = MovingAverageSmootherFactory.Create(maType, resolved);
         _xMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _dev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _dev = new StandardDeviationVolatilityState(maType, resolved);
         _xDev = new StandardDeviationVolatilityState(maType, resolved, _ => _xValue);
         _correlation = new RollingWindowCorrelation(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AutoFilter;
@@ -10085,11 +10055,11 @@ public sealed class AutoLineState : IStreamingIndicatorState, IDisposable
     private double _prevX;
     private bool _hasPrev;
 
-    public AutoLineState(int length = 500, InputName inputName = InputName.Close)
+    public AutoLineState(int length = 500)
     {
         var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, inputName);
-        _input = new StreamingInputResolver(inputName, null);
+        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AutoLine;
@@ -10142,12 +10112,12 @@ public sealed class AutoLineWithDriftState : IStreamingIndicatorState, IDisposab
     private int _index;
     private bool _hasPrev;
 
-    public AutoLineWithDriftState(int length = 500, InputName inputName = InputName.Close)
+    public AutoLineWithDriftState(int length = 500)
     {
         _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, inputName);
+        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length);
         _values = new PooledRingBuffer<double>(_length + 2);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AutoLineWithDrift;
@@ -10218,8 +10188,7 @@ public sealed class AutonomousRecursiveMovingAverageState : IStreamingIndicatorS
     private int _index;
     private bool _hasPrev;
 
-    public AutonomousRecursiveMovingAverageState(int length = 14, int momLength = 7, double gamma = 3,
-        InputName inputName = InputName.Close)
+    public AutonomousRecursiveMovingAverageState(int length = 14, int momLength = 7, double gamma = 3)
     {
         _length = Math.Max(1, length);
         _momLength = Math.Max(1, momLength);
@@ -10227,7 +10196,7 @@ public sealed class AutonomousRecursiveMovingAverageState : IStreamingIndicatorS
         _cSum = new RollingWindowSum(_length);
         _ma1Sum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(Math.Max(_length, _momLength) + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AutonomousRecursiveMovingAverage;
@@ -10296,12 +10265,12 @@ public sealed class AverageAbsoluteErrorNormalizationState : IStreamingIndicator
     private double _prevY;
     private bool _hasPrev;
 
-    public AverageAbsoluteErrorNormalizationState(int length = 14, InputName inputName = InputName.Close)
+    public AverageAbsoluteErrorNormalizationState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _eSum = new RollingWindowSum(resolved);
         _eAbsSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AverageAbsoluteErrorNormalization;
@@ -10366,7 +10335,7 @@ public sealed class AverageMoneyFlowOscillatorState : IStreamingIndicatorState, 
     private bool _hasPrev;
 
     public AverageMoneyFlowOscillatorState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage, int length = 5,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         var resolvedLength = Math.Max(1, length);
         _avgVolume = MovingAverageSmootherFactory.Create(maType, resolvedLength);
@@ -10374,7 +10343,7 @@ public sealed class AverageMoneyFlowOscillatorState : IStreamingIndicatorState, 
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _rMax = new RollingWindowMax(resolvedLength);
         _rMin = new RollingWindowMin(resolvedLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AverageMoneyFlowOscillator;
@@ -10444,12 +10413,12 @@ public sealed class AverageTrueRangeTrailingStopsState : IStreamingIndicatorStat
     private bool _hasPrev;
 
     public AverageTrueRangeTrailingStopsState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 63, int length2 = 21, double factor = 3, InputName inputName = InputName.Close)
+        int length1 = 63, int length2 = 21, double factor = 3)
     {
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _atr = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _factor = factor;
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.AverageTrueRangeTrailingStops;
@@ -10515,7 +10484,7 @@ public sealed class BayesianOscillatorState : IStreamingIndicatorState, IDisposa
     private readonly StreamingInputResolver _input;
 
     public BayesianOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
-        double stdDevMult = 2.5, double lowerThreshold = 15, InputName inputName = InputName.Close)
+        double stdDevMult = 2.5, double lowerThreshold = 15)
     {
         _ = lowerThreshold;
         var resolved = Math.Max(1, length);
@@ -10526,7 +10495,7 @@ public sealed class BayesianOscillatorState : IStreamingIndicatorState, IDisposa
         _probUpperDown = new RollingWindowSum(resolved);
         _probBasisUp = new RollingWindowSum(resolved);
         _probBasisDown = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BayesianOscillator;
@@ -10677,7 +10646,7 @@ public sealed class BilateralStochasticOscillatorState : IStreamingIndicatorStat
     private readonly StreamingInputResolver _input;
 
     public BilateralStochasticOscillatorState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 100,
-        int signalLength = 20, InputName inputName = InputName.Close)
+        int signalLength = 20)
     {
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
@@ -10685,7 +10654,7 @@ public sealed class BilateralStochasticOscillatorState : IStreamingIndicatorStat
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BilateralStochasticOscillator;
@@ -10748,13 +10717,13 @@ public sealed class BollingerBandsAverageTrueRangeState : IStreamingIndicatorSta
     private bool _hasPrev;
 
     public BollingerBandsAverageTrueRangeState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int atrLength = 22,
-        int length = 55, double stdDevMult = 2, InputName inputName = InputName.Close)
+        int length = 55, double stdDevMult = 2)
     {
         _stdDevMult = stdDevMult;
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _stdDev = new RollingStandardDeviation(Math.Max(1, length));
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, atrLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsAverageTrueRange;
@@ -10821,7 +10790,7 @@ public sealed class BollingerBandsFibonacciRatiosState : IStreamingIndicatorStat
 
     public BollingerBandsFibonacciRatiosState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 20,
         double fibRatio1 = MathHelper.Phi, double fibRatio2 = MathHelper.Phi + 1,
-        double fibRatio3 = (2 * MathHelper.Phi) + 1, InputName inputName = InputName.Close)
+        double fibRatio3 = (2 * MathHelper.Phi) + 1)
     {
         _ = fibRatio1;
         _ = fibRatio2;
@@ -10829,7 +10798,7 @@ public sealed class BollingerBandsFibonacciRatiosState : IStreamingIndicatorStat
         var resolved = Math.Max(1, length);
         _sma = MovingAverageSmootherFactory.Create(maType, resolved);
         _atr = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsFibonacciRatios;
@@ -10891,13 +10860,13 @@ public sealed class BollingerBandsPercentBState : IStreamingIndicatorState, IDis
     private readonly StreamingInputResolver _input;
 
     public BollingerBandsPercentBState(double stdDevMult = 2, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 20, InputName inputName = InputName.Close)
+        int length = 20)
     {
         var resolved = Math.Max(1, length);
         _stdDevMult = stdDevMult;
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsPercentB;
@@ -10944,13 +10913,13 @@ public sealed class BollingerBandsWidthState : IStreamingIndicatorState, IDispos
     private readonly StreamingInputResolver _input;
 
     public BollingerBandsWidthState(double stdDevMult = 2, MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int length = 20, InputName inputName = InputName.Close)
+        int length = 20)
     {
         var resolved = Math.Max(1, length);
         _stdDevMult = stdDevMult;
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsWidth;
@@ -11000,13 +10969,13 @@ public sealed class BollingerBandsWithAtrPctState : IStreamingIndicatorState, ID
     private bool _hasPrev;
 
     public BollingerBandsWithAtrPctState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int bbLength = 20, double stdDevMult = 2, InputName inputName = InputName.Close)
+        int bbLength = 20, double stdDevMult = 2)
     {
         var resolvedLength = Math.Max(1, length);
         _ratio = (double)2 / (resolvedLength + 1);
         _stdDevMult = stdDevMult;
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, bbLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsWithAtrPct;
@@ -11074,14 +11043,14 @@ public sealed class BreakoutRelativeStrengthIndexState : IStreamingIndicatorStat
     private StreamingInputResolver _input;
     private double _prevBoPower;
 
-    public BreakoutRelativeStrengthIndexState(InputName inputName = InputName.FullTypicalPrice, int length = 14,
+    public BreakoutRelativeStrengthIndexState(int length = 14,
         int lbLength = 2)
     {
         _length = Math.Max(1, length);
         _volumeSum = new RollingWindowSum(Math.Max(1, lbLength));
         _posPowerSum = new RollingWindowSum(_length);
         _negPowerSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
     }
 
     public IndicatorName Name => IndicatorName.BreakoutRelativeStrengthIndex;
@@ -11145,14 +11114,13 @@ public sealed class BryantAdaptiveMovingAverageState : IStreamingIndicatorState,
     private double _prevBama;
     private bool _hasPrev;
 
-    public BryantAdaptiveMovingAverageState(int length = 14, int maxLength = 100, double trend = -1,
-        InputName inputName = InputName.Close)
+    public BryantAdaptiveMovingAverageState(int length = 14, int maxLength = 100, double trend = -1)
     {
         _length = Math.Max(1, length);
         _maxLength = maxLength;
         _trend = trend;
         _er = new EfficiencyRatioState(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BryantAdaptiveMovingAverage;
@@ -11207,13 +11175,13 @@ public sealed class BuffAverageState : IStreamingIndicatorState, IDisposable
     private readonly RollingWindowSum _slowVolumeSum;
     private readonly StreamingInputResolver _input;
 
-    public BuffAverageState(int fastLength = 5, int slowLength = 20, InputName inputName = InputName.Close)
+    public BuffAverageState(int fastLength = 5, int slowLength = 20)
     {
         _fastPriceSum = new RollingWindowSum(Math.Max(1, fastLength));
         _fastVolumeSum = new RollingWindowSum(Math.Max(1, fastLength));
         _slowPriceSum = new RollingWindowSum(Math.Max(1, slowLength));
         _slowVolumeSum = new RollingWindowSum(Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.BuffAverage;
@@ -11269,14 +11237,14 @@ public sealed class CalmarRatioState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public CalmarRatioState(int length = 30, InputName inputName = InputName.Close)
+    public CalmarRatioState(int length = 30)
     {
         _length = Math.Max(1, length);
         var windowLength = Math.Max(_length, 2);
         _maxWindow = new RollingWindowMax(windowLength);
         _drawdownMin = new RollingWindowMin(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _power = CalculatePower(_length);
     }
 
@@ -11449,7 +11417,7 @@ public sealed class CCTStochRelativeStrengthIndexState : IStreamingIndicatorStat
 
     public CCTStochRelativeStrengthIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int length1 = 5, int length2 = 8, int length3 = 13, int length4 = 14, int length5 = 21,
-        int smoothLength1 = 3, int smoothLength2 = 8, int signalLength = 9, InputName inputName = InputName.Close)
+        int smoothLength1 = 3, int smoothLength2 = 8, int signalLength = 9)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -11480,7 +11448,7 @@ public sealed class CCTStochRelativeStrengthIndexState : IStreamingIndicatorStat
         _type6Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _customSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CCTStochRelativeStrengthIndex;
@@ -11630,7 +11598,7 @@ public sealed class ChandeCompositeMomentumIndexState : IStreamingIndicatorState
     private bool _hasPrev;
 
     public ChandeCompositeMomentumIndexState(MovingAvgType maType = MovingAvgType.DoubleExponentialMovingAverage,
-        int length1 = 5, int length2 = 10, int length3 = 20, int smoothLength = 3, InputName inputName = InputName.Close)
+        int length1 = 5, int length2 = 10, int length3 = 20, int smoothLength = 3)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -11643,13 +11611,13 @@ public sealed class ChandeCompositeMomentumIndexState : IStreamingIndicatorState
         _diff2Sum2 = new RollingWindowSum(resolved2);
         _diff2Sum3 = new RollingWindowSum(resolved3);
         _dmiSum = new RollingWindowSum(resolved1);
-        _stdDev1 = new StandardDeviationVolatilityState(maType, resolved1, inputName);
+        _stdDev1 = new StandardDeviationVolatilityState(maType, resolved1);
         _stdDev2 = new StandardDeviationVolatilityState(maType, resolved2, _ => _stdDev1Value);
         _stdDev3 = new StandardDeviationVolatilityState(maType, resolved3, _ => _stdDev2Value);
         _cmo5Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
         _cmo10Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
         _cmo20Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeCompositeMomentumIndex;
@@ -11763,10 +11731,10 @@ public sealed class ChandeForecastOscillatorState : IStreamingIndicatorState, ID
     private readonly StreamingInputResolver _input;
     private double _regressionInput;
 
-    public ChandeForecastOscillatorState(int length = 14, InputName inputName = InputName.Close)
+    public ChandeForecastOscillatorState(int length = 14)
     {
         _regression = new LinearRegressionState(length, _ => _regressionInput);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeForecastOscillator;
@@ -11870,11 +11838,11 @@ public sealed class ChandeKrollRSquaredIndexState : IStreamingIndicatorState, ID
     private int _index;
 
     public ChandeKrollRSquaredIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 14,
-        int smoothLength = 3, InputName inputName = InputName.Close)
+        int smoothLength = 3)
     {
         _correlation = new RollingWindowCorrelation(Math.Max(1, length));
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeKrollRSquaredIndex;
@@ -11996,12 +11964,12 @@ public sealed class ChandeMomentumOscillatorAbsoluteState : IStreamingIndicatorS
     private double _prevValue;
     private bool _hasPrev;
 
-    public ChandeMomentumOscillatorAbsoluteState(int length = 9, InputName inputName = InputName.Close)
+    public ChandeMomentumOscillatorAbsoluteState(int length = 9)
     {
         _length = Math.Max(1, length);
         _absDiffSum = new RollingWindowSum(_length);
         _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAbsolute;
@@ -12063,8 +12031,7 @@ public sealed class ChandeMomentumOscillatorAverageState : IStreamingIndicatorSt
     private double _prevValue;
     private bool _hasPrev;
 
-    public ChandeMomentumOscillatorAverageState(int length1 = 5, int length2 = 10, int length3 = 20,
-        InputName inputName = InputName.Close)
+    public ChandeMomentumOscillatorAverageState(int length1 = 5, int length2 = 10, int length3 = 20)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -12075,7 +12042,7 @@ public sealed class ChandeMomentumOscillatorAverageState : IStreamingIndicatorSt
         _absDiffSum1 = new RollingWindowSum(resolved1);
         _absDiffSum2 = new RollingWindowSum(resolved2);
         _absDiffSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAverage;
@@ -12152,8 +12119,7 @@ public sealed class ChandeMomentumOscillatorAbsoluteAverageState : IStreamingInd
     private double _prevValue;
     private bool _hasPrev;
 
-    public ChandeMomentumOscillatorAbsoluteAverageState(int length1 = 5, int length2 = 10, int length3 = 20,
-        InputName inputName = InputName.Close)
+    public ChandeMomentumOscillatorAbsoluteAverageState(int length1 = 5, int length2 = 10, int length3 = 20)
     {
         var resolved1 = Math.Max(1, length1);
         var resolved2 = Math.Max(1, length2);
@@ -12164,7 +12130,7 @@ public sealed class ChandeMomentumOscillatorAbsoluteAverageState : IStreamingInd
         _absDiffSum1 = new RollingWindowSum(resolved1);
         _absDiffSum2 = new RollingWindowSum(resolved2);
         _absDiffSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAbsoluteAverage;
@@ -12237,12 +12203,12 @@ public sealed class ChandeMomentumOscillatorAverageDisparityIndexState : IStream
     private readonly StreamingInputResolver _input;
 
     public ChandeMomentumOscillatorAverageDisparityIndexState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length1 = 200, int length2 = 50, int length3 = 20, InputName inputName = InputName.Close)
+        int length1 = 200, int length2 = 50, int length3 = 20)
     {
         _ma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _ma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
         _ma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAverageDisparityIndex;
@@ -12296,14 +12262,14 @@ public sealed class ChandeMomentumOscillatorFilterState : IStreamingIndicatorSta
     private bool _hasPrev;
 
     public ChandeMomentumOscillatorFilterState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 9, double filter = 3, InputName inputName = InputName.Close)
+        int length = 9, double filter = 3)
     {
         var resolved = Math.Max(1, length);
         _filter = filter;
         _diffSum = new RollingWindowSum(resolved);
         _absDiffSum = new RollingWindowSum(resolved);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorFilter;
@@ -12407,12 +12373,12 @@ public sealed class ChandeTrendScoreState : IStreamingIndicatorState, IDisposabl
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public ChandeTrendScoreState(int startLength = 11, int endLength = 20, InputName inputName = InputName.Close)
+    public ChandeTrendScoreState(int startLength = 11, int endLength = 20)
     {
         _startLength = Math.Max(1, startLength);
         _endLength = Math.Max(_startLength, endLength);
         _values = new PooledRingBuffer<double>(_endLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ChandeTrendScore;
@@ -12467,12 +12433,12 @@ public sealed class ChandeVolatilityIndexDynamicAverageIndicatorState : IStreami
     private bool _hasPrev;
 
     public ChandeVolatilityIndexDynamicAverageIndicatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
-        int length = 20, double alpha1 = 0.2, double alpha2 = 0.04, InputName inputName = InputName.Close)
+        int length = 20, double alpha1 = 0.2, double alpha2 = 0.04)
     {
         var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
+        _stdDev = new StandardDeviationVolatilityState(maType, resolved);
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
         _alpha1 = alpha1;
         _alpha2 = alpha2;
     }
@@ -12536,7 +12502,7 @@ public sealed class CompoundRatioMovingAverageState : IStreamingIndicatorState, 
     private readonly StreamingInputResolver _input;
 
     public CompoundRatioMovingAverageState(MovingAvgType maType = MovingAvgType.WeightedMovingAverage,
-        int length = 20, InputName inputName = InputName.Close)
+        int length = 20)
     {
         _length = Math.Max(1, length);
         var r = Math.Pow(_length, ((double)1 / (_length - 1)) - 1);
@@ -12549,7 +12515,7 @@ public sealed class CompoundRatioMovingAverageState : IStreamingIndicatorState, 
         _buffer = new PooledRingBuffer<double>(_length);
         var smoothLength = Math.Max((int)Math.Round(Math.Sqrt(_length)), 1);
         _smoother = MovingAverageSmootherFactory.Create(maType, smoothLength);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CompoundRatioMovingAverage;
@@ -12628,8 +12594,7 @@ public sealed class ConstanceBrownCompositeIndexState : IStreamingIndicatorState
     private readonly StreamingInputResolver _input;
 
     public ConstanceBrownCompositeIndexState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage,
-        int fastLength = 13, int slowLength = 33, int length1 = 14, int length2 = 9, int smoothLength = 3,
-        InputName inputName = InputName.Close)
+        int fastLength = 13, int slowLength = 33, int length1 = 14, int length2 = 9, int smoothLength = 3)
     {
         var resolvedLength1 = Math.Max(1, length1);
         _length2 = Math.Max(1, length2);
@@ -12640,7 +12605,7 @@ public sealed class ConstanceBrownCompositeIndexState : IStreamingIndicatorState
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _rsi1Window = new PooledRingBuffer<double>(_length2 + 1);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.ConstanceBrownCompositeIndex;
@@ -12705,13 +12670,12 @@ public sealed class CorrectedMovingAverageState : IStreamingIndicatorState, IDis
     private double _prevCma;
     private int _count;
 
-    public CorrectedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 35,
-        InputName inputName = InputName.Close)
+    public CorrectedMovingAverageState(MovingAvgType maType = MovingAvgType.SimpleMovingAverage, int length = 35)
     {
         _length = Math.Max(1, length);
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _stdDev = new RollingStandardDeviation(_length);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CorrectedMovingAverage;
@@ -12793,7 +12757,7 @@ public sealed class CubedWeightedMovingAverageState : IStreamingIndicatorState, 
     private readonly PooledRingBuffer<double> _values;
     private readonly StreamingInputResolver _input;
 
-    public CubedWeightedMovingAverageState(int length = 14, InputName inputName = InputName.Close)
+    public CubedWeightedMovingAverageState(int length = 14)
     {
         var resolved = Math.Max(1, length);
         _weights = new double[resolved];
@@ -12807,7 +12771,7 @@ public sealed class CubedWeightedMovingAverageState : IStreamingIndicatorState, 
 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(inputName, null);
+        _input = new StreamingInputResolver(InputName.Close, null);
     }
 
     public IndicatorName Name => IndicatorName.CubedWeightedMovingAverage;

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -37,18 +37,6 @@ public sealed class SimpleMovingAverageState : IStreamingIndicatorState, IDispos
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SimpleMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _window = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SimpleMovingAverage;
 
     public void Reset()
@@ -92,17 +80,6 @@ public sealed class ExponentialMovingAverageState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ExponentialMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema = new EmaState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ExponentialMovingAverage;
 
     public void Reset()
@@ -135,17 +112,6 @@ public sealed class WeightedMovingAverageState : IStreamingIndicatorState, IDisp
     {
         _wma = new WmaState(length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public WeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wma = new WmaState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.WeightedMovingAverage;
@@ -187,17 +153,6 @@ public sealed class WellesWilderMovingAverageState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WellesWilderMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wilder = new WilderState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WellesWilderMovingAverage;
 
     public void Reset()
@@ -234,19 +189,6 @@ public sealed class TriangularMovingAverageState : IStreamingIndicatorState, IDi
         _primary = MovingAverageSmootherFactory.Create(maType, resolved);
         _secondary = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TriangularMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _primary = MovingAverageSmootherFactory.Create(maType, resolved);
-        _secondary = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TriangularMovingAverage;
@@ -300,22 +242,6 @@ public sealed class HullMovingAverageState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HullMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var length2 = MathHelper.MinOrMax((int)Math.Round((double)resolved / 2));
-        var sqrtLength = MathHelper.MinOrMax((int)Math.Round(MathHelper.Sqrt(resolved)));
-        _longSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _shortSmoother = MovingAverageSmootherFactory.Create(maType, length2);
-        _finalSmoother = MovingAverageSmootherFactory.Create(maType, sqrtLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HullMovingAverage;
 
     public void Reset()
@@ -363,16 +289,6 @@ public sealed class AveragePriceState : IStreamingIndicatorState
         _input = new StreamingInputResolver(InputName.AveragePrice, null);
     }
 
-    public AveragePriceState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.AveragePrice, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AveragePrice;
 
     public void Reset()
@@ -402,16 +318,6 @@ public sealed class FullTypicalPriceState : IStreamingIndicatorState
     public FullTypicalPriceState()
     {
         _input = new StreamingInputResolver(InputName.FullTypicalPrice, null);
-    }
-
-    public FullTypicalPriceState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.FullTypicalPrice, selector);
     }
 
     public IndicatorName Name => IndicatorName.FullTypicalPrice;
@@ -445,16 +351,6 @@ public sealed class MedianPriceState : IStreamingIndicatorState
         _input = new StreamingInputResolver(InputName.MedianPrice, null);
     }
 
-    public MedianPriceState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.MedianPrice, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MedianPrice;
 
     public void Reset()
@@ -486,16 +382,6 @@ public sealed class TypicalPriceState : IStreamingIndicatorState
         _input = new StreamingInputResolver(InputName.TypicalPrice, null);
     }
 
-    public TypicalPriceState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.TypicalPrice, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TypicalPrice;
 
     public void Reset()
@@ -525,16 +411,6 @@ public sealed class WeightedCloseState : IStreamingIndicatorState
     public WeightedCloseState()
     {
         _input = new StreamingInputResolver(InputName.WeightedClose, null);
-    }
-
-    public WeightedCloseState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.WeightedClose, selector);
     }
 
     public IndicatorName Name => IndicatorName.WeightedClose;
@@ -571,19 +447,6 @@ public sealed class MidpointState : IStreamingIndicatorState, IDisposable
         _maxWindow = new RollingWindowMax(resolved);
         _minWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MidpointState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(resolved);
-        _minWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.Midpoint;
@@ -688,20 +551,6 @@ public sealed class AverageTrueRangeChannelState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AverageTrueRangeChannelState(MovingAvgType maType, int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AverageTrueRangeChannel;
 
     public void Reset()
@@ -769,21 +618,6 @@ public sealed class UniChannelState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public UniChannelState(MovingAvgType maType, int length, double ubFac, double lbFac, bool type1,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _ubFac = ubFac;
-        _lbFac = lbFac;
-        _type1 = type1;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.UniChannel;
 
     public void Reset()
@@ -835,22 +669,6 @@ public sealed class PriceHeadleyAccelerationBandsState : IStreamingIndicatorStat
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _factor = factor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PriceHeadleyAccelerationBandsState(MovingAvgType maType, int length, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _upperSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowerSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PriceHeadleyAccelerationBands;
@@ -914,21 +732,6 @@ public sealed class PseudoPolynomialChannelState : IStreamingIndicatorState, IDi
         _kSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _kWindow = new PooledRingBuffer<double>(_length * 2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PseudoPolynomialChannelState(MovingAvgType maType, int length, double morph,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _morph = morph;
-        _kSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _kWindow = new PooledRingBuffer<double>(_length * 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PseudoPolynomialChannel;
@@ -1003,19 +806,6 @@ public sealed class ProjectedSupportAndResistanceState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ProjectedSupportAndResistanceState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ProjectedSupportAndResistance;
 
     public void Reset()
@@ -1070,17 +860,6 @@ public sealed class ProjectionBandsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ProjectionBandsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _calculator = new ProjectionBandsCalculator(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ProjectionBands;
 
     public void Reset()
@@ -1125,19 +904,6 @@ public sealed class ProjectionOscillatorState : IStreamingIndicatorState, IDispo
         _bands = new ProjectionBandsCalculator(length);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ProjectionOscillatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _bands = new ProjectionBandsCalculator(length);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ProjectionOscillator;
@@ -1189,19 +955,6 @@ public sealed class ProjectionBandwidthState : IStreamingIndicatorState, IDispos
         _bands = new ProjectionBandsCalculator(resolvedLength);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ProjectionBandwidthState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        _bands = new ProjectionBandsCalculator(resolvedLength);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ProjectionBandwidth;
@@ -1256,21 +1009,6 @@ public sealed class RootMovingAverageSquaredErrorBandsState : IStreamingIndicato
         _powSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDevFactor = stdDevFactor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RootMovingAverageSquaredErrorBandsState(double stdDevFactor, MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _powSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RootMovingAverageSquaredErrorBands;
@@ -1330,23 +1068,6 @@ public sealed class MovingAverageBandsState : IStreamingIndicatorState, IDisposa
         _sqSum = new RollingWindowSum(resolvedFast);
         _mult = mult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MovingAverageBandsState(MovingAvgType maType, int fastLength, int slowLength, double mult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, resolvedFast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSlow);
-        _sqSum = new RollingWindowSum(resolvedFast);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageBands;
@@ -1409,20 +1130,6 @@ public sealed class MovingAverageSupportResistanceState : IStreamingIndicatorSta
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MovingAverageSupportResistanceState(MovingAvgType maType, int length, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _supportLevel = 1 + (factor / 100);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MovingAverageSupportResistance;
 
     public void Reset()
@@ -1474,18 +1181,6 @@ public sealed class MotionToAttractionChannelsState : IStreamingIndicatorState
         var resolved = Math.Max(1, length);
         _alpha = (double)1 / resolved;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MotionToAttractionChannelsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = (double)1 / resolved;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MotionToAttractionChannels;
@@ -1565,20 +1260,6 @@ public sealed class MeanAbsoluteErrorBandsState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MeanAbsoluteErrorBandsState(double stdDevFactor, MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MeanAbsoluteErrorBands;
 
     public void Reset()
@@ -1642,21 +1323,6 @@ public sealed class MeanAbsoluteDeviationBandsState : IStreamingIndicatorState, 
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MeanAbsoluteDeviationBandsState(double stdDevFactor, MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDevFactor = stdDevFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MeanAbsoluteDeviationBands;
 
     public void Reset()
@@ -1712,21 +1378,6 @@ public sealed class MovingAverageDisplacedEnvelopeState : IStreamingIndicatorSta
         _emaWindow = new PooledRingBuffer<double>(_length2);
         _pct = pct;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MovingAverageDisplacedEnvelopeState(MovingAvgType maType, int length1, int length2, double pct,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _emaSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _emaWindow = new PooledRingBuffer<double>(_length2);
-        _pct = pct;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageDisplacedEnvelope;
@@ -1791,22 +1442,6 @@ public sealed class VerticalHorizontalFilterState : IStreamingIndicatorState, ID
         _changeSum = new RollingWindowSum(resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VerticalHorizontalFilterState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _maxWindow = new RollingWindowMax(resolved);
-        _minWindow = new RollingWindowMin(resolved);
-        _changeSum = new RollingWindowSum(resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VerticalHorizontalFilter;
@@ -1881,20 +1516,6 @@ public sealed class SigmaSpikesState : IStreamingIndicatorState, IDisposable
         _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SigmaSpikesState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SigmaSpikes;
@@ -1976,23 +1597,6 @@ public sealed class StatisticalVolatilityState : IStreamingIndicatorState, IDisp
         _annualSqrt = Math.Sqrt((double)length2 / resolved);
     }
 
-    public StatisticalVolatilityState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length1);
-        _closeMax = new RollingWindowMax(resolved);
-        _closeMin = new RollingWindowMin(resolved);
-        _highMax = new RollingWindowMax(resolved);
-        _lowMin = new RollingWindowMin(resolved);
-        _volSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _annualSqrt = Math.Sqrt((double)length2 / resolved);
-    }
-
     public IndicatorName Name => IndicatorName.StatisticalVolatility;
 
     public void Reset()
@@ -2057,20 +1661,6 @@ public sealed class VolatilitySwitchIndicatorState : IStreamingIndicatorState, I
         _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolatilitySwitchIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _varianceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolatilitySwitchIndicator;
@@ -2138,18 +1728,6 @@ public sealed class ExtendedRecursiveBandsState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ExtendedRecursiveBandsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sc = (double)2 / (resolved + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ExtendedRecursiveBands;
 
     public void Reset()
@@ -2208,21 +1786,6 @@ public sealed class StollerAverageRangeChannelsState : IStreamingIndicatorState,
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _atrMult = atrMult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StollerAverageRangeChannelsState(MovingAvgType maType, int length, double atrMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrMult = atrMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StollerAverageRangeChannels;
@@ -2294,22 +1857,6 @@ public sealed class Dema2LinesState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public Dema2LinesState(MovingAvgType maType, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var fast = Math.Max(1, fastLength);
-        var slow = Math.Max(1, slowLength);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, fast);
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, slow);
-        _fastDema = MovingAverageSmootherFactory.Create(maType, fast);
-        _slowDema = MovingAverageSmootherFactory.Create(maType, slow);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Dema2Lines;
 
     public void Reset()
@@ -2369,21 +1916,6 @@ public sealed class DynamicSupportAndResistanceState : IStreamingIndicatorState,
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DynamicSupportAndResistanceState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _mult = MathHelper.Sqrt(resolved);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DynamicSupportAndResistance;
@@ -2512,18 +2044,6 @@ public sealed class PeriodicChannelState : IStreamingIndicatorState, IDisposable
         _length1 = Math.Max(1, length1);
         _corrWindow = new RollingWindowCorrelation(Math.Max(1, length2));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PeriodicChannelState(int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _corrWindow = new RollingWindowCorrelation(Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PeriodicChannel;
@@ -2664,18 +2184,6 @@ public sealed class PriceLineChannelState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PriceLineChannelState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PriceLineChannel;
 
     public void Reset()
@@ -2772,20 +2280,6 @@ public sealed class PriceCurveChannelState : IStreamingIndicatorState, IDisposab
         _length = Math.Max(1, length);
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-        _lastAChangeIndex = -1;
-        _lastBChangeIndex = -1;
-    }
-
-    public PriceCurveChannelState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _lastAChangeIndex = -1;
         _lastBChangeIndex = -1;
     }
@@ -2897,22 +2391,6 @@ public sealed class RangeBandsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RangeBandsState(double stdDevFactor, MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDevFactor = stdDevFactor;
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        var windowLength = Math.Max(2, _length);
-        _maxWindow = new RollingWindowMax(windowLength);
-        _minWindow = new RollingWindowMin(windowLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RangeBands;
 
     public void Reset()
@@ -2964,16 +2442,6 @@ public sealed class RangeIdentifierState : IStreamingIndicatorState
     public RangeIdentifierState(int length = 34, InputName inputName = InputName.Close)
     {
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RangeIdentifierState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RangeIdentifier;
@@ -3028,7 +2496,7 @@ public sealed class LinearRegressionState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public LinearRegressionState(int length, Func<OhlcvBar, double> selector)
+    internal LinearRegressionState(int length, Func<OhlcvBar, double> selector)
     {
         if (selector == null)
         {
@@ -3099,18 +2567,6 @@ public sealed class StandardDeviationChannelState : IStreamingIndicatorState, ID
         _stdDevMult = stdDevMult;
     }
 
-    public StandardDeviationChannelState(int length, double stdDevMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _stdDevState = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, length, selector);
-        _regressionState = new LinearRegressionState(length, _ => _regressionInput);
-        _stdDevMult = stdDevMult;
-    }
-
     public IndicatorName Name => IndicatorName.StandardDeviationChannel;
 
     public void Reset()
@@ -3160,17 +2616,6 @@ public sealed class TimeSeriesForecastState : IStreamingIndicatorState, IDisposa
     {
         _regressionState = new LinearRegressionState(length, inputName);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public TimeSeriesForecastState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _regressionState = new LinearRegressionState(length, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.TimeSeriesForecast;
@@ -3235,18 +2680,6 @@ public sealed class SmartEnvelopeState : IStreamingIndicatorState
         _length = Math.Max(1, length);
         _factor = factor;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SmartEnvelopeState(int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SmartEnvelope;
@@ -3321,20 +2754,6 @@ public sealed class SupportResistanceState : IStreamingIndicatorState, IDisposab
         _highWindow = new RollingWindowMax(resolved);
         _lowWindow = new RollingWindowMin(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public SupportResistanceState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.SupportResistance;
@@ -3417,23 +2836,6 @@ public sealed class StationaryExtrapolatedLevelsState : IStreamingIndicatorState
         _extMin2 = new RollingWindowMin(_length);
         _yBuffer = new PooledRingBuffer<double>(_length * 2 + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StationaryExtrapolatedLevelsState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _extMax1 = new RollingWindowMax(_length);
-        _extMin1 = new RollingWindowMin(_length);
-        _extMax2 = new RollingWindowMax(_length);
-        _extMin2 = new RollingWindowMin(_length);
-        _yBuffer = new PooledRingBuffer<double>(_length * 2 + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StationaryExtrapolatedLevels;
@@ -3522,22 +2924,6 @@ public sealed class ScalpersChannelState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ScalpersChannelState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _highWindow = new RollingWindowMax(resolved1);
-        _lowWindow = new RollingWindowMin(resolved1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ScalpersChannel;
 
     public void Reset()
@@ -3617,25 +3003,6 @@ public sealed class SmoothedVolatilityBandsState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public SmoothedVolatilityBandsState(MovingAvgType maType, int length1, int length2, double deviation, double bandAdjust,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var atrPeriod = Math.Max(1, (resolved1 * 2) - 1);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, atrPeriod);
-        _maSmoother = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, resolved2);
-        _deviation = deviation;
-        _bandAdjust = bandAdjust;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.SmoothedVolatilityBands;
 
     public void Reset()
@@ -3703,19 +3070,6 @@ public sealed class MovingAverageEnvelopeState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MovingAverageEnvelopeState(MovingAvgType maType, int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MovingAverageEnvelope;
 
     public void Reset()
@@ -3767,18 +3121,6 @@ public sealed class LinearChannelsState : IStreamingIndicatorState
         _length = Math.Max(1, length);
         _mult = mult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public LinearChannelsState(int length, double mult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mult = mult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.LinearChannels;
@@ -3848,21 +3190,6 @@ public sealed class NarrowSidewaysChannelState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public NarrowSidewaysChannelState(MovingAvgType maType, int length, double stdDevMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _meanSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new RollingStandardDeviation(resolved);
-        _stdDevMult = stdDevMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.NarrowSidewaysChannel;
 
     public void Reset()
@@ -3913,20 +3240,6 @@ public sealed class RateOfChangeBandsState : IStreamingIndicatorState, IDisposab
     {
         _length = Math.Max(1, length);
         _roc = new RateOfChangeState(_length, inputName);
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _rocSquaredSum = new RollingWindowSum(_length);
-    }
-
-    public RateOfChangeBandsState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _roc = new RateOfChangeState(_length, selector);
         _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _rocSquaredSum = new RollingWindowSum(_length);
     }
@@ -3986,17 +3299,6 @@ public sealed class GChannelsState : IStreamingIndicatorState
     {
         _length = Math.Max(1, length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public GChannelsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.GChannels;
@@ -4060,21 +3362,6 @@ public sealed class HighLowMovingAverageState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public HighLowMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _upperSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowerSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.HighLowMovingAverage;
 
     public void Reset()
@@ -4132,20 +3419,6 @@ public sealed class HighLowBandsState : IStreamingIndicatorState, IDisposable
         _secondSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _pctShift = pctShift;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public HighLowBandsState(MovingAvgType maType, int length, double pctShift, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _firstSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _secondSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _pctShift = pctShift;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.HighLowBands;
@@ -4291,19 +3564,6 @@ public sealed class DEnvelopeState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DEnvelopeState(int length, double devFactor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _alpha = (double)2 / (resolved + 1);
-        _devFactor = devFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DEnvelope;
 
     public void Reset()
@@ -4367,19 +3627,6 @@ public sealed class PriceChannelState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public PriceChannelState(MovingAvgType maType, int length, double pct, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _pct = pct;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.PriceChannel;
 
     public void Reset()
@@ -4428,19 +3675,6 @@ public sealed class MovingAverageChannelState : IStreamingIndicatorState, IDispo
         _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MovingAverageChannelState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _lowSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.MovingAverageChannel;
@@ -4496,19 +3730,6 @@ public sealed class RelativeStrengthIndexState : IStreamingIndicatorState
         _avgLoss = new WilderState(length);
         _signal = new WilderState(signalLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public RelativeStrengthIndexState(int length, int signalLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _avgGain = new WilderState(length);
-        _avgLoss = new WilderState(length);
-        _signal = new WilderState(signalLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.RelativeStrengthIndex;
@@ -4578,22 +3799,6 @@ public sealed class StochasticOscillatorState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StochasticOscillatorState(MovingAvgType maType, int length, int smoothLength1, int smoothLength2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StochasticOscillator;
 
     public void Reset()
@@ -4656,19 +3861,6 @@ public sealed class WilliamsRState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public WilliamsRState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.WilliamsR;
 
     public void Reset()
@@ -4720,20 +3912,6 @@ public sealed class CommodityChannelIndexState : IStreamingIndicatorState, IDisp
         _priceSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _meanDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-        _constant = constant;
-    }
-
-    public CommodityChannelIndexState(InputName inputName, MovingAvgType maType, int length, double constant,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _priceSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _meanDevSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(inputName, selector);
         _constant = constant;
     }
 
@@ -4798,25 +3976,6 @@ public sealed class StochasticRelativeStrengthIndexState : IStreamingIndicatorSt
         _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public StochasticRelativeStrengthIndexState(MovingAvgType maType, int length, int smoothLength1, int smoothLength2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _rsi = new RsiState(maType, _length);
-        _inputHighWindow = new RollingWindowMax(2);
-        _inputLowWindow = new RollingWindowMin(2);
-        _maxWindow = new RollingWindowMax(_length);
-        _minWindow = new RollingWindowMin(_length);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.StochasticRelativeStrengthIndex;
@@ -4892,22 +4051,6 @@ public sealed class ConnorsRelativeStrengthIndexState : IStreamingIndicatorState
         _rocRank = new RollingPercentRank(_rocLength);
         _rocWindow = new PooledRingBuffer<double>(_rocLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ConnorsRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rocLength = Math.Max(1, length3);
-        _rsi = new RsiState(maType, Math.Max(1, length2));
-        _streakRsi = new RsiState(maType, Math.Max(1, length1));
-        _rocRank = new RollingPercentRank(_rocLength);
-        _rocWindow = new PooledRingBuffer<double>(_rocLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ConnorsRelativeStrengthIndex;
@@ -4999,24 +4142,6 @@ public sealed class StochasticConnorsRelativeStrengthIndexState : IStreamingIndi
         _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
     }
 
-    public StochasticConnorsRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, int length3,
-        int smoothLength1, int smoothLength2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length2);
-        _connors = new ConnorsRelativeStrengthIndexState(maType, length1, length2, length3, selector);
-        _inputHighWindow = new RollingWindowMax(2);
-        _inputLowWindow = new RollingWindowMin(2);
-        _maxWindow = new RollingWindowMax(_length);
-        _minWindow = new RollingWindowMin(_length);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-    }
-
     public IndicatorName Name => IndicatorName.StochasticConnorsRelativeStrengthIndex;
 
     public void Reset()
@@ -5093,25 +4218,6 @@ public sealed class StochasticMomentumIndexState : IStreamingIndicatorState, IDi
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StochasticMomentumIndexState(MovingAvgType maType, int length1, int length2, int smoothLength1,
-        int smoothLength2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _diffSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _diffSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _rangeSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _rangeSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StochasticMomentumIndex;
 
     public void Reset()
@@ -5186,20 +4292,6 @@ public sealed class MovingAverageConvergenceDivergenceState : IStreamingIndicato
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public MovingAverageConvergenceDivergenceState(int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = new EmaState(fastLength);
-        _slow = new EmaState(slowLength);
-        _signal = new EmaState(signalLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.MovingAverageConvergenceDivergence;
 
     public void Reset()
@@ -5245,19 +4337,6 @@ public sealed class AbsolutePriceOscillatorState : IStreamingIndicatorState, IDi
         _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AbsolutePriceOscillatorState(MovingAvgType maType, int fastLength, int slowLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AbsolutePriceOscillator;
@@ -5309,20 +4388,6 @@ public sealed class PercentagePriceOscillatorState : IStreamingIndicatorState, I
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public PercentagePriceOscillatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.PercentagePriceOscillator;
@@ -5379,20 +4444,6 @@ public sealed class PercentageVolumeOscillatorState : IStreamingIndicatorState, 
         _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(InputName.Volume, null);
-    }
-
-    public PercentageVolumeOscillatorState(MovingAvgType maType, int fastLength, int slowLength, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fast = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slow = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Volume, selector);
     }
 
     public IndicatorName Name => IndicatorName.PercentageVolumeOscillator;
@@ -5452,19 +4503,6 @@ public sealed class DonchianChannelsState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DonchianChannelsState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DonchianChannels;
 
     public void Reset()
@@ -5517,20 +4555,6 @@ public sealed class ClosedFormDistanceVolatilityState : IStreamingIndicatorState
         _highSum = new RollingWindowSum(_length);
         _lowSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ClosedFormDistanceVolatilityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _ema = MovingAverageSmootherFactory.Create(maType, _length);
-        _highSum = new RollingWindowSum(_length);
-        _lowSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ClosedFormDistanceVolatility;
@@ -5594,22 +4618,6 @@ public sealed class DonchianChannelWidthState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DonchianChannelWidthState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _priceSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _widthSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DonchianChannelWidth;
 
     public void Reset()
@@ -5666,18 +4674,6 @@ public sealed class HistoricalVolatilityState : IStreamingIndicatorState, IDispo
     {
         _stdDev = new StandardDeviationVolatilityState(maType, length, _ => _logReturn);
         _input = new StreamingInputResolver(inputName, null);
-        _annualSqrt = MathHelper.Sqrt(365);
-    }
-
-    public HistoricalVolatilityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _stdDev = new StandardDeviationVolatilityState(maType, length, _ => _logReturn);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _annualSqrt = MathHelper.Sqrt(365);
     }
 
@@ -5740,21 +4736,6 @@ public sealed class GarmanKlassVolatilityState : IStreamingIndicatorState, IDisp
         _logSum = new RollingWindowSum(_length);
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-        _logCoeff = (2 * Math.Log(2)) - 1;
-    }
-
-    public GarmanKlassVolatilityState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _logSum = new RollingWindowSum(_length);
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _logCoeff = (2 * Math.Log(2)) - 1;
     }
 
@@ -5823,21 +4804,6 @@ public sealed class GopalakrishnanRangeIndexState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public GopalakrishnanRangeIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _logLength = Math.Log(resolved);
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.GopalakrishnanRangeIndex;
 
     public void Reset()
@@ -5901,24 +4867,6 @@ public sealed class HistoricalVolatilityPercentileState : IStreamingIndicatorSta
         _devLogSqSum = new RollingWindowSum(_length);
         _signal = MovingAverageSmootherFactory.Create(maType, _length);
         _input = new StreamingInputResolver(inputName, null);
-        _hvOrder = new RollingOrderStatistic(_annualLength);
-    }
-
-    public HistoricalVolatilityPercentileState(MovingAvgType maType, int length, int annualLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _annualLength = Math.Max(1, annualLength);
-        _annualSqrt = MathHelper.Sqrt(_annualLength);
-        _tempLogSum = new RollingWindowSum(_length);
-        _devLogSqSum = new RollingWindowSum(_length);
-        _signal = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _hvOrder = new RollingOrderStatistic(_annualLength);
     }
 
@@ -6010,22 +4958,6 @@ public sealed class FastZScoreState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public FastZScoreState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        var length2 = MathHelper.MinOrMax((int)Math.Ceiling((double)resolved / 2));
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _linregLong = new LinearRegressionState(resolved, _ => _maValue);
-        _linregShort = new LinearRegressionState(length2, _ => _maValue);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, _ => _maValue);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.FastZScore;
 
     public void Reset()
@@ -6086,20 +5018,6 @@ public sealed class ChoppinessIndexState : IStreamingIndicatorState, IDisposable
         _highWindow = new RollingWindowMax(_length);
         _lowWindow = new RollingWindowMin(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ChoppinessIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _trSum = new RollingWindowSum(_length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ChoppinessIndex;
@@ -6172,20 +5090,6 @@ public sealed class ChandeMomentumOscillatorState : IStreamingIndicatorState, ID
         _negSum = new RollingWindowSum(Math.Max(1, length));
         _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ChandeMomentumOscillatorState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _posSum = new RollingWindowSum(Math.Max(1, length));
-        _negSum = new RollingWindowSum(Math.Max(1, length));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillator;
@@ -6390,21 +5294,6 @@ public sealed class BollingerBandsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BollingerBandsState(int length, double stdDevMult, Func<OhlcvBar, double> selector,
-        MovingAvgType maType = MovingAvgType.SimpleMovingAverage)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDevMult = stdDevMult;
-        _middle = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BollingerBands;
 
     public void Reset()
@@ -6459,7 +5348,7 @@ public sealed class StandardDeviationVolatilityState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StandardDeviationVolatilityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
+    internal StandardDeviationVolatilityState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
     {
         if (selector == null)
         {
@@ -6531,20 +5420,6 @@ public sealed class StandardDeviationState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public StandardDeviationState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sumWindow = new RollingWindowSum(_length);
-        _powMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _signalMa = MovingAverageSmootherFactory.Create(maType, _length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.StandardDeviation;
 
     public void Reset()
@@ -6602,18 +5477,6 @@ public sealed class UltimateVolatilityIndicatorState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public UltimateVolatilityIndicatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _absSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.UltimateVolatilityIndicator;
 
     public void Reset()
@@ -6665,20 +5528,6 @@ public sealed class VolatilityBasedMomentumState : IStreamingIndicatorState, IDi
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
         _window = new PooledRingBuffer<double>(_length1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public VolatilityBasedMomentumState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length1 = Math.Max(1, length1);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, _length1);
-        _window = new PooledRingBuffer<double>(_length1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.VolatilityBasedMomentum;
@@ -6749,18 +5598,6 @@ public sealed class VolatilityQualityIndexState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public VolatilityQualityIndexState(MovingAvgType maType, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.VolatilityQualityIndex;
 
     public void Reset()
@@ -6828,17 +5665,6 @@ public sealed class OnBalanceVolumeState : IStreamingIndicatorState
     {
         _signal = new EmaState(length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public OnBalanceVolumeState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signal = new EmaState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.OnBalanceVolume;
@@ -6951,19 +5777,6 @@ public sealed class MoneyFlowIndexState : IStreamingIndicatorState, IDisposable,
         _posSum = new RollingWindowSum(resolved);
         _negSum = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public MoneyFlowIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _posSum = new RollingWindowSum(resolved);
-        _negSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.TypicalPrice, selector);
     }
 
     public IndicatorName Name => IndicatorName.MoneyFlowIndex;
@@ -7157,22 +5970,6 @@ public sealed class TrueStrengthIndexState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrueStrengthIndexState(MovingAvgType maType, int length1, int length2, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _pcSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _pcSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _absSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _absSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.TrueStrengthIndex;
 
     public void Reset()
@@ -7239,17 +6036,6 @@ public sealed class ElderRayIndexState : IStreamingIndicatorState, IDisposable
     {
         _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ElderRayIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ElderRayIndex;
@@ -7574,21 +6360,6 @@ public sealed class ChartmillValueIndicatorState : IStreamingIndicatorState, IDi
         _lengthSqrt = MathHelper.Pow(resolved, 0.5);
     }
 
-    public ChartmillValueIndicatorState(MovingAvgType maType, InputName inputName, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _inputSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(inputName, selector);
-        _lengthSqrt = MathHelper.Pow(resolved, 0.5);
-    }
-
     public IndicatorName Name => IndicatorName.ChartmillValueIndicator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -7751,20 +6522,6 @@ public sealed class DetrendedPriceOscillatorState : IStreamingIndicatorState, ID
         _window = new PooledRingBuffer<double>(_prevPeriods);
     }
 
-    public DetrendedPriceOscillatorState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _prevPeriods = MathHelper.MinOrMax((int)Math.Ceiling(((double)resolved / 2) + 1));
-        _smoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-        _window = new PooledRingBuffer<double>(_prevPeriods);
-    }
-
     public IndicatorName Name => IndicatorName.DetrendedPriceOscillator;
 
     public void Reset()
@@ -7905,22 +6662,6 @@ public sealed class AbsoluteStrengthMTFIndicatorState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AbsoluteStrengthMTFIndicatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        _price1 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _price2 = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _bulls = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _bears = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AbsoluteStrengthMTFIndicator;
 
     public void Reset()
@@ -7984,18 +6725,6 @@ public sealed class AroonOscillatorState : IStreamingIndicatorState, IDisposable
         _length = Math.Max(1, length);
         _window = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AroonOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AroonOscillator;
@@ -8257,20 +6986,6 @@ public sealed class ChopZoneState : IStreamingIndicatorState, IDisposable, ICust
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChopZoneState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _highWindow = new RollingWindowMax(resolved1);
-        _lowWindow = new RollingWindowMin(resolved1);
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChopZone;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -8340,19 +7055,6 @@ public sealed class CenterOfLinearityState : IStreamingIndicatorState, IDisposab
         _sumWindow = new RollingWindowSum(_length);
         _window = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public CenterOfLinearityState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sumWindow = new RollingWindowSum(_length);
-        _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.CenterOfLinearity;
@@ -8465,19 +7167,6 @@ public sealed class CoppockCurveState : IStreamingIndicatorState, IDisposable
         int slowLength = 14, InputName inputName = InputName.Close)
     {
         _rocFast = new RateOfChangeState(Math.Max(1, fastLength), inputName);
-        _slowLength = Math.Max(1, slowLength);
-        _rocFastWindow = new PooledRingBuffer<double>(_slowLength);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-    }
-
-    public CoppockCurveState(MovingAvgType maType, int length, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rocFast = new RateOfChangeState(Math.Max(1, fastLength), selector);
         _slowLength = Math.Max(1, slowLength);
         _rocFastWindow = new PooledRingBuffer<double>(_slowLength);
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
@@ -8650,19 +7339,6 @@ public sealed class DeltaMovingAverageState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DeltaMovingAverageState(MovingAvgType maType, int length1, int length2, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length2 = Math.Max(1, length2);
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _openWindow = new PooledRingBuffer<double>(_length2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DeltaMovingAverage;
 
     public void Reset()
@@ -8786,21 +7462,6 @@ public sealed class DerivativeOscillatorState : IStreamingIndicatorState, IDispo
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DerivativeOscillatorState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rsi = new RsiState(maType, Math.Max(1, length1));
-        _ema1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _ema2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _sumWindow = new RollingWindowSum(Math.Max(1, length2));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DerivativeOscillator;
 
     public void Reset()
@@ -8863,22 +7524,6 @@ public sealed class DemandOscillatorState : IStreamingIndicatorState, IDisposabl
         _doSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
         _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DemandOscillatorState(MovingAvgType maType, int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved2 = Math.Max(1, length2);
-        _highWindow = new RollingWindowMax(resolved2);
-        _lowWindow = new RollingWindowMin(resolved2);
-        _rangeSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _doSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DemandOscillator;
@@ -8966,24 +7611,6 @@ public sealed class DoubleSmoothedMomentaState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DoubleSmoothedMomentaState(MovingAvgType maType, int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _maxWindow = new RollingWindowMax(resolved1);
-        _minWindow = new RollingWindowMin(resolved1);
-        _topSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _topSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _botSmoother1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _botSmoother2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DoubleSmoothedMomenta;
 
     public void Reset()
@@ -9052,19 +7679,6 @@ public sealed class DidiIndexState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DidiIndexState(MovingAvgType maType, int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _shortSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _mediumSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _longSma = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DidiIndex;
 
     public void Reset()
@@ -9114,17 +7728,6 @@ public sealed class DisparityIndexState : IStreamingIndicatorState, IDisposable
     {
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public DisparityIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.DisparityIndex;
@@ -9314,21 +7917,6 @@ public sealed class DTOscillatorState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public DTOscillatorState(MovingAvgType maType, int length1, int length2, int length3, int length4, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _wima = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _maxWindow = new RollingWindowMax(Math.Max(1, length2));
-        _minWindow = new RollingWindowMin(Math.Max(1, length2));
-        _stoSum = new RollingWindowSum(Math.Max(1, length3));
-        _skSum = new RollingWindowSum(Math.Max(1, length4));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.DTOscillator;
 
     public void Reset()
@@ -9388,18 +7976,6 @@ public sealed class RateOfChangeState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public RateOfChangeState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.RateOfChange;
 
     public void Reset()
@@ -9455,7 +8031,7 @@ public sealed class UlcerIndexState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public UlcerIndexState(int length, Func<OhlcvBar, double> selector)
+    internal UlcerIndexState(int length, Func<OhlcvBar, double> selector)
     {
         if (selector == null)
         {
@@ -9605,20 +8181,6 @@ public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposab
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AwesomeOscillatorState(int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _slowLength = Math.Max(1, slowLength);
-        _fastSum = new RollingWindowSum(_fastLength);
-        _slowSum = new RollingWindowSum(_slowLength);
-        _input = new StreamingInputResolver(InputName.MedianPrice, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AwesomeOscillator;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -9680,23 +8242,6 @@ public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisp
         _slowSum = new RollingWindowSum(_slowLength);
         _smoothSum = new RollingWindowSum(_smoothLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AcceleratorOscillatorState(int fastLength, int slowLength, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastLength = Math.Max(1, fastLength);
-        _slowLength = Math.Max(1, slowLength);
-        _smoothLength = Math.Max(1, smoothLength);
-        _fastSum = new RollingWindowSum(_fastLength);
-        _slowSum = new RollingWindowSum(_slowLength);
-        _smoothSum = new RollingWindowSum(_smoothLength);
-        _input = new StreamingInputResolver(InputName.MedianPrice, selector);
     }
 
     public IndicatorName Name => IndicatorName.AcceleratorOscillator;
@@ -9764,19 +8309,6 @@ public sealed class TrixState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public TrixState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema1 = new EmaState(length);
-        _ema2 = new EmaState(length);
-        _ema3 = new EmaState(length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.Trix;
 
     public void Reset()
@@ -9833,20 +8365,6 @@ public sealed class _1LCLeastSquaresMovingAverageState : IStreamingIndicatorStat
         _stdDev = new RollingStandardDeviation(_length);
         _correlation = new RollingWindowCorrelation(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public _1LCLeastSquaresMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new RollingStandardDeviation(_length);
-        _correlation = new RollingWindowCorrelation(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName._1LCLeastSquaresMovingAverage;
@@ -9915,24 +8433,6 @@ public sealed class _3HMAState : IStreamingIndicatorState, IDisposable
         _wma3 = MovingAverageSmootherFactory.Create(maType, p);
         _final = MovingAverageSmootherFactory.Create(maType, p);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public _3HMAState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var p = MathHelper.MinOrMax((int)Math.Ceiling((double)length / 2));
-        var p1 = MathHelper.MinOrMax((int)Math.Ceiling((double)p / 3));
-        var p2 = MathHelper.MinOrMax((int)Math.Ceiling((double)p / 2));
-
-        _wma1 = MovingAverageSmootherFactory.Create(maType, p1);
-        _wma2 = MovingAverageSmootherFactory.Create(maType, p2);
-        _wma3 = MovingAverageSmootherFactory.Create(maType, p);
-        _final = MovingAverageSmootherFactory.Create(maType, p);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName._3HMA;
@@ -10009,30 +8509,6 @@ public sealed class _4MovingAverageConvergenceDivergenceState : IStreamingIndica
         _blueMult = blueMult;
         _yellowMult = yellowMult;
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public _4MovingAverageConvergenceDivergenceState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int length6, double blueMult, double yellowMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _ema5 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _ema8 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ema10 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _ema17 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _ema14 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _ema16 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
-        _signal1 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal2 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal3 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal4 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _blueMult = blueMult;
-        _yellowMult = yellowMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName._4MovingAverageConvergenceDivergence;
@@ -10146,30 +8622,6 @@ public sealed class _4PercentagePriceOscillatorState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public _4PercentagePriceOscillatorState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int length6, double blueMult, double yellowMult, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        _ema5 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _ema8 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ema10 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _ema17 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length4));
-        _ema14 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length5));
-        _ema16 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length6));
-        _signal1 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal2 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal3 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _signal4 = MovingAverageSmootherFactory.Create(maType, resolved1);
-        _blueMult = blueMult;
-        _yellowMult = yellowMult;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName._4PercentagePriceOscillator;
 
     public void Reset()
@@ -10273,22 +8725,6 @@ public sealed class AdaptiveMovingAverageState : IStreamingIndicatorState, IDisp
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AdaptiveMovingAverageState(int fastLength, int slowLength, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _fastAlpha = (double)2 / (Math.Max(1, fastLength) + 1);
-        _slowAlpha = (double)2 / (Math.Max(1, slowLength) + 1);
-        var windowLength = Math.Max(1, _length + 1);
-        _highWindow = new RollingWindowMax(windowLength);
-        _lowWindow = new RollingWindowMin(windowLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AdaptiveMovingAverage;
 
     public void Reset()
@@ -10359,21 +8795,6 @@ public sealed class AdaptiveExponentialMovingAverageState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AdaptiveExponentialMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _mltp1 = (double)2 / (_length + 1);
-        _sma = MovingAverageSmootherFactory.Create(maType, _length);
-        _highWindow = new RollingWindowMax(_length);
-        _lowWindow = new RollingWindowMin(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AdaptiveExponentialMovingAverage;
 
     public void Reset()
@@ -10438,17 +8859,6 @@ public sealed class AdaptiveAutonomousRecursiveMovingAverageState : IStreamingIn
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AdaptiveAutonomousRecursiveMovingAverageState(int length, double gamma, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new AdaptiveAutonomousRecursiveMovingAverageEngine(length, gamma);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AdaptiveAutonomousRecursiveMovingAverage;
 
     public void Reset()
@@ -10503,19 +8913,6 @@ public sealed class AdaptiveLeastSquaresState : IStreamingIndicatorState, IDispo
         _smooth = smooth;
         _trWindow = new RollingWindowMax(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AdaptiveLeastSquaresState(int length, double smooth, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smooth = smooth;
-        _trWindow = new RollingWindowMax(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveLeastSquares;
@@ -10626,16 +9023,6 @@ public sealed class AlphaDecreasingExponentialMovingAverageState : IStreamingInd
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AlphaDecreasingExponentialMovingAverageState(Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AlphaDecreasingExponentialMovingAverage;
 
     public void Reset()
@@ -10688,22 +9075,6 @@ public sealed class AdaptivePriceZoneIndicatorState : IStreamingIndicatorState, 
         _xhlEma1 = MovingAverageSmootherFactory.Create(maType, nP);
         _xhlEma2 = MovingAverageSmootherFactory.Create(maType, nP);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AdaptivePriceZoneIndicatorState(MovingAvgType maType, int length, double pct, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var nP = MathHelper.MinOrMax((int)Math.Ceiling(MathHelper.Sqrt(length)));
-        _pct = pct;
-        _ema1 = MovingAverageSmootherFactory.Create(maType, nP);
-        _ema2 = MovingAverageSmootherFactory.Create(maType, nP);
-        _xhlEma1 = MovingAverageSmootherFactory.Create(maType, nP);
-        _xhlEma2 = MovingAverageSmootherFactory.Create(maType, nP);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AdaptivePriceZoneIndicator;
@@ -10761,17 +9132,6 @@ public sealed class AdaptiveRelativeStrengthIndexState : IStreamingIndicatorStat
     {
         _rsi = new RsiState(maType, Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AdaptiveRelativeStrengthIndexState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _rsi = new RsiState(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveRelativeStrengthIndex;
@@ -10842,26 +9202,6 @@ public sealed class AdaptiveStochasticState : IStreamingIndicatorState, IDisposa
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AdaptiveStochasticState(int length, int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        var resolvedFast = Math.Max(1, fastLength);
-        var resolvedSlow = Math.Max(1, slowLength);
-        var regressionLength = Math.Max(1, Math.Abs(resolvedSlow - resolvedFast));
-        _er = new EfficiencyRatioState(resolvedLength);
-        _regression = new LinearRegressionState(regressionLength, _ => _regressionInput);
-        _fastMax = new RollingWindowMax(resolvedFast);
-        _fastMin = new RollingWindowMin(resolvedFast);
-        _slowMax = new RollingWindowMax(resolvedSlow);
-        _slowMin = new RollingWindowMin(resolvedSlow);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AdaptiveStochastic;
 
     public void Reset()
@@ -10929,18 +9269,6 @@ public sealed class AdaptiveTrailingStopState : IStreamingIndicatorState, IDispo
         _factor = factor;
         _er = new EfficiencyRatioState(Math.Max(1, length));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AdaptiveTrailingStopState(int length, double factor, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _factor = factor;
-        _er = new EfficiencyRatioState(Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AdaptiveTrailingStop;
@@ -11018,17 +9346,6 @@ public sealed class AdaptiveAutonomousRecursiveTrailingStopState : IStreamingInd
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AdaptiveAutonomousRecursiveTrailingStopState(int length, double gamma, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _engine = new AdaptiveAutonomousRecursiveMovingAverageEngine(length, gamma);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AdaptiveAutonomousRecursiveTrailingStop;
 
     public void Reset()
@@ -11091,18 +9408,6 @@ public sealed class AhrensMovingAverageState : IStreamingIndicatorState, IDispos
         _length = Math.Max(1, length);
         _window = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AhrensMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AhrensMovingAverage;
@@ -11176,32 +9481,6 @@ public sealed class ArnaudLegouxMovingAverageState : IStreamingIndicatorState, I
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ArnaudLegouxMovingAverageState(int length, double offset, int sigma, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var m = offset * (_length - 1);
-        var s = (double)_length / sigma;
-        _weights = new double[_length];
-        double weightSum = 0;
-        for (var j = 0; j < _length; j++)
-        {
-            var weight = s != 0
-                ? MathHelper.Exp(-1 * MathHelper.Pow(j - m, 2) / (2 * MathHelper.Pow(s, 2)))
-                : 0;
-            _weights[j] = weight;
-            weightSum += weight;
-        }
-
-        _weightSum = weightSum;
-        _window = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ArnaudLegouxMovingAverage;
 
     public void Reset()
@@ -11272,26 +9551,6 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable,
         _teethWindow = new PooledRingBuffer<double>(_teethOffset + 1);
         _lipsWindow = new PooledRingBuffer<double>(_lipsOffset + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AlligatorIndexState(InputName inputName, MovingAvgType maType, int jawLength, int jawOffset, int teethLength, int teethOffset,
-        int lipsLength, int lipsOffset, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _jawOffset = Math.Max(0, jawOffset);
-        _teethOffset = Math.Max(0, teethOffset);
-        _lipsOffset = Math.Max(0, lipsOffset);
-        _jawSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, jawLength));
-        _teethSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, teethLength));
-        _lipsSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, lipsLength));
-        _jawWindow = new PooledRingBuffer<double>(_jawOffset + 1);
-        _teethWindow = new PooledRingBuffer<double>(_teethOffset + 1);
-        _lipsWindow = new PooledRingBuffer<double>(_lipsOffset + 1);
-        _input = new StreamingInputResolver(inputName, selector);
     }
 
     public IndicatorName Name => IndicatorName.AlligatorIndex;
@@ -11371,22 +9630,6 @@ public sealed class AnchoredMomentumState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AnchoredMomentumState(MovingAvgType maType, int smoothLength, int signalLength, int momentumLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _signalLength = Math.Max(1, signalLength);
-        var p = MathHelper.MinOrMax((2 * momentumLength) + 1);
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _priceSum = new RollingWindowSum(p);
-        _signalSum = new RollingWindowSum(_signalLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AnchoredMomentum;
 
     public void Reset()
@@ -11445,20 +9688,6 @@ public sealed class ApirineSlowRelativeStrengthIndexState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ApirineSlowRelativeStrengthIndexState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _smooth = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _gain = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _loss = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ApirineSlowRelativeStrengthIndex;
 
     public void Reset()
@@ -11514,18 +9743,6 @@ public sealed class AsymmetricalRelativeStrengthIndexState : IStreamingIndicator
         _length = Math.Max(1, length);
         _upCountSum = new RollingWindowSum(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AsymmetricalRelativeStrengthIndexState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _upCountSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AsymmetricalRelativeStrengthIndex;
@@ -11621,32 +9838,6 @@ public sealed class AtrFilteredExponentialMovingAverageState : IStreamingIndicat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AtrFilteredExponentialMovingAverageState(MovingAvgType maType, int length, int atrLength, int stdDevLength,
-        int lbLength, double min, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDevLength = Math.Max(1, stdDevLength);
-        if (maType == MovingAvgType.SimpleMovingAverage)
-        {
-            _atrSmoother = new ExactSimpleMovingAverageSmoother(Math.Max(1, atrLength));
-            _stdDevASmoother = new ExactSimpleMovingAverageSmoother(_stdDevLength);
-        }
-        else
-        {
-            _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, atrLength));
-            _stdDevASmoother = MovingAverageSmootherFactory.Create(maType, _stdDevLength);
-        }
-        _atrValSum = new RollingCumulativeSum();
-        _stdDevMin = new RollingWindowMin(Math.Max(1, lbLength));
-        _min = min;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AtrFilteredExponentialMovingAverage;
 
     public void Reset()
@@ -11735,26 +9926,6 @@ public sealed class AutoDispersionBandsState : IStreamingIndicatorState, IDispos
         _lowerSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _values = new PooledRingBuffer<double>(_length + 1);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AutoDispersionBandsState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _x2Sum = new RollingWindowSum(_length);
-        _aMax = new RollingWindowMax(_length);
-        _bMin = new RollingWindowMin(_length);
-        _aSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _upperSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _bSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _lowerSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _values = new PooledRingBuffer<double>(_length + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AutoDispersionBands;
@@ -11849,22 +10020,6 @@ public sealed class AutoFilterState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AutoFilterState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _yMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _xMa = MovingAverageSmootherFactory.Create(maType, resolved);
-        _dev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _xDev = new StandardDeviationVolatilityState(maType, resolved, _ => _xValue);
-        _correlation = new RollingWindowCorrelation(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AutoFilter;
 
     public void Reset()
@@ -11937,18 +10092,6 @@ public sealed class AutoLineState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AutoLineState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, resolved, selector);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AutoLine;
 
     public void Reset()
@@ -12005,19 +10148,6 @@ public sealed class AutoLineWithDriftState : IStreamingIndicatorState, IDisposab
         _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, inputName);
         _values = new PooledRingBuffer<double>(_length + 2);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AutoLineWithDriftState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(MovingAvgType.SimpleMovingAverage, _length, selector);
-        _values = new PooledRingBuffer<double>(_length + 2);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AutoLineWithDrift;
@@ -12100,23 +10230,6 @@ public sealed class AutonomousRecursiveMovingAverageState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AutonomousRecursiveMovingAverageState(int length, int momLength, double gamma,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _momLength = Math.Max(1, momLength);
-        _gamma = gamma;
-        _cSum = new RollingWindowSum(_length);
-        _ma1Sum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(Math.Max(_length, _momLength) + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AutonomousRecursiveMovingAverage;
 
     public void Reset()
@@ -12191,19 +10304,6 @@ public sealed class AverageAbsoluteErrorNormalizationState : IStreamingIndicator
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AverageAbsoluteErrorNormalizationState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _eSum = new RollingWindowSum(resolved);
-        _eAbsSum = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AverageAbsoluteErrorNormalization;
 
     public void Reset()
@@ -12275,23 +10375,6 @@ public sealed class AverageMoneyFlowOscillatorState : IStreamingIndicatorState, 
         _rMax = new RollingWindowMax(resolvedLength);
         _rMin = new RollingWindowMin(resolvedLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public AverageMoneyFlowOscillatorState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        _avgVolume = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _avgChange = MovingAverageSmootherFactory.Create(maType, resolvedLength);
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _rMax = new RollingWindowMax(resolvedLength);
-        _rMin = new RollingWindowMin(resolvedLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.AverageMoneyFlowOscillator;
@@ -12369,20 +10452,6 @@ public sealed class AverageTrueRangeTrailingStopsState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public AverageTrueRangeTrailingStopsState(MovingAvgType maType, int length1, int length2, double factor,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ema = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _atr = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _factor = factor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.AverageTrueRangeTrailingStops;
 
     public void Reset()
@@ -12458,26 +10527,6 @@ public sealed class BayesianOscillatorState : IStreamingIndicatorState, IDisposa
         _probBasisUp = new RollingWindowSum(resolved);
         _probBasisDown = new RollingWindowSum(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public BayesianOscillatorState(MovingAvgType maType, int length, double stdDevMult, double lowerThreshold,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = lowerThreshold;
-        var resolved = Math.Max(1, length);
-        _stdDevMult = stdDevMult;
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new RollingStandardDeviation(resolved);
-        _probUpperUp = new RollingWindowSum(resolved);
-        _probUpperDown = new RollingWindowSum(resolved);
-        _probBasisUp = new RollingWindowSum(resolved);
-        _probBasisDown = new RollingWindowSum(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.BayesianOscillator;
@@ -12639,23 +10688,6 @@ public sealed class BilateralStochasticOscillatorState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BilateralStochasticOscillatorState(MovingAvgType maType, int length, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _rangeSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _signal = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _highWindow = new RollingWindowMax(resolved);
-        _lowWindow = new RollingWindowMin(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BilateralStochasticOscillator;
 
     public void Reset()
@@ -12723,21 +10755,6 @@ public sealed class BollingerBandsAverageTrueRangeState : IStreamingIndicatorSta
         _stdDev = new RollingStandardDeviation(Math.Max(1, length));
         _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, atrLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public BollingerBandsAverageTrueRangeState(MovingAvgType maType, int atrLength, int length, double stdDevMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _stdDevMult = stdDevMult;
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length));
-        _stdDev = new RollingStandardDeviation(Math.Max(1, length));
-        _atrSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, atrLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsAverageTrueRange;
@@ -12815,23 +10832,6 @@ public sealed class BollingerBandsFibonacciRatiosState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BollingerBandsFibonacciRatiosState(MovingAvgType maType, int length, double fibRatio1, double fibRatio2,
-        double fibRatio3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ = fibRatio1;
-        _ = fibRatio2;
-        _fibRatio3 = fibRatio3;
-        var resolved = Math.Max(1, length);
-        _sma = MovingAverageSmootherFactory.Create(maType, resolved);
-        _atr = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BollingerBandsFibonacciRatios;
 
     public void Reset()
@@ -12900,21 +10900,6 @@ public sealed class BollingerBandsPercentBState : IStreamingIndicatorState, IDis
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BollingerBandsPercentBState(double stdDevMult, MovingAvgType maType, int length,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDevMult = stdDevMult;
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BollingerBandsPercentB;
 
     public void Reset()
@@ -12966,20 +10951,6 @@ public sealed class BollingerBandsWidthState : IStreamingIndicatorState, IDispos
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _stdDev = new RollingStandardDeviation(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public BollingerBandsWidthState(double stdDevMult, MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDevMult = stdDevMult;
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _stdDev = new RollingStandardDeviation(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsWidth;
@@ -13036,21 +11007,6 @@ public sealed class BollingerBandsWithAtrPctState : IStreamingIndicatorState, ID
         _stdDevMult = stdDevMult;
         _basisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, bbLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public BollingerBandsWithAtrPctState(MovingAvgType maType, int length, int bbLength, double stdDevMult,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength = Math.Max(1, length);
-        _ratio = (double)2 / (resolvedLength + 1);
-        _stdDevMult = stdDevMult;
-        _basisSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, bbLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.BollingerBandsWithAtrPct;
@@ -13128,21 +11084,6 @@ public sealed class BreakoutRelativeStrengthIndexState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BreakoutRelativeStrengthIndexState(InputName inputName, int length, int lbLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _volumeSum = new RollingWindowSum(Math.Max(1, lbLength));
-        _posPowerSum = new RollingWindowSum(_length);
-        _negPowerSum = new RollingWindowSum(_length);
-        _input = new StreamingInputResolver(inputName, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BreakoutRelativeStrengthIndex;
 
     void ICustomInputConsumer.ReadCloseAsInput() =>
@@ -13214,20 +11155,6 @@ public sealed class BryantAdaptiveMovingAverageState : IStreamingIndicatorState,
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public BryantAdaptiveMovingAverageState(int length, int maxLength, double trend, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _maxLength = maxLength;
-        _trend = trend;
-        _er = new EfficiencyRatioState(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.BryantAdaptiveMovingAverage;
 
     public void Reset()
@@ -13287,20 +11214,6 @@ public sealed class BuffAverageState : IStreamingIndicatorState, IDisposable
         _slowPriceSum = new RollingWindowSum(Math.Max(1, slowLength));
         _slowVolumeSum = new RollingWindowSum(Math.Max(1, slowLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public BuffAverageState(int fastLength, int slowLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _fastPriceSum = new RollingWindowSum(Math.Max(1, fastLength));
-        _fastVolumeSum = new RollingWindowSum(Math.Max(1, fastLength));
-        _slowPriceSum = new RollingWindowSum(Math.Max(1, slowLength));
-        _slowVolumeSum = new RollingWindowSum(Math.Max(1, slowLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.BuffAverage;
@@ -13364,22 +11277,6 @@ public sealed class CalmarRatioState : IStreamingIndicatorState, IDisposable
         _drawdownMin = new RollingWindowMin(_length);
         _values = new PooledRingBuffer<double>(_length);
         _input = new StreamingInputResolver(inputName, null);
-        _power = CalculatePower(_length);
-    }
-
-    public CalmarRatioState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var windowLength = Math.Max(_length, 2);
-        _maxWindow = new RollingWindowMax(windowLength);
-        _drawdownMin = new RollingWindowMin(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _power = CalculatePower(_length);
     }
 
@@ -13586,47 +11483,6 @@ public sealed class CCTStochRelativeStrengthIndexState : IStreamingIndicatorStat
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public CCTStochRelativeStrengthIndexState(MovingAvgType maType, int length1, int length2, int length3, int length4,
-        int length5, int smoothLength1, int smoothLength2, int signalLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        var resolved4 = Math.Max(1, length4);
-        var resolved5 = Math.Max(1, length5);
-        _rsi5 = new RsiState(maType, resolved1);
-        _rsi8 = new RsiState(maType, resolved2);
-        _rsi13 = new RsiState(maType, resolved3);
-        _rsi14 = new RsiState(maType, resolved4);
-        _rsi21 = new RsiState(maType, resolved5);
-        _rsi21Len2Min = new RollingWindowMin(resolved2);
-        _rsi21Len2Max = new RollingWindowMax(resolved2);
-        _rsi21Len3Min = new RollingWindowMin(resolved3);
-        _rsi21Len3Max = new RollingWindowMax(resolved3);
-        _rsi21Len5Min = new RollingWindowMin(resolved5);
-        _rsi21Len5Max = new RollingWindowMax(resolved5);
-        _rsi14Len4Min = new RollingWindowMin(resolved4);
-        _rsi14Len4Max = new RollingWindowMax(resolved4);
-        _rsi5Len1Min = new RollingWindowMin(resolved1);
-        _rsi5Len1Max = new RollingWindowMax(resolved1);
-        _rsi13Len3Min = new RollingWindowMin(resolved3);
-        _rsi13Len3Max = new RollingWindowMax(resolved3);
-        _rsi8Len2Min = new RollingWindowMin(resolved2);
-        _rsi8Len2Max = new RollingWindowMax(resolved2);
-        _type4Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength2));
-        _type5Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _type6Smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _customSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength1));
-        _signalSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, signalLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.CCTStochRelativeStrengthIndex;
 
     public void Reset()
@@ -13796,34 +11652,6 @@ public sealed class ChandeCompositeMomentumIndexState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeCompositeMomentumIndexState(MovingAvgType maType, int length1, int length2, int length3,
-        int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        _smoothLength = Math.Max(1, smoothLength);
-        _diff1Sum1 = new RollingWindowSum(resolved1);
-        _diff1Sum2 = new RollingWindowSum(resolved2);
-        _diff1Sum3 = new RollingWindowSum(resolved3);
-        _diff2Sum1 = new RollingWindowSum(resolved1);
-        _diff2Sum2 = new RollingWindowSum(resolved2);
-        _diff2Sum3 = new RollingWindowSum(resolved3);
-        _dmiSum = new RollingWindowSum(resolved1);
-        _stdDev1 = new StandardDeviationVolatilityState(maType, resolved1, selector);
-        _stdDev2 = new StandardDeviationVolatilityState(maType, resolved2, _ => _stdDev1Value);
-        _stdDev3 = new StandardDeviationVolatilityState(maType, resolved3, _ => _stdDev2Value);
-        _cmo5Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _cmo10Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _cmo20Smoother = MovingAverageSmootherFactory.Create(maType, _smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeCompositeMomentumIndex;
 
     public void Reset()
@@ -13941,17 +11769,6 @@ public sealed class ChandeForecastOscillatorState : IStreamingIndicatorState, ID
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeForecastOscillatorState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _regression = new LinearRegressionState(length, _ => _regressionInput);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeForecastOscillator;
 
     public void Reset()
@@ -14058,19 +11875,6 @@ public sealed class ChandeKrollRSquaredIndexState : IStreamingIndicatorState, ID
         _correlation = new RollingWindowCorrelation(Math.Max(1, length));
         _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ChandeKrollRSquaredIndexState(MovingAvgType maType, int length, int smoothLength,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _correlation = new RollingWindowCorrelation(Math.Max(1, length));
-        _smoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, smoothLength));
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ChandeKrollRSquaredIndex;
@@ -14200,19 +12004,6 @@ public sealed class ChandeMomentumOscillatorAbsoluteState : IStreamingIndicatorS
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeMomentumOscillatorAbsoluteState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _absDiffSum = new RollingWindowSum(_length);
-        _values = new PooledRingBuffer<double>(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAbsolute;
 
     public void Reset()
@@ -14285,25 +12076,6 @@ public sealed class ChandeMomentumOscillatorAverageState : IStreamingIndicatorSt
         _absDiffSum2 = new RollingWindowSum(resolved2);
         _absDiffSum3 = new RollingWindowSum(resolved3);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ChandeMomentumOscillatorAverageState(int length1, int length2, int length3, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        _diffSum1 = new RollingWindowSum(resolved1);
-        _diffSum2 = new RollingWindowSum(resolved2);
-        _diffSum3 = new RollingWindowSum(resolved3);
-        _absDiffSum1 = new RollingWindowSum(resolved1);
-        _absDiffSum2 = new RollingWindowSum(resolved2);
-        _absDiffSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAverage;
@@ -14395,26 +12167,6 @@ public sealed class ChandeMomentumOscillatorAbsoluteAverageState : IStreamingInd
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeMomentumOscillatorAbsoluteAverageState(int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved1 = Math.Max(1, length1);
-        var resolved2 = Math.Max(1, length2);
-        var resolved3 = Math.Max(1, length3);
-        _diffSum1 = new RollingWindowSum(resolved1);
-        _diffSum2 = new RollingWindowSum(resolved2);
-        _diffSum3 = new RollingWindowSum(resolved3);
-        _absDiffSum1 = new RollingWindowSum(resolved1);
-        _absDiffSum2 = new RollingWindowSum(resolved2);
-        _absDiffSum3 = new RollingWindowSum(resolved3);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAbsoluteAverage;
 
     public void Reset()
@@ -14493,20 +12245,6 @@ public sealed class ChandeMomentumOscillatorAverageDisparityIndexState : IStream
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeMomentumOscillatorAverageDisparityIndexState(MovingAvgType maType, int length1, int length2, int length3,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _ma1 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _ma2 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length2));
-        _ma3 = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length3));
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorAverageDisparityIndex;
 
     public void Reset()
@@ -14566,22 +12304,6 @@ public sealed class ChandeMomentumOscillatorFilterState : IStreamingIndicatorSta
         _absDiffSum = new RollingWindowSum(resolved);
         _signal = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public ChandeMomentumOscillatorFilterState(MovingAvgType maType, int length, double filter,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _filter = filter;
-        _diffSum = new RollingWindowSum(resolved);
-        _absDiffSum = new RollingWindowSum(resolved);
-        _signal = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.ChandeMomentumOscillatorFilter;
@@ -14693,19 +12415,6 @@ public sealed class ChandeTrendScoreState : IStreamingIndicatorState, IDisposabl
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ChandeTrendScoreState(int startLength, int endLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _startLength = Math.Max(1, startLength);
-        _endLength = Math.Max(_startLength, endLength);
-        _values = new PooledRingBuffer<double>(_endLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ChandeTrendScore;
 
     public void Reset()
@@ -14764,22 +12473,6 @@ public sealed class ChandeVolatilityIndexDynamicAverageIndicatorState : IStreami
         _stdDev = new StandardDeviationVolatilityState(maType, resolved, inputName);
         _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
         _input = new StreamingInputResolver(inputName, null);
-        _alpha1 = alpha1;
-        _alpha2 = alpha2;
-    }
-
-    public ChandeVolatilityIndexDynamicAverageIndicatorState(MovingAvgType maType, int length, double alpha1, double alpha2,
-        Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _stdDev = new StandardDeviationVolatilityState(maType, resolved, selector);
-        _stdDevSmoother = MovingAverageSmootherFactory.Create(maType, resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
         _alpha1 = alpha1;
         _alpha2 = alpha2;
     }
@@ -14857,27 +12550,6 @@ public sealed class CompoundRatioMovingAverageState : IStreamingIndicatorState, 
         var smoothLength = Math.Max((int)Math.Round(Math.Sqrt(_length)), 1);
         _smoother = MovingAverageSmootherFactory.Create(maType, smoothLength);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public CompoundRatioMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        var r = Math.Pow(_length, ((double)1 / (_length - 1)) - 1);
-        _bas = 1 + (r * 2);
-        _weights = new double[_length];
-        for (var j = 0; j < _length; j++)
-        {
-            _weights[j] = Math.Pow(_bas, _length - j);
-        }
-        _buffer = new PooledRingBuffer<double>(_length);
-        var smoothLength = Math.Max((int)Math.Round(Math.Sqrt(_length)), 1);
-        _smoother = MovingAverageSmootherFactory.Create(maType, smoothLength);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.CompoundRatioMovingAverage;
@@ -14971,26 +12643,6 @@ public sealed class ConstanceBrownCompositeIndexState : IStreamingIndicatorState
         _input = new StreamingInputResolver(inputName, null);
     }
 
-    public ConstanceBrownCompositeIndexState(MovingAvgType maType, int fastLength, int slowLength, int length1,
-        int length2, int smoothLength, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolvedLength1 = Math.Max(1, length1);
-        _length2 = Math.Max(1, length2);
-        var resolvedSmooth = Math.Max(1, smoothLength);
-        _rsi1 = new RsiState(MovingAvgType.WildersSmoothingMethod, resolvedLength1);
-        _rsi2 = new RsiState(MovingAvgType.WildersSmoothingMethod, resolvedSmooth);
-        _rsiSmoother = MovingAverageSmootherFactory.Create(maType, resolvedSmooth);
-        _fastSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, fastLength));
-        _slowSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, slowLength));
-        _rsi1Window = new PooledRingBuffer<double>(_length2 + 1);
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
-
     public IndicatorName Name => IndicatorName.ConstanceBrownCompositeIndex;
 
     public void Reset()
@@ -15060,19 +12712,6 @@ public sealed class CorrectedMovingAverageState : IStreamingIndicatorState, IDis
         _smaSmoother = MovingAverageSmootherFactory.Create(maType, _length);
         _stdDev = new RollingStandardDeviation(_length);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public CorrectedMovingAverageState(MovingAvgType maType, int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _length = Math.Max(1, length);
-        _smaSmoother = MovingAverageSmootherFactory.Create(maType, _length);
-        _stdDev = new RollingStandardDeviation(_length);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.CorrectedMovingAverage;
@@ -15169,28 +12808,6 @@ public sealed class CubedWeightedMovingAverageState : IStreamingIndicatorState, 
         _weightSum = weightSum;
         _values = new PooledRingBuffer<double>(resolved);
         _input = new StreamingInputResolver(inputName, null);
-    }
-
-    public CubedWeightedMovingAverageState(int length, Func<OhlcvBar, double> selector)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        var resolved = Math.Max(1, length);
-        _weights = new double[resolved];
-        double weightSum = 0;
-        for (var i = 0; i < resolved; i++)
-        {
-            var weight = MathHelper.Pow(resolved - i, 3);
-            _weights[i] = weight;
-            weightSum += weight;
-        }
-
-        _weightSum = weightSum;
-        _values = new PooledRingBuffer<double>(resolved);
-        _input = new StreamingInputResolver(InputName.Close, selector);
     }
 
     public IndicatorName Name => IndicatorName.CubedWeightedMovingAverage;

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -3466,19 +3466,6 @@ public sealed class KeltnerChannelsState : IStreamingIndicatorState, IDisposable
         _input = new StreamingInputResolver(InputName.Close, null);
     }
 
-    public KeltnerChannelsState(MovingAvgType maType, int length1, int length2, double multFactor,
-        Func<OhlcvBar, double> selector, MovingAvgType atrMaType = MovingAvgType.WildersSmoothingMethod)
-    {
-        if (selector == null)
-        {
-            throw new ArgumentNullException(nameof(selector));
-        }
-
-        _atrSmoother = MovingAverageSmootherFactory.Create(atrMaType, Math.Max(1, length2));
-        _middleSmoother = MovingAverageSmootherFactory.Create(maType, Math.Max(1, length1));
-        _mult = multFactor;
-        _input = new StreamingInputResolver(InputName.Close, selector);
-    }
 
     public IndicatorName Name => IndicatorName.KeltnerChannels;
 

--- a/src/Streaming/StatefulIndicators.cs
+++ b/src/Streaming/StatefulIndicators.cs
@@ -354,9 +354,9 @@ public sealed class HullMovingAverageState : IStreamingIndicatorState, IDisposab
 }
 
 
-public sealed class AveragePriceState : IStreamingIndicatorState
+public sealed class AveragePriceState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public AveragePriceState()
     {
@@ -374,6 +374,9 @@ public sealed class AveragePriceState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.AveragePrice;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -395,9 +398,9 @@ public sealed class AveragePriceState : IStreamingIndicatorState
     }
 }
 
-public sealed class FullTypicalPriceState : IStreamingIndicatorState
+public sealed class FullTypicalPriceState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public FullTypicalPriceState()
     {
@@ -415,6 +418,9 @@ public sealed class FullTypicalPriceState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.FullTypicalPrice;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -436,9 +442,9 @@ public sealed class FullTypicalPriceState : IStreamingIndicatorState
     }
 }
 
-public sealed class MedianPriceState : IStreamingIndicatorState
+public sealed class MedianPriceState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public MedianPriceState()
     {
@@ -456,6 +462,9 @@ public sealed class MedianPriceState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.MedianPrice;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -477,9 +486,9 @@ public sealed class MedianPriceState : IStreamingIndicatorState
     }
 }
 
-public sealed class TypicalPriceState : IStreamingIndicatorState
+public sealed class TypicalPriceState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public TypicalPriceState()
     {
@@ -497,6 +506,9 @@ public sealed class TypicalPriceState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.TypicalPrice;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -518,9 +530,9 @@ public sealed class TypicalPriceState : IStreamingIndicatorState
     }
 }
 
-public sealed class WeightedCloseState : IStreamingIndicatorState
+public sealed class WeightedCloseState : IStreamingIndicatorState, ICustomInputConsumer
 {
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public WeightedCloseState()
     {
@@ -538,6 +550,9 @@ public sealed class WeightedCloseState : IStreamingIndicatorState
     }
 
     public IndicatorName Name => IndicatorName.WeightedClose;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -4707,11 +4722,11 @@ public sealed class WilliamsRState : IStreamingIndicatorState, IDisposable
     }
 }
 
-public sealed class CommodityChannelIndexState : IStreamingIndicatorState, IDisposable
+public sealed class CommodityChannelIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _priceSmoother;
     private readonly IMovingAverageSmoother _meanDevSmoother;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly double _constant;
 
     public CommodityChannelIndexState(InputName inputName = InputName.TypicalPrice,
@@ -4738,6 +4753,9 @@ public sealed class CommodityChannelIndexState : IStreamingIndicatorState, IDisp
     }
 
     public IndicatorName Name => IndicatorName.CommodityChannelIndex;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -5362,12 +5380,12 @@ public sealed class PercentagePriceOscillatorState : IStreamingIndicatorState, I
     }
 }
 
-public sealed class PercentageVolumeOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class PercentageVolumeOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _fast;
     private readonly IMovingAverageSmoother _slow;
     private readonly IMovingAverageSmoother _signal;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public PercentageVolumeOscillatorState(MovingAvgType maType = MovingAvgType.ExponentialMovingAverage,
         int fastLength = 12, int slowLength = 26, int signalLength = 9)
@@ -5393,6 +5411,9 @@ public sealed class PercentageVolumeOscillatorState : IStreamingIndicatorState, 
     }
 
     public IndicatorName Name => IndicatorName.PercentageVolumeOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -6931,11 +6952,11 @@ public sealed class ChaikinMoneyFlowState : IStreamingIndicatorState, IDisposabl
     }
 }
 
-public sealed class MoneyFlowIndexState : IStreamingIndicatorState, IDisposable
+public sealed class MoneyFlowIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly RollingWindowSum _posSum;
     private readonly RollingWindowSum _negSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevTypical;
     private bool _hasPrev;
 
@@ -6961,6 +6982,9 @@ public sealed class MoneyFlowIndexState : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.MoneyFlowIndex;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -7546,11 +7570,11 @@ public sealed class BelkhayateTimingState : IStreamingIndicatorState
     }
 }
 
-public sealed class ChartmillValueIndicatorState : IStreamingIndicatorState, IDisposable
+public sealed class ChartmillValueIndicatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly IMovingAverageSmoother _inputSmoother;
     private readonly IMovingAverageSmoother _atrSmoother;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private readonly double _lengthSqrt;
     private double _prevClose;
     private bool _hasPrev;
@@ -7581,6 +7605,9 @@ public sealed class ChartmillValueIndicatorState : IStreamingIndicatorState, IDi
     }
 
     public IndicatorName Name => IndicatorName.ChartmillValueIndicator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -8226,12 +8253,12 @@ public sealed class ContractHighLowState : IStreamingIndicatorState
     }
 }
 
-public sealed class ChopZoneState : IStreamingIndicatorState, IDisposable
+public sealed class ChopZoneState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly RollingWindowMax _highWindow;
     private readonly RollingWindowMin _lowWindow;
     private readonly IMovingAverageSmoother _ema;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevEma;
     private bool _hasPrevEma;
 
@@ -8260,6 +8287,9 @@ public sealed class ChopZoneState : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.ChopZone;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -9573,13 +9603,13 @@ public sealed class VortexIndicatorState : IStreamingIndicatorState, IDisposable
     }
 }
 
-public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _fastLength;
     private readonly int _slowLength;
     private readonly RollingWindowSum _fastSum;
     private readonly RollingWindowSum _slowSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public AwesomeOscillatorState(int fastLength = 5, int slowLength = 34, InputName inputName = InputName.MedianPrice)
     {
@@ -9605,6 +9635,9 @@ public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposab
     }
 
     public IndicatorName Name => IndicatorName.AwesomeOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -9642,7 +9675,7 @@ public sealed class AwesomeOscillatorState : IStreamingIndicatorState, IDisposab
     }
 }
 
-public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisposable
+public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _fastLength;
     private readonly int _slowLength;
@@ -9650,7 +9683,7 @@ public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisp
     private readonly RollingWindowSum _fastSum;
     private readonly RollingWindowSum _slowSum;
     private readonly RollingWindowSum _smoothSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public AcceleratorOscillatorState(int fastLength = 5, int slowLength = 34, int smoothLength = 5,
         InputName inputName = InputName.MedianPrice)
@@ -9682,6 +9715,9 @@ public sealed class AcceleratorOscillatorState : IStreamingIndicatorState, IDisp
     }
 
     public IndicatorName Name => IndicatorName.AcceleratorOscillator;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -11225,7 +11261,7 @@ public sealed class ArnaudLegouxMovingAverageState : IStreamingIndicatorState, I
     }
 }
 
-public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable
+public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _jawOffset;
     private readonly int _teethOffset;
@@ -11236,7 +11272,7 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable
     private readonly PooledRingBuffer<double> _jawWindow;
     private readonly PooledRingBuffer<double> _teethWindow;
     private readonly PooledRingBuffer<double> _lipsWindow;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
 
     public AlligatorIndexState(InputName inputName = InputName.MedianPrice, MovingAvgType maType = MovingAvgType.WildersSmoothingMethod, int jawLength = 13,
         int jawOffset = 8, int teethLength = 8, int teethOffset = 5, int lipsLength = 5, int lipsOffset = 3)
@@ -11274,6 +11310,9 @@ public sealed class AlligatorIndexState : IStreamingIndicatorState, IDisposable
     }
 
     public IndicatorName Name => IndicatorName.AlligatorIndex;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {
@@ -13085,13 +13124,13 @@ public sealed class BollingerBandsWithAtrPctState : IStreamingIndicatorState, ID
     }
 }
 
-public sealed class BreakoutRelativeStrengthIndexState : IStreamingIndicatorState, IDisposable
+public sealed class BreakoutRelativeStrengthIndexState : IStreamingIndicatorState, IDisposable, ICustomInputConsumer
 {
     private readonly int _length;
     private readonly RollingWindowSum _volumeSum;
     private readonly RollingWindowSum _posPowerSum;
     private readonly RollingWindowSum _negPowerSum;
-    private readonly StreamingInputResolver _input;
+    private StreamingInputResolver _input;
     private double _prevBoPower;
 
     public BreakoutRelativeStrengthIndexState(InputName inputName = InputName.FullTypicalPrice, int length = 14,
@@ -13120,6 +13159,9 @@ public sealed class BreakoutRelativeStrengthIndexState : IStreamingIndicatorStat
     }
 
     public IndicatorName Name => IndicatorName.BreakoutRelativeStrengthIndex;
+
+    void ICustomInputConsumer.ReadCloseAsInput() =>
+        _input = new StreamingInputResolver(InputName.Close, null);
 
     public void Reset()
     {

--- a/src/Streaming/StreamingIndicatorEngine.cs
+++ b/src/Streaming/StreamingIndicatorEngine.cs
@@ -535,7 +535,7 @@ public sealed class StreamingIndicatorEngine : IStreamObserver
                 UpdateLast(bar);
             }
 
-            var stockData = new StockData(_bars, _options.InputName)
+            var stockData = new StockData(_bars)
             {
                 Options = _options.Options
             };
@@ -739,7 +739,6 @@ public sealed class IndicatorSubscriptionOptions
     public bool IncludeUpdates { get; set; } = true;
     public bool IncludeOutputValues { get; set; } = true;
     public SeriesAlignmentPolicy SeriesAlignmentPolicy { get; set; } = SeriesAlignmentPolicy.LastKnown;
-    public InputName InputName { get; set; } = InputName.Close;
     public IndicatorOptions? Options { get; set; }
 }
 

--- a/src/Streaming/StreamingInputSelector.cs
+++ b/src/Streaming/StreamingInputSelector.cs
@@ -3,7 +3,7 @@ using OoplesFinance.StockIndicators.Enums;
 
 namespace OoplesFinance.StockIndicators.Streaming;
 
-public static class StreamingInputSelector
+internal static class StreamingInputSelector
 {
     public static double GetValue(OhlcvBar bar, InputName inputName)
     {

--- a/src/Streaming/StreamingOptions.cs
+++ b/src/Streaming/StreamingOptions.cs
@@ -51,7 +51,6 @@ public sealed class StreamingOptions
     public StreamingProcessingMode? ProcessingMode { get; set; }
     public StreamingBackpressurePolicy? BackpressurePolicy { get; set; }        
     public int? MaxPendingMessages { get; set; }
-    public InputName? InputName { get; set; }
     public bool? IncludeOutputValues { get; set; }
     public IndicatorOptions? IndicatorOptions { get; set; }
     public IReadOnlyList<StreamingIndicatorRegistration>? Indicators { get; set; }
@@ -86,7 +85,6 @@ public sealed class StreamingOptions
         {
             IncludeUpdates = policy == StreamingUpdatePolicy.IncludeUpdates,
             IncludeOutputValues = IncludeOutputValues ?? true,
-            InputName = InputName ?? global::OoplesFinance.StockIndicators.Enums.InputName.Close,
             Options = IndicatorOptions
         };
     }

--- a/tests/CalculationsTests/CeilingCycleTests.cs
+++ b/tests/CalculationsTests/CeilingCycleTests.cs
@@ -1,0 +1,24 @@
+using OoplesFinance.StockIndicators.Helpers;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.CalculationsTests;
+
+/// <summary>
+/// A measured cycle becomes a whole number of bars without float noise choosing the window.
+/// </summary>
+public sealed class CeilingCycleTests
+{
+    [Theory]
+    [InlineData(29.0, 29)]
+    // One ulp above 29: the value the streaming periodogram produced where the batch produced 29 exactly,
+    // which made Ehlers ACCI V2 average over 30 bars in one engine and 29 in the other.
+    [InlineData(29.000000000000004, 29)]
+    [InlineData(28.999999999999996, 29)]
+    [InlineData(29.2, 30)]
+    [InlineData(29.000001, 30)]
+    [InlineData(10.5, 11)]
+    [InlineData(0.0, 0)]
+    public void RoundsUpUnlessWithinNoiseOfAnInteger(double cycle, int expected)
+    {
+        MathHelper.CeilingCycle(cycle).Should().Be(expected);
+    }
+}

--- a/tests/CalculationsTests/IncludeCustomValuesTests.cs
+++ b/tests/CalculationsTests/IncludeCustomValuesTests.cs
@@ -1,0 +1,100 @@
+using System.Reflection;
+using FluentAssertions.Execution;
+using OoplesFinance.StockIndicators.Builder;
+using IndicatorOptions = OoplesFinance.StockIndicators.Models.IndicatorOptions;
+using static OoplesFinance.StockIndicators.Tests.Unit.StreamingTests.IndicatorRunner;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.CalculationsTests;
+
+/// <summary>
+/// IncludeCustomValues decides whether an indicator publishes its single series, never what it computes.
+/// </summary>
+/// <remarks>
+/// Composite indicators read the series their components leave on <see cref="StockData.CustomValuesList"/>,
+/// and a caller chains the next indicator the same way. Turning publication off must hide the series from
+/// the caller and nothing else: every indicator completes, and every published output series is the one
+/// it publishes with the option on.
+/// </remarks>
+public sealed class IncludeCustomValuesTests : GlobalTestData
+{
+    private const int Bars = 251;
+
+    [Fact]
+    public void TurningCustomValuesOffChangesNoOutput()
+    {
+        var bars = StockTestData.Take(Bars).ToList();
+        var failed = new List<string>();
+        var differs = new List<string>();
+        var cannotRun = new List<string>();
+        var noMethod = 0;
+        var compared = 0;
+
+        foreach (var name in Enum.GetValues(typeof(IndicatorName)).Cast<IndicatorName>().OrderBy(n => n.ToString(), StringComparer.Ordinal))
+        {
+            var method = IndicatorInvoker.GetMethod(name);
+            if (method is null)
+            {
+                noMethod++;
+                continue;
+            }
+
+            StockData on;
+            try
+            {
+                on = Invoke(method, bars, new IndicatorOptions());
+            }
+            catch (Exception ex)
+            {
+                // Named, not this test's subject: an indicator that cannot run on its defaults at all.
+                cannotRun.Add($"{name} ({(ex.InnerException ?? ex).GetType().Name})");
+                continue;
+            }
+
+            StockData off;
+            try
+            {
+                off = Invoke(method, bars, new IndicatorOptions { IncludeCustomValues = false });
+            }
+            catch (Exception ex)
+            {
+                failed.Add($"{name} ({(ex.InnerException ?? ex).GetType().Name})");
+                continue;
+            }
+
+            compared++;
+            foreach (var kv in on.OutputValues)
+            {
+                if (!off.OutputValues.TryGetValue(kv.Key, out var offSeries) || offSeries.Count != kv.Value.Count)
+                {
+                    differs.Add($"{name} {kv.Key}: missing or a different length");
+                    break;
+                }
+
+                var bar = Enumerable.Range(0, kv.Value.Count).FirstOrDefault(i => !IsClose(kv.Value[i], offSeries[i]), -1);
+                if (bar >= 0)
+                {
+                    differs.Add($"{name} {kv.Key} at bar {bar}: {kv.Value[bar]} on, {offSeries[bar]} off");
+                    break;
+                }
+            }
+        }
+
+        using var scope = new AssertionScope();
+        compared.Should().BeGreaterThan(700,
+            $"every batch indicator is run both ways; {noMethod} names have no batch method and " +
+            $"{cannotRun.Count} cannot run on their defaults: {string.Join(", ", cannotRun)}");
+        failed.Should().BeEmpty($"every indicator completes with custom values off ({failed.Count}): {string.Join(", ", failed)}");
+        differs.Should().BeEmpty($"custom values off changes no output ({differs.Count}): {string.Join(" | ", differs)}");
+    }
+
+    private static StockData Invoke(MethodInfo method, List<TickerData> bars, IndicatorOptions options)
+    {
+        var ps = method.GetParameters();
+        var args = new object?[ps.Length];
+        args[0] = new StockData(bars) { Options = options };
+        for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
+
+        return (StockData)(method.Invoke(null, args)
+            ?? throw new InvalidOperationException($"{method.Name} returned null instead of its StockData"));
+    }
+}

--- a/tests/CalculationsTests/IncludeCustomValuesTests.cs
+++ b/tests/CalculationsTests/IncludeCustomValuesTests.cs
@@ -62,6 +62,14 @@ public sealed class IncludeCustomValuesTests : GlobalTestData
             }
 
             compared++;
+            var onKeys = new HashSet<string>(on.OutputValues.Keys, StringComparer.Ordinal);
+            if (!onKeys.SetEquals(off.OutputValues.Keys))
+            {
+                differs.Add($"{name}: on [{string.Join(",", onKeys.OrderBy(k => k, StringComparer.Ordinal))}], " +
+                    $"off [{string.Join(",", off.OutputValues.Keys.OrderBy(k => k, StringComparer.Ordinal))}]");
+                continue;
+            }
+
             foreach (var kv in on.OutputValues)
             {
                 if (!off.OutputValues.TryGetValue(kv.Key, out var offSeries) || offSeries.Count != kv.Value.Count)

--- a/tests/CalculationsTests/IncludeOutputValuesTests.cs
+++ b/tests/CalculationsTests/IncludeOutputValuesTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using FluentAssertions.Execution;
+using OoplesFinance.StockIndicators.Builder;
+using static OoplesFinance.StockIndicators.Tests.Unit.StreamingTests.IndicatorRunner;
+using IndicatorOptions = OoplesFinance.StockIndicators.Models.IndicatorOptions;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.CalculationsTests;
+
+/// <summary>
+/// IncludeOutputValues decides whether an indicator publishes its named series, never what it computes.
+/// </summary>
+/// <remarks>
+/// Composites read their components' named series - a MACD's signal line, a band's upper band - from
+/// <see cref="StockData.OutputValues"/>. Turning publication off must hide them from the caller only: every
+/// indicator completes, and its single series is the one it publishes with the option on.
+/// </remarks>
+public sealed class IncludeOutputValuesTests : GlobalTestData
+{
+    private const int Bars = 251;
+
+    [Fact]
+    public void TurningOutputValuesOffChangesNoResult()
+    {
+        var bars = StockTestData.Take(Bars).ToList();
+        var failed = new List<string>();
+        var differs = new List<string>();
+        var cannotRun = new List<string>();
+        var compared = 0;
+
+        foreach (var name in Enum.GetValues(typeof(IndicatorName)).Cast<IndicatorName>().OrderBy(n => n.ToString(), StringComparer.Ordinal))
+        {
+            var method = IndicatorInvoker.GetMethod(name);
+            if (method is null)
+            {
+                continue;
+            }
+
+            StockData on;
+            try
+            {
+                on = Invoke(method, bars, new IndicatorOptions());
+            }
+            catch (Exception ex)
+            {
+                // Named, not this test's subject: an indicator that cannot run on its defaults at all.
+                cannotRun.Add($"{name} ({(ex.InnerException ?? ex).GetType().Name})");
+                continue;
+            }
+
+            StockData off;
+            try
+            {
+                off = Invoke(method, bars, new IndicatorOptions { IncludeOutputValues = false });
+            }
+            catch (Exception ex)
+            {
+                failed.Add($"{name} ({(ex.InnerException ?? ex).GetType().Name})");
+                continue;
+            }
+
+            compared++;
+            if (off.OutputValues.Count != 0)
+            {
+                differs.Add($"{name}: published {off.OutputValues.Count} named series with the option off");
+            }
+
+            if (on.CustomValuesList.Count != off.CustomValuesList.Count)
+            {
+                differs.Add($"{name}: {on.CustomValuesList.Count} values on, {off.CustomValuesList.Count} off");
+                continue;
+            }
+
+            var bar = Enumerable.Range(0, on.CustomValuesList.Count)
+                .FirstOrDefault(i => !IsClose(on.CustomValuesList[i], off.CustomValuesList[i]), -1);
+            if (bar >= 0)
+            {
+                differs.Add($"{name} at bar {bar}: {on.CustomValuesList[bar]} on, {off.CustomValuesList[bar]} off");
+            }
+        }
+
+        using var scope = new AssertionScope();
+        compared.Should().BeGreaterThan(700,
+            $"every batch indicator is run both ways; {cannotRun.Count} cannot run on their defaults: {string.Join(", ", cannotRun)}");
+        failed.Should().BeEmpty($"every indicator completes with output values off ({failed.Count}): {string.Join(", ", failed)}");
+        differs.Should().BeEmpty($"output values off changes no result ({differs.Count}): {string.Join(" | ", differs)}");
+    }
+
+    private static StockData Invoke(MethodInfo method, List<TickerData> bars, IndicatorOptions options)
+    {
+        var ps = method.GetParameters();
+        var args = new object?[ps.Length];
+        args[0] = new StockData(bars) { Options = options };
+        for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
+
+        return method.Invoke(null, args) as StockData
+            ?? throw new InvalidOperationException($"{method.Name} returned null instead of its StockData");
+    }
+}

--- a/tests/CalculationsTests/RollingOrderStatisticTests.cs
+++ b/tests/CalculationsTests/RollingOrderStatisticTests.cs
@@ -1,0 +1,43 @@
+using OoplesFinance.StockIndicators.Helpers;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.CalculationsTests;
+
+/// <summary>
+/// A preview leaves the order statistic exactly as it found it, whatever the pending value is.
+/// </summary>
+public sealed class RollingOrderStatisticTests
+{
+    /// <summary>Above the small-window threshold, so the order-statistic tree is the path under test.</summary>
+    private const int Length = RollingWindowSettings.SmallWindowThreshold + 8;
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    [InlineData(17.5)]
+    public void APreviewLeavesNoTrace(double pending)
+    {
+        using var previewed = new RollingOrderStatistic(Length);
+        using var twin = new RollingOrderStatistic(Length);
+        for (var i = 0; i < Length + 5; i++)
+        {
+            previewed.Add(i);
+            twin.Add(i);
+        }
+
+        // A NaN went right on insert and was never found on removal, so this left a node in the tree and every
+        // later percentile counted one value too many.
+        previewed.PercentileNearestRank(50, pending);
+
+        for (var i = 0; i < 10; i++)
+        {
+            previewed.Add(100 + i);
+            twin.Add(100 + i);
+            foreach (var percentile in new[] { 25d, 50d, 75d })
+            {
+                previewed.PercentileNearestRank(percentile).Should().Be(twin.PercentileNearestRank(percentile),
+                    $"after add {i}, the {percentile}th percentile is the twin's");
+            }
+        }
+    }
+}

--- a/tests/CalculationsTests/RoundingDigitsTests.cs
+++ b/tests/CalculationsTests/RoundingDigitsTests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using FluentAssertions.Execution;
+using OoplesFinance.StockIndicators.Builder;
+using IndicatorOptions = OoplesFinance.StockIndicators.Models.IndicatorOptions;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.CalculationsTests;
+
+/// <summary>
+/// RoundingDigits rounds what an indicator publishes, and nothing it computes on.
+/// </summary>
+/// <remarks>
+/// A composite that hands a component an intermediate series through <c>SetCustomValues</c> hands it that
+/// series rounded, since publication rounds. The final values are then the rounding of a different
+/// computation. The check needs no tolerance: rounding once, after the same computation, gives exactly the
+/// unrounded values passed through <see cref="Math.Round(double, int)"/>, so any difference at all is an
+/// intermediate that was rounded.
+/// </remarks>
+public sealed class RoundingDigitsTests : GlobalTestData
+{
+    private const int Bars = 251;
+    private const int Digits = 4;
+
+    [Fact]
+    public void RoundingChangesOnlyThePublishedDigits()
+    {
+        var bars = StockTestData.Take(Bars).ToList();
+        var differs = new List<string>();
+        var cannotRun = new List<string>();
+        var compared = 0;
+
+        foreach (var name in Enum.GetValues(typeof(IndicatorName)).Cast<IndicatorName>().OrderBy(n => n.ToString(), StringComparer.Ordinal))
+        {
+            var method = IndicatorInvoker.GetMethod(name);
+            if (method is null)
+            {
+                continue;
+            }
+
+            StockData raw;
+            StockData rounded;
+            try
+            {
+                raw = Invoke(method, bars, new IndicatorOptions());
+                rounded = Invoke(method, bars, new IndicatorOptions { RoundingDigits = Digits });
+            }
+            catch (Exception ex)
+            {
+                // Named, not this test's subject: an indicator that cannot run on its defaults at all.
+                cannotRun.Add($"{name} ({(ex.InnerException ?? ex).GetType().Name})");
+                continue;
+            }
+
+            compared++;
+            if (!new HashSet<string>(raw.OutputValues.Keys, StringComparer.Ordinal).SetEquals(rounded.OutputValues.Keys))
+            {
+                differs.Add($"{name}: output keys differ");
+                continue;
+            }
+
+            var series = raw.OutputValues.Select(kv => (Key: kv.Key, Raw: kv.Value, Rounded: rounded.OutputValues[kv.Key]))
+                .Append(("<primary>", raw.CustomValuesList, rounded.CustomValuesList));
+            foreach (var (key, rawValues, roundedValues) in series)
+            {
+                if (rawValues.Count != roundedValues.Count)
+                {
+                    differs.Add($"{name} {key}: {rawValues.Count} values unrounded, {roundedValues.Count} rounded");
+                    break;
+                }
+
+                var bar = Enumerable.Range(0, rawValues.Count)
+                    .FirstOrDefault(i => !Same(Math.Round(rawValues[i], Digits), roundedValues[i]), -1);
+                if (bar >= 0)
+                {
+                    differs.Add($"{name} {key} at bar {bar}: {Math.Round(rawValues[bar], Digits)} expected, {roundedValues[bar]} published");
+                    break;
+                }
+            }
+        }
+
+        using var scope = new AssertionScope();
+        compared.Should().BeGreaterThan(700,
+            $"every batch indicator is run both ways; {cannotRun.Count} cannot run on their defaults: {string.Join(", ", cannotRun)}");
+        differs.Should().BeEmpty(
+            $"rounding changes only the published digits; each of these rounded something it computed on ({differs.Count}): " +
+            string.Join(" | ", differs));
+    }
+
+    private static bool Same(double expected, double actual) =>
+        expected.Equals(actual) || (double.IsNaN(expected) && double.IsNaN(actual));
+
+    private static StockData Invoke(MethodInfo method, List<TickerData> bars, IndicatorOptions options)
+    {
+        var ps = method.GetParameters();
+        var args = new object?[ps.Length];
+        args[0] = new StockData(bars) { Options = options };
+        for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
+
+        return method.Invoke(null, args) as StockData
+            ?? throw new InvalidOperationException($"{method.Name} returned null instead of its StockData");
+    }
+}

--- a/tests/PerformanceTests/LatencyBenchmarks.cs
+++ b/tests/PerformanceTests/LatencyBenchmarks.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 /// These tests verify that operations meet latency requirements.
 /// </summary>
 [Trait("Category", "Performance")]
+[Collection(PerformanceCollection.Name)]
 public class LatencyBenchmarks
 {
     private readonly ITestOutputHelper _output;
@@ -294,6 +295,7 @@ public class LatencyBenchmarks
 /// Throughput benchmarks for high-frequency operations.
 /// </summary>
 [Trait("Category", "Performance")]
+[Collection(PerformanceCollection.Name)]
 public class ThroughputBenchmarks
 {
     private readonly ITestOutputHelper _output;
@@ -385,6 +387,7 @@ public class ThroughputBenchmarks
 /// Memory allocation benchmarks.
 /// </summary>
 [Trait("Category", "Performance")]
+[Collection(PerformanceCollection.Name)]
 public class MemoryBenchmarks
 {
     private readonly ITestOutputHelper _output;

--- a/tests/PerformanceTests/PerformanceCollection.cs
+++ b/tests/PerformanceTests/PerformanceCollection.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.PerformanceTests;
+
+/// <summary>
+/// Runs the throughput and latency benchmarks on their own, never alongside other tests.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests assert absolute rates - more than 1000 VaR calculations a second, for instance - and xUnit
+/// runs test classes in parallel by default. On a two-core CI runner a benchmark sharing the CPU with a
+/// heavy test class measures the contention rather than the code: ConcurrentVaRCalculations failed at 626
+/// and 646 a second on two consecutive runs of a branch whose only change near it was a much heavier
+/// sweep in another class, while its own code path (PortfolioRiskCalculator) was untouched.
+/// </para>
+/// <para>
+/// A [Collection] attribute alone does not do this - without a matching [CollectionDefinition] with
+/// DisableParallelization it silently loses the guarantee.
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class PerformanceCollection
+{
+    /// <summary>The collection name the benchmark classes opt into.</summary>
+    public const string Name = "Performance";
+}

--- a/tests/StreamingTests/InputSeriesTests.cs
+++ b/tests/StreamingTests/InputSeriesTests.cs
@@ -18,17 +18,17 @@ public sealed class InputSeriesTests : GlobalTestData
     /// <summary>The migration table: each preset and the input name it replaces.</summary>
     public static IEnumerable<object[]> Presets()
     {
-        yield return new object[] { InputName.Close, nameof(InputSeries.Close) };
-        yield return new object[] { InputName.AdjustedClose, nameof(InputSeries.AdjustedClose) };
-        yield return new object[] { InputName.Open, nameof(InputSeries.Open) };
-        yield return new object[] { InputName.High, nameof(InputSeries.High) };
-        yield return new object[] { InputName.Low, nameof(InputSeries.Low) };
-        yield return new object[] { InputName.Volume, nameof(InputSeries.Volume) };
-        yield return new object[] { InputName.MedianPrice, nameof(InputSeries.MedianPrice) };
-        yield return new object[] { InputName.TypicalPrice, nameof(InputSeries.TypicalPrice) };
-        yield return new object[] { InputName.FullTypicalPrice, nameof(InputSeries.FullTypicalPrice) };
-        yield return new object[] { InputName.WeightedClose, nameof(InputSeries.WeightedClose) };
-        yield return new object[] { InputName.AveragePrice, nameof(InputSeries.AveragePrice) };
+        yield return new object[] { nameof(InputName.Close), nameof(InputSeries.Close) };
+        yield return new object[] { nameof(InputName.AdjustedClose), nameof(InputSeries.AdjustedClose) };
+        yield return new object[] { nameof(InputName.Open), nameof(InputSeries.Open) };
+        yield return new object[] { nameof(InputName.High), nameof(InputSeries.High) };
+        yield return new object[] { nameof(InputName.Low), nameof(InputSeries.Low) };
+        yield return new object[] { nameof(InputName.Volume), nameof(InputSeries.Volume) };
+        yield return new object[] { nameof(InputName.MedianPrice), nameof(InputSeries.MedianPrice) };
+        yield return new object[] { nameof(InputName.TypicalPrice), nameof(InputSeries.TypicalPrice) };
+        yield return new object[] { nameof(InputName.FullTypicalPrice), nameof(InputSeries.FullTypicalPrice) };
+        yield return new object[] { nameof(InputName.WeightedClose), nameof(InputSeries.WeightedClose) };
+        yield return new object[] { nameof(InputName.AveragePrice), nameof(InputSeries.AveragePrice) };
     }
 
     /// <summary>
@@ -37,8 +37,11 @@ public sealed class InputSeriesTests : GlobalTestData
     /// </summary>
     [Theory]
     [MemberData(nameof(Presets))]
-    public void EachPresetIsExactlyTheInputNameItReplaces(InputName name, string preset)
+    public void EachPresetIsExactlyTheInputNameItReplaces(string inputName, string preset)
     {
+        // The row carries the name as a string: InputName is internal now, and a public test method
+        // cannot expose an internal type in its signature.
+        var name = Enum.Parse<InputName>(inputName);
         var series = (IInputSeries)typeof(InputSeries).GetProperty(preset)!.GetValue(null)!;
 
         foreach (var ticker in Tickers())

--- a/tests/StreamingTests/InputSeriesTests.cs
+++ b/tests/StreamingTests/InputSeriesTests.cs
@@ -1,0 +1,139 @@
+using OoplesFinance.StockIndicators.Streaming;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
+
+/// <summary>
+/// The input-series presets that replace passing an input name, and streaming chaining.
+/// </summary>
+public sealed class InputSeriesTests : GlobalTestData
+{
+    private const int Bars = 200;
+    private const double Tolerance = 1e-9;
+
+    private List<TickerData> Tickers() => StockTestData.Take(Bars).ToList();
+
+    private static OhlcvBar ToBar(TickerData t, bool isFinal = true) =>
+        new("TEST", BarTimeframe.Tick, t.Date, t.Date, t.Open, t.High, t.Low, t.Close, t.Volume, isFinal);
+
+    /// <summary>The migration table: each preset and the input name it replaces.</summary>
+    public static IEnumerable<object[]> Presets()
+    {
+        yield return new object[] { InputName.Close, nameof(InputSeries.Close) };
+        yield return new object[] { InputName.AdjustedClose, nameof(InputSeries.AdjustedClose) };
+        yield return new object[] { InputName.Open, nameof(InputSeries.Open) };
+        yield return new object[] { InputName.High, nameof(InputSeries.High) };
+        yield return new object[] { InputName.Low, nameof(InputSeries.Low) };
+        yield return new object[] { InputName.Volume, nameof(InputSeries.Volume) };
+        yield return new object[] { InputName.MedianPrice, nameof(InputSeries.MedianPrice) };
+        yield return new object[] { InputName.TypicalPrice, nameof(InputSeries.TypicalPrice) };
+        yield return new object[] { InputName.FullTypicalPrice, nameof(InputSeries.FullTypicalPrice) };
+        yield return new object[] { InputName.WeightedClose, nameof(InputSeries.WeightedClose) };
+        yield return new object[] { InputName.AveragePrice, nameof(InputSeries.AveragePrice) };
+    }
+
+    /// <summary>
+    /// A one-token migration only works if the preset is exactly the value the name selected - not
+    /// approximately, and not the same formula re-typed with a different rounding order.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Presets))]
+    public void EachPresetIsExactlyTheInputNameItReplaces(InputName name, string preset)
+    {
+        var series = (IInputSeries)typeof(InputSeries).GetProperty(preset)!.GetValue(null)!;
+
+        foreach (var ticker in Tickers())
+        {
+            var bar = ToBar(ticker);
+            series.Next(bar, isFinal: true).Should().Be(StreamingInputSelector.GetValue(bar, name),
+                $"{preset} replaces InputName.{name}");
+        }
+    }
+
+    [Fact]
+    public void TheMidpointPresetMatchesTheBatchMidpoint()
+    {
+        var tickers = Tickers();
+        var series = InputSeries.Midpoint(14);
+
+        var streamed = tickers.Select(t => series.Next(ToBar(t), isFinal: true)).ToList();
+        var batch = new StockData(tickers).CalculateMidpoint(14).CustomValuesList;
+
+        streamed.Should().HaveCount(batch.Count);
+        for (var i = 0; i < batch.Count; i++)
+        {
+            streamed[i].Should().BeApproximately(batch[i], Tolerance, $"bar {i}");
+        }
+    }
+
+    [Fact]
+    public void TheMidpricePresetMatchesTheBatchMidprice()
+    {
+        var tickers = Tickers();
+        var series = InputSeries.Midprice(14);
+
+        var streamed = tickers.Select(t => series.Next(ToBar(t), isFinal: true)).ToList();
+        var batch = new StockData(tickers).CalculateMidprice(14).CustomValuesList;
+
+        streamed.Should().HaveCount(batch.Count);
+        for (var i = 0; i < batch.Count; i++)
+        {
+            streamed[i].Should().BeApproximately(batch[i], Tolerance, $"bar {i}");
+        }
+    }
+
+    /// <summary>
+    /// The reason a windowed series is an interface rather than a function: revising a forming bar any
+    /// number of times must give the same final answer as seeing it once.
+    /// </summary>
+    [Fact]
+    public void AFormingBarDoesNotAdvanceAWindowedSeries()
+    {
+        var tickers = Tickers();
+        var revised = InputSeries.Midpoint(14);
+        var clean = InputSeries.Midpoint(14);
+
+        foreach (var t in tickers)
+        {
+            // Two revisions of the forming bar, one well away from the final values.
+            revised.Next(new OhlcvBar("TEST", BarTimeframe.Tick, t.Date, t.Date, t.Open, t.High * 2, t.Low / 2,
+                t.Close * 3, t.Volume, isFinal: false), isFinal: false);
+            revised.Next(ToBar(t, isFinal: false), isFinal: false);
+
+            revised.Next(ToBar(t), isFinal: true).Should().Be(clean.Next(ToBar(t), isFinal: true));
+        }
+    }
+
+    /// <summary>
+    /// Streaming chaining is the counterpart of batch chaining, so the two must give the same numbers.
+    /// </summary>
+    [Fact]
+    public void AStateAsTheInputMatchesBatchChaining()
+    {
+        var tickers = Tickers();
+
+        var chained = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.Of(new RelativeStrengthIndexState(14)));
+        var streamed = tickers.Select(t => chained.Update(ToBar(t), isFinal: true, includeOutputs: false).Value).ToList();
+
+        var batch = new StockData(tickers).CalculateRelativeStrengthIndex(length: 14).CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        streamed.Should().HaveCount(batch.Count);
+        for (var i = 0; i < batch.Count; i++)
+        {
+            streamed[i].Should().BeApproximately(batch[i], Tolerance, $"bar {i}");
+        }
+    }
+
+    [Fact]
+    public void APresetGivesTheSameResultAsTheSelectorItReplaces()
+    {
+        var tickers = Tickers();
+
+        var viaPreset = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.MedianPrice);
+        var viaSelector = new CustomInputState(new SimpleMovingAverageState(20), bar => (bar.High + bar.Low) / 2);
+
+        foreach (var t in tickers)
+        {
+            viaPreset.Update(ToBar(t), true, false).Value.Should().Be(viaSelector.Update(ToBar(t), true, false).Value);
+        }
+    }
+}

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using OoplesFinance.StockIndicators.Enums;
+using OoplesFinance.StockIndicators.Helpers;
 using OoplesFinance.StockIndicators.Models;
 using OoplesFinance.StockIndicators.Streaming;
 using Xunit;
@@ -138,7 +139,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
 
     /// <summary>
-    /// Runs a batch indicator on the close, or on a median-price series chained in front of it.
+    /// Runs a batch indicator on a close series or a median-price series chained in front of it.
     /// </summary>
     /// <remarks>
     /// Chaining is the one lever: a chained series always wins. Some methods still take their own
@@ -153,7 +154,21 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         var args = new object?[ps.Length];
         for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
 
-        args[0] = chainMedian ? new StockData(bars).CalculateMedianPrice() : new StockData(bars);
+        // BOTH runs chain a series, mirroring the streaming side's close and median selectors. An
+        // unchained baseline is not "close" for every method: AwesomeOscillator, AcceleratorOscillator,
+        // AlligatorIndex and GatorOscillator default to MedianPrice, so chaining a median series in
+        // front of them changed nothing and read as "batch ignores its input" when it does not.
+        var data = new StockData(bars);
+        if (chainMedian)
+        {
+            data = data.CalculateMedianPrice();
+        }
+        else
+        {
+            data.SetCustomValues(new List<double>(data.ClosePrices));
+        }
+
+        args[0] = data;
 
         return batch.Invoke(null, args)!;
     }

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -48,8 +48,27 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     /// <summary>The whole fixture, so long-window indicators get as much warmup as exists.</summary>
     private const int Bars = 251;
 
-    [Fact]
-    public void StreamingRespondsToACustomInputExactlyWhenTheBatchDoes()
+    /// <summary>A custom series the test feeds both engines.</summary>
+    public enum CustomSeries
+    {
+        /// <summary>
+        /// Median price: inside every bar's range, so an indicator that reads true highs and lows
+        /// legitimately does not move.
+        /// </summary>
+        InRange,
+
+        /// <summary>
+        /// The close divided by 100: outside every bar's range, so high and low come from the series
+        /// itself under the per-bar rule. Only this series exercises that half of the rule; on the
+        /// median series alone it went untested and 43 indicators disagreed on it.
+        /// </summary>
+        OutOfRange,
+    }
+
+    [Theory]
+    [InlineData(CustomSeries.InRange)]
+    [InlineData(CustomSeries.OutOfRange)]
+    public void StreamingRespondsToACustomInputExactlyWhenTheBatchDoes(CustomSeries series)
     {
         var bars = StockTestData.Take(Bars).ToList();
         bars.Should().NotBeEmpty();
@@ -84,10 +103,10 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             bool streamMoved;
             try
             {
-                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, chainMedian: false));
-                var batchOnMedian = Flatten((StockData)InvokeBatch(batch, bars, chainMedian: true));
+                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, custom: null));
+                var batchOnCustom = Flatten((StockData)InvokeBatch(batch, bars, series));
                 var streamOnClose = Run(Build(selector.Value.Ctor, selector.Value.Args, (Func<OhlcvBar, double>)Close), bars);
-                var streamOnMedian = Run(Build(selector.Value.Ctor, selector.Value.Args, (Func<OhlcvBar, double>)Median), bars);
+                var streamOnCustom = Run(Build(selector.Value.Ctor, selector.Value.Args, Selector(series)), bars);
 
                 // An indicator whose window never fills over this fixture - the catalogue has
                 // defaults as long as 550 against 251 bars - emits nothing but zeros, and "no
@@ -96,8 +115,8 @@ public sealed class StreamingCustomInputTests : GlobalTestData
                 // against QuadraticLeastSquaresMovingAverage.
                 if (Silent(streamOnClose) || Silent(batchOnClose)) { unpaired++; continue; }
 
-                batchMoved = Differs(batchOnClose, batchOnMedian);
-                streamMoved = Differs(streamOnClose, streamOnMedian);
+                batchMoved = Differs(batchOnClose, batchOnCustom);
+                streamMoved = Differs(streamOnClose, streamOnCustom);
             }
             catch (Exception ex)
             {
@@ -128,7 +147,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             $"Func<OhlcvBar, double> constructor: {string.Join(", ", cannotTakeInput)}");
 
         disagreements.Should().BeEmpty(
-            $"streaming and batch must agree about what the input series controls. " +
+            $"streaming and batch must agree about what the {series} input series controls. " +
             $"{compared} indicators compared, {unpaired} without a comparable run " +
             $"(could not run: {string.Join(", ", couldNotRun)}). " +
             $"Disagreements ({disagreements.Count}): {string.Join(" | ", disagreements)}");
@@ -137,6 +156,11 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     private static double Close(OhlcvBar bar) => bar.Close;
 
     private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
+
+    private static double ScaledClose(OhlcvBar bar) => bar.Close / 100;
+
+    private static Func<OhlcvBar, double> Selector(CustomSeries series) =>
+        series == CustomSeries.InRange ? Median : ScaledClose;
 
     /// <summary>
     /// Runs a batch indicator on a close series or a median-price series chained in front of it.
@@ -148,25 +172,24 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     /// AwesomeOscillator defaults it to MedianPrice. An earlier version of this test drove those
     /// through the parameter instead, which hid exactly that defect: they ignore the chain.
     /// </remarks>
-    private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, bool chainMedian)
+    private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, CustomSeries? custom)
     {
         var ps = batch.GetParameters();
         var args = new object?[ps.Length];
         for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
 
-        // BOTH runs chain a series, mirroring the streaming side's close and median selectors. An
-        // unchained baseline is not "close" for every method: AwesomeOscillator, AcceleratorOscillator,
-        // AlligatorIndex and GatorOscillator default to MedianPrice, so chaining a median series in
-        // front of them changed nothing and read as "batch ignores its input" when it does not.
+        // BOTH runs chain a series, mirroring the streaming side's selectors. An unchained baseline
+        // is not "close" for every method: AwesomeOscillator, AcceleratorOscillator, AlligatorIndex
+        // and GatorOscillator default to MedianPrice, so chaining a median series in front of them
+        // changed nothing and read as "batch ignores its input" when it does not.
         var data = new StockData(bars);
-        if (chainMedian)
+        var values = custom switch
         {
-            data = data.CalculateMedianPrice();
-        }
-        else
-        {
-            data.SetCustomValues(new List<double>(data.ClosePrices));
-        }
+            CustomSeries.InRange => data.HighPrices.Zip(data.LowPrices, (h, l) => (h + l) / 2).ToList(),
+            CustomSeries.OutOfRange => data.ClosePrices.Select(c => c / 100).ToList(),
+            _ => new List<double>(data.ClosePrices),
+        };
+        data.SetCustomValues(values);
 
         args[0] = data;
 

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -226,7 +226,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             ?? throw new InvalidOperationException($"{batch.Name} returned null instead of its StockData");
     }
 
-    private static IStreamingIndicatorState Build((ConstructorInfo Ctor, object?[] Args) build) =>
+    internal static IStreamingIndicatorState Build((ConstructorInfo Ctor, object?[] Args) build) =>
         (IStreamingIndicatorState)build.Ctor.Invoke(build.Args);
 
     /// <summary>
@@ -234,7 +234,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     /// have defaults, preferring the one with the fewest parameters.
     /// </summary>
     /// <returns>Null when no constructor can be called without arguments.</returns>
-    private static (ConstructorInfo Ctor, object?[] Args)? FindDefaultConstruction(Type type)
+    internal static (ConstructorInfo Ctor, object?[] Args)? FindDefaultConstruction(Type type)
     {
         var ctor = type.GetConstructors()
             .Where(c => c.GetParameters().All(p => p.HasDefaultValue))

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -59,10 +59,17 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         InRange,
 
         /// <summary>
-        /// The close divided by 100: outside every bar's range, so high and low come from the series
-        /// itself under the per-bar rule. Only this series exercises that half of the rule; on the
-        /// median series alone it went untested and 43 indicators disagreed on it.
+        /// The natural log of the close: outside every bar's range, so high and low come from the
+        /// series itself under the per-bar rule, and a non-linear transform, so it is a genuinely
+        /// different series even to an indicator that ignores scale.
         /// </summary>
+        /// <remarks>
+        /// The first out-of-range probe divided the close by 100. That is a pure rescale, and a
+        /// scale-invariant indicator - momentum as a ratio, a z-score, anything normalised - is right
+        /// to give the same answer for it, so the probe could not tell a correct "ignores" from a
+        /// defect. What it reported instead was floating-point noise on whichever side happened to
+        /// round differently.
+        /// </remarks>
         OutOfRange,
     }
 
@@ -160,10 +167,10 @@ public sealed class StreamingCustomInputTests : GlobalTestData
 
     private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
 
-    private static double ScaledClose(OhlcvBar bar) => bar.Close / 100;
+    private static double LogClose(OhlcvBar bar) => Math.Log(bar.Close);
 
     private static Func<OhlcvBar, double> Selector(CustomSeries series) =>
-        series == CustomSeries.InRange ? Median : ScaledClose;
+        series == CustomSeries.InRange ? Median : LogClose;
 
     /// <summary>
     /// Runs a batch indicator on a close series or a median-price series chained in front of it.
@@ -189,7 +196,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         var values = custom switch
         {
             CustomSeries.InRange => data.HighPrices.Zip(data.LowPrices, (h, l) => (h + l) / 2).ToList(),
-            CustomSeries.OutOfRange => data.ClosePrices.Select(c => c / 100).ToList(),
+            CustomSeries.OutOfRange => data.ClosePrices.Select(c => Math.Log(c)).ToList(),
             _ => new List<double>(data.ClosePrices),
         };
         data.SetCustomValues(values);
@@ -294,7 +301,12 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             for (var i = 0; i < Math.Min(mine.Count, other.Count) && i < Bars; i++)
             {
                 if (double.IsNaN(mine[i]) && double.IsNaN(other[i])) { continue; }
-                if (Math.Abs(mine[i] - other[i]) > 1e-12) { return true; }
+                // Relative, not absolute. A series in the millions - volume, an accumulation line - carries
+                // more than 1e-12 of rounding noise from reordered arithmetic alone, and an absolute
+                // threshold read that noise as "responds". A real response to a different input series
+                // differs by orders of magnitude more than a part in a billion.
+                var scale = Math.Max(1.0, Math.Max(Math.Abs(mine[i]), Math.Abs(other[i])));
+                if (Math.Abs(mine[i] - other[i]) > 1e-9 * scale) { return true; }
             }
         }
 

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -44,7 +44,8 @@ namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
 /// </remarks>
 public sealed class StreamingCustomInputTests : GlobalTestData
 {
-    private const int Bars = 70;
+    /// <summary>The whole fixture, so long-window indicators get as much warmup as exists.</summary>
+    private const int Bars = 251;
 
     [Fact]
     public void StreamingRespondsToACustomInputExactlyWhenTheBatchDoes()
@@ -74,8 +75,20 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             bool streamMoved;
             try
             {
-                batchMoved = BatchRespondsToInput(batch, bars);
-                streamMoved = StreamingRespondsToSelector(pair.Value, bars);
+                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, InputName.Close));
+                var batchOnMedian = Flatten((StockData)InvokeBatch(batch, bars, InputName.MedianPrice));
+                var streamOnClose = Run(Build(pair.Value.ByName, pair.Value.Args, InputName.Close), bars);
+                var streamOnMedian = Run(Build(pair.Value.BySelector, pair.Value.Args, (Func<OhlcvBar, double>)Median), bars);
+
+                // An indicator whose window never fills over this fixture - the catalogue has
+                // defaults as long as 550 against 251 bars - emits nothing but zeros, and "no
+                // difference" then means "no signal" rather than "ignores the input". Refusing a
+                // verdict is the honest reading; concluding from it produced a false accusation
+                // against QuadraticLeastSquaresMovingAverage.
+                if (Silent(streamOnClose) || Silent(batchOnClose)) { unpaired++; continue; }
+
+                batchMoved = Differs(batchOnClose, batchOnMedian);
+                streamMoved = Differs(streamOnClose, streamOnMedian);
             }
             catch
             {
@@ -102,6 +115,49 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     }
 
     private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
+
+    /// <summary>
+    /// Runs a batch indicator on a given input series, using whichever lever that indicator exposes.
+    /// </summary>
+    /// <remarks>
+    /// The catalogue has two ways of accepting an input series and they are not interchangeable.
+    /// Most indicators read it from the StockData - CustomValuesList if chained, else InputValues -
+    /// so chaining is how a caller changes it. A minority declare an <c>InputName</c> parameter and
+    /// resolve through the two-argument <c>GetInputValuesList(inputName, stockData)</c>, which never
+    /// looks at the chained series at all; AwesomeOscillator is one, and it defaults to
+    /// <c>MedianPrice</c> rather than close.
+    ///
+    /// Testing only the chaining lever reported those as ignoring their input, which they do not -
+    /// they ignore that particular lever. Each is driven the way it actually accepts input.
+    /// </remarks>
+    private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, InputName input)
+    {
+        var ps = batch.GetParameters();
+        var args = new object?[ps.Length];
+        for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
+
+        var byParameter = Array.FindIndex(ps, p => p.ParameterType == typeof(InputName));
+        if (byParameter > 0)
+        {
+            args[0] = new StockData(bars);
+            args[byParameter] = input;
+        }
+        else
+        {
+            args[0] = input == InputName.MedianPrice
+                ? new StockData(bars).CalculateMedianPrice()
+                : new StockData(bars);
+        }
+
+        return batch.Invoke(null, args)!;
+    }
+
+    private static IStreamingIndicatorState Build(ConstructorInfo ctor, object?[] args, object last) =>
+        (IStreamingIndicatorState)ctor.Invoke(args.Append<object?>(last).ToArray())!;
+
+    /// <summary>Whether a run produced nothing to compare.</summary>
+    private static bool Silent(Dictionary<string, List<double>> series) =>
+        series.Values.All(s => s.All(v => v == 0 || double.IsNaN(v)));
 
     /// <summary>
     /// An (InputName, selector) constructor pair differing only in the final parameter, plus the
@@ -150,31 +206,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
                 && m.GetParameters().Skip(1).All(p => p.HasDefaultValue));
     }
 
-    private static bool BatchRespondsToInput(MethodInfo batch, List<TickerData> bars)
-    {
-        var args = new object?[batch.GetParameters().Length];
-        for (var i = 1; i < args.Length; i++) { args[i] = batch.GetParameters()[i].DefaultValue; }
 
-        args[0] = new StockData(bars);
-        var onClose = Flatten((StockData)batch.Invoke(null, args)!);
-
-        // Chaining is how a batch caller supplies a different series.
-        args[0] = new StockData(bars).CalculateMedianPrice();
-        var onMedian = Flatten((StockData)batch.Invoke(null, args)!);
-
-        return Differs(onClose, onMedian);
-    }
-
-    private static bool StreamingRespondsToSelector(
-        (ConstructorInfo ByName, ConstructorInfo BySelector, object?[] Args) pair, List<TickerData> bars)
-    {
-        var onClose = Run(
-            (IStreamingIndicatorState)pair.ByName.Invoke(pair.Args.Append<object?>(InputName.Close).ToArray())!, bars);
-        var onMedian = Run(
-            (IStreamingIndicatorState)pair.BySelector.Invoke(pair.Args.Append<object?>((Func<OhlcvBar, double>)Median).ToArray())!, bars);
-
-        return Differs(onClose, onMedian);
-    }
 
     /// <summary>Every published series of a batch result, keyed by output name.</summary>
     private static Dictionary<string, List<double>> Flatten(StockData result)

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -4,17 +4,19 @@ using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using OoplesFinance.StockIndicators.Builder;
 using OoplesFinance.StockIndicators.Enums;
 using OoplesFinance.StockIndicators.Helpers;
 using OoplesFinance.StockIndicators.Models;
 using OoplesFinance.StockIndicators.Streaming;
 using Xunit;
+using static OoplesFinance.StockIndicators.Tests.Unit.StreamingTests.IndicatorRunner;
 
 namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
 
 /// <summary>
-/// Every indicator takes a caller-supplied input series, and streaming responds to one exactly when
-/// the batch does.
+/// Every indicator takes a caller-supplied input series, and streaming computes on it exactly what the batch
+/// computes.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -25,23 +27,19 @@ namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
 /// through InputName.
 /// </para>
 /// <para>
-/// <b>Two rules.</b> First, every state must be reachable by custom input at all. The first version of
-/// this test only compared states that had both an InputName and a selector overload, and 82 states
-/// had no selector overload, so they went unexamined; a state that cannot be built for the wrapper is
-/// now a named failure rather than a skip. Second, a state must respond to a custom series if,
-/// and only if, its batch twin does. That rule is an equivalence rather than "must respond" because
-/// some indicators legitimately read specific bar fields - a median-price series lies inside the
-/// bar's range, so an Ichimoku line built on true highs and lows does not move - and an equivalence
-/// needs no list of exceptions. A list of exceptions is a trapdoor: any genuine defect can be
-/// silenced with a name and a plausible sentence.
+/// <b>Two rules.</b> First, every state must be reachable by custom input at all: a state that cannot be
+/// built for the wrapper, or that has no batch twin, is a named failure rather than a skip. Second, on the
+/// close and on a custom series alike, streaming must publish the same outputs as its batch twin, with the
+/// same values on every bar, within <see cref="IndicatorRunner.IsClose"/>. An earlier version only checked
+/// that both engines moved when the input changed, which a pair computing different numbers passed, and
+/// which needed an escape for indicators whose window never filled. Comparing the values needs neither.
 /// </para>
 /// <para>
-/// <b>Two traps in the harness itself.</b> The selector constructor usually declares no defaults, so
-/// filling its leading parameters with <c>default</c> builds a state with <c>length: 0</c>. Both runs
-/// therefore use the SAME constructor and the SAME leading arguments, taken from a sibling overload's
-/// defaults, and differ only in the selector. And <c>Result.Value</c> is only one member of a state's
-/// output set; comparing it alone misses a state whose input moves only a secondary series, which is
-/// how DrunkardWalk escaped an earlier sweep. Every key is compared, on both sides.
+/// <b>Two traps in the harness itself.</b> The state is built once with the constructor whose parameters
+/// all have defaults, and both runs use that construction and differ only in the selector. And
+/// <c>Result.Value</c> is only one member of a state's output set; comparing it alone misses a state whose
+/// input moves only a secondary series, which is how DrunkardWalk escaped an earlier sweep. Every key is
+/// compared, on both sides.
 /// </para>
 /// </remarks>
 public sealed class StreamingCustomInputTests : GlobalTestData
@@ -63,27 +61,20 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         /// series itself under the per-bar rule, and a non-linear transform, so it is a genuinely
         /// different series even to an indicator that ignores scale.
         /// </summary>
-        /// <remarks>
-        /// The first out-of-range probe divided the close by 100. That is a pure rescale, and a
-        /// scale-invariant indicator - momentum as a ratio, a z-score, anything normalised - is right
-        /// to give the same answer for it, so the probe could not tell a correct "ignores" from a
-        /// defect. What it reported instead was floating-point noise on whichever side happened to
-        /// round differently.
-        /// </remarks>
         OutOfRange,
     }
 
     [Theory]
     [InlineData(CustomSeries.InRange)]
     [InlineData(CustomSeries.OutOfRange)]
-    public void StreamingRespondsToACustomInputExactlyWhenTheBatchDoes(CustomSeries series)
+    public void StreamingComputesWhatTheBatchComputesOnACustomInput(CustomSeries series)
     {
         var bars = StockTestData.Take(Bars).ToList();
         bars.Should().NotBeEmpty();
 
         var stateType = typeof(IStreamingIndicatorState);
         var types = stateType.Assembly.GetTypes()
-            .Where(t => t.IsClass && !t.IsAbstract && stateType.IsAssignableFrom(t))
+            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic && stateType.IsAssignableFrom(t))
             // The wrapper under test, not an indicator: it has no defaults to build it with and no
             // batch twin, and it is what every other type here is driven through.
             .Where(t => t != typeof(CustomInputState))
@@ -91,10 +82,10 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             .ToList();
 
         var cannotTakeInput = new List<string>();
-        var disagreements = new List<string>();
+        var unpaired = new List<string>();
         var couldNotRun = new List<string>();
+        var disagreements = new List<string>();
         var compared = 0;
-        var unpaired = 0;
 
         foreach (var type in types)
         {
@@ -105,50 +96,41 @@ public sealed class StreamingCustomInputTests : GlobalTestData
                 continue;
             }
 
-            var batch = FindBatchMethod(type.Name);
-            if (batch is null) { unpaired++; continue; }
-
-            bool batchMoved;
-            bool streamMoved;
+            Dictionary<string, List<double>> batchOnClose;
+            Dictionary<string, List<double>> batchOnCustom;
+            Dictionary<string, List<double>> streamOnClose;
+            Dictionary<string, List<double>> streamOnCustom;
             try
             {
-                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, custom: null));
-                var batchOnCustom = Flatten((StockData)InvokeBatch(batch, bars, series));
-                var streamOnClose = Run(new CustomInputState(Build(build.Value), Close), bars);
-                var streamOnCustom = Run(new CustomInputState(Build(build.Value), Selector(series)), bars);
+                var state = Build(build.Value);
+                var batch = IndicatorInvoker.GetMethod(state.Name);
+                if (batch is null)
+                {
+                    unpaired.Add($"{type.Name} (no batch method for {state.Name})");
+                    continue;
+                }
 
-                // An indicator whose window never fills over this fixture - the catalogue has
-                // defaults as long as 550 against 251 bars - emits nothing but zeros, and "no
-                // difference" then means "no signal" rather than "ignores the input". Refusing a
-                // verdict is the honest reading; concluding from it produced a false accusation
-                // against QuadraticLeastSquaresMovingAverage.
-                if (Silent(streamOnClose) || Silent(batchOnClose)) { unpaired++; continue; }
-
-                batchMoved = Differs(batchOnClose, batchOnCustom);
-                streamMoved = Differs(streamOnClose, streamOnCustom);
+                batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, custom: null));
+                batchOnCustom = Flatten((StockData)InvokeBatch(batch, bars, series));
+                streamOnClose = Run(new CustomInputState(state, Close), bars);
+                streamOnCustom = Run(new CustomInputState(Build(build.Value), Selector(series)), bars);
             }
             catch (Exception ex)
             {
                 // Named, not swallowed: a state that throws on a plain run is worth knowing about.
                 couldNotRun.Add($"{type.Name} ({(ex.InnerException ?? ex).GetType().Name})");
-                unpaired++;
                 continue;
             }
 
             compared++;
-
-            if (batchMoved != streamMoved)
-            {
-                disagreements.Add(
-                    $"{type.Name}: batch {(batchMoved ? "responds" : "ignores")}, " +
-                    $"streaming {(streamMoved ? "responds" : "ignores")}");
-            }
+            Compare($"{type.Name} on the close", batchOnClose, streamOnClose, disagreements);
+            Compare($"{type.Name} on the {series} series", batchOnCustom, streamOnCustom, disagreements);
         }
 
-        compared.Should().BeGreaterThan(150, "the harness must exercise a broad set of indicators");
+        compared.Should().BeGreaterThan(700, "every public streaming state is compared");
 
-        // Both lists in one run: they are independent defects, and a first assertion that throws
-        // would hide the second list behind it.
+        // All lists in one run: they are independent defects, and a first assertion that throws would hide
+        // the others behind it.
         using var scope = new AssertionScope();
 
         cannotTakeInput.Should().BeEmpty(
@@ -156,14 +138,54 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             $"build the state with its defaults; {cannotTakeInput.Count} cannot be built: " +
             $"{string.Join(", ", cannotTakeInput)}");
 
+        unpaired.Should().BeEmpty($"every streaming state has a batch twin: {string.Join(" | ", unpaired)}");
+
         couldNotRun.Should().BeEmpty(
             $"every indicator must complete both the batch and the streaming run: {string.Join(", ", couldNotRun)}");
 
         disagreements.Should().BeEmpty(
-            $"streaming and batch must agree about what the {series} input series controls. " +
-            $"{compared} indicators compared, {unpaired} without a comparable run " +
-            $"(could not run: {string.Join(", ", couldNotRun)}). " +
-            $"Disagreements ({disagreements.Count}): {string.Join(" | ", disagreements)}");
+            $"streaming computes what batch computes on the close and on the {series} series; {compared} " +
+            $"indicators compared. Disagreements ({disagreements.Count}): {string.Join(" | ", disagreements)}");
+    }
+
+    private static void Compare(string label, Dictionary<string, List<double>> batch,
+        Dictionary<string, List<double>> streamed, List<string> disagreements)
+    {
+        var batchKeys = new HashSet<string>(batch.Keys, StringComparer.Ordinal);
+        var streamKeys = new HashSet<string>(streamed.Keys, StringComparer.Ordinal);
+        if (!batchKeys.Contains(Primary))
+        {
+            // A band indicator publishes its bands and no single series in batch; its streaming value is one
+            // of those bands, compared under its own name.
+            streamKeys.Remove(Primary);
+        }
+
+        if (!batchKeys.SetEquals(streamKeys))
+        {
+            disagreements.Add($"{label}: batch only [{string.Join(",", batchKeys.Except(streamKeys))}], " +
+                $"streaming only [{string.Join(",", streamKeys.Except(batchKeys))}]");
+            return;
+        }
+
+        foreach (var key in batchKeys.OrderBy(k => k, StringComparer.Ordinal))
+        {
+            var expected = batch[key];
+            var actual = streamed[key];
+            if (expected.Count != actual.Count)
+            {
+                disagreements.Add($"{label} {key}: {expected.Count} batch values, {actual.Count} streamed");
+                continue;
+            }
+
+            for (var i = 0; i < expected.Count; i++)
+            {
+                if (!IsClose(expected[i], actual[i]))
+                {
+                    disagreements.Add($"{label} {key} at bar {i}: batch {expected[i]}, streaming {actual[i]}");
+                    break;
+                }
+            }
+        }
     }
 
     private static double Close(OhlcvBar bar) => bar.Close;
@@ -176,14 +198,12 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         series == CustomSeries.InRange ? Median : LogClose;
 
     /// <summary>
-    /// Runs a batch indicator on a close series or a median-price series chained in front of it.
+    /// Runs a batch indicator on a close series or a custom series chained in front of it.
     /// </summary>
     /// <remarks>
-    /// Chaining is the one lever: a chained series always wins. Some methods still take their own
-    /// <c>inputName</c> parameter and resolve it through the two-argument
-    /// <c>GetInputValuesList(inputName, stockData)</c>, which never looks at the chained series -
-    /// AwesomeOscillator defaults it to MedianPrice. An earlier version of this test drove those
-    /// through the parameter instead, which hid exactly that defect: they ignore the chain.
+    /// Chaining is the one lever: a chained series always wins. BOTH runs chain a series, mirroring the
+    /// streaming side's selectors; an unchained baseline is not "close" for every method, since some read a
+    /// median price by default.
     /// </remarks>
     private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, CustomSeries? custom)
     {
@@ -191,10 +211,6 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         var args = new object?[ps.Length];
         for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
 
-        // BOTH runs chain a series, mirroring the streaming side's selectors. An unchained baseline
-        // is not "close" for every method: AwesomeOscillator, AcceleratorOscillator, AlligatorIndex
-        // and GatorOscillator default to MedianPrice, so chaining a median series in front of them
-        // changed nothing and read as "batch ignores its input" when it does not.
         var data = new StockData(bars);
         var values = custom switch
         {
@@ -213,21 +229,11 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     private static IStreamingIndicatorState Build((ConstructorInfo Ctor, object?[] Args) build) =>
         (IStreamingIndicatorState)build.Ctor.Invoke(build.Args);
 
-    /// <summary>Whether a run produced nothing to compare.</summary>
-    private static bool Silent(Dictionary<string, List<double>> series) =>
-        series.Values.All(s => s.All(v => v == 0 || double.IsNaN(v)));
-
     /// <summary>
     /// How to build the state as a caller would with no arguments: a constructor whose parameters all
     /// have defaults, preferring the one with the fewest parameters.
     /// </summary>
     /// <returns>Null when no constructor can be called without arguments.</returns>
-    /// <remarks>
-    /// Custom input no longer comes from a per-state selector overload - <see cref="CustomInputState"/>
-    /// wraps any state - so what matters is only that the state can be built. Both runs build it the
-    /// same way and differ only in the selector, which rules out the old trap of two overloads being
-    /// filled with different argument values.
-    /// </remarks>
     private static (ConstructorInfo Ctor, object?[] Args)? FindDefaultConstruction(Type type)
     {
         var ctor = type.GetConstructors()
@@ -240,33 +246,14 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             : (ctor, ctor.GetParameters().Select(p => p.DefaultValue).ToArray());
     }
 
-    /// <summary>The batch twin, by the catalogue's naming convention: XyzState -&gt; CalculateXyz.</summary>
-    private static MethodInfo? FindBatchMethod(string stateTypeName)
-    {
-        if (!stateTypeName.EndsWith("State", StringComparison.Ordinal)) { return null; }
-
-        var name = "Calculate" + stateTypeName[..^"State".Length];
-
-        return typeof(StockData).Assembly.GetTypes()
-            .Where(t => t.IsSealed && t.IsAbstract)                       // static classes
-            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
-            .FirstOrDefault(m =>
-                m.Name == name
-                && m.ReturnType == typeof(StockData)
-                && m.GetParameters().Length > 0
-                && m.GetParameters()[0].ParameterType == typeof(StockData)
-                && m.GetParameters().Skip(1).All(p => p.HasDefaultValue));
-    }
-
-
-
     /// <summary>Every published series of a batch result, keyed by output name.</summary>
     private static Dictionary<string, List<double>> Flatten(StockData result)
     {
-        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal)
+        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal);
+        if (result.CustomValuesList.Count > 0)
         {
-            ["<primary>"] = result.CustomValuesList,
-        };
+            all[Primary] = result.CustomValuesList;
+        }
 
         foreach (var kv in result.OutputValues) { all[kv.Key] = kv.Value; }
 
@@ -276,7 +263,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     /// <summary>Every published series of a streaming run, keyed the same way.</summary>
     private static Dictionary<string, List<double>> Run(IStreamingIndicatorState state, List<TickerData> bars)
     {
-        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal) { ["<primary>"] = new() };
+        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal) { [Primary] = new() };
 
         foreach (var t in bars)
         {
@@ -284,7 +271,7 @@ public sealed class StreamingCustomInputTests : GlobalTestData
                 t.Open, t.High, t.Low, t.Close, t.Volume, isFinal: true);
             var r = state.Update(bar, isFinal: true, includeOutputs: true);
 
-            all["<primary>"].Add(r.Value);
+            all[Primary].Add(r.Value);
             if (r.Outputs is null) { continue; }
 
             foreach (var kv in r.Outputs)
@@ -295,30 +282,5 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         }
 
         return all;
-    }
-
-    private static bool Differs(Dictionary<string, List<double>> a, Dictionary<string, List<double>> b)
-    {
-        // The union of both runs' keys, and unequal lengths count as a difference: absent data is not
-        // agreement. Iterating one side's keys, bounded by the shorter series, read "only the second run
-        // published this" or "one run stopped early" as "no change".
-        foreach (var key in a.Keys.Union(b.Keys, StringComparer.Ordinal))
-        {
-            if (!a.TryGetValue(key, out var mine) || !b.TryGetValue(key, out var other)) { return true; }
-            if (mine.Count != other.Count) { return true; }
-
-            for (var i = 0; i < mine.Count; i++)
-            {
-                if (double.IsNaN(mine[i]) && double.IsNaN(other[i])) { continue; }
-                // Relative, not absolute. A series in the millions - volume, an accumulation line - carries
-                // more than 1e-12 of rounding noise from reordered arithmetic alone, and an absolute
-                // threshold read that noise as "responds". A real response to a different input series
-                // differs by orders of magnitude more than a part in a billion.
-                var scale = Math.Max(1.0, Math.Max(Math.Abs(mine[i]), Math.Abs(other[i])));
-                if (Math.Abs(mine[i] - other[i]) > 1e-9 * scale) { return true; }
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -20,14 +20,15 @@ namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
 /// <para>
 /// Both engines let a caller compute an indicator on something other than the close. In batch that
 /// is chaining - <c>data.CalculateMedianPrice().CalculateRsi()</c> - and a chained series always wins.
-/// In streaming it is the <c>Func&lt;OhlcvBar, double&gt;</c> constructor overload. Callers pass
-/// values, not a name for them, so nothing here goes through InputName.
+/// In streaming it is <see cref="CustomInputState"/>, which wraps any state with a
+/// <c>Func&lt;OhlcvBar, double&gt;</c>. Callers pass values, not a name for them, so nothing here goes
+/// through InputName.
 /// </para>
 /// <para>
-/// <b>Two rules.</b> First, every state must HAVE a selector constructor: one without it cannot take
-/// custom values at all, and it is a named failure here rather than a skip. Skipping it is how 87
-/// states went unexamined by the first version of this test, which only compared states that had
-/// both an InputName and a selector overload. Second, a state must respond to a custom series if,
+/// <b>Two rules.</b> First, every state must be reachable by custom input at all. The first version of
+/// this test only compared states that had both an InputName and a selector overload, and 82 states
+/// had no selector overload, so they went unexamined; a state that cannot be built for the wrapper is
+/// now a named failure rather than a skip. Second, a state must respond to a custom series if,
 /// and only if, its batch twin does. That rule is an equivalence rather than "must respond" because
 /// some indicators legitimately read specific bar fields - a median-price series lies inside the
 /// bar's range, so an Ichimoku line built on true highs and lows does not move - and an equivalence
@@ -76,6 +77,9 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         var stateType = typeof(IStreamingIndicatorState);
         var types = stateType.Assembly.GetTypes()
             .Where(t => t.IsClass && !t.IsAbstract && stateType.IsAssignableFrom(t))
+            // The wrapper under test, not an indicator: it has no defaults to build it with and no
+            // batch twin, and it is what every other type here is driven through.
+            .Where(t => t != typeof(CustomInputState))
             .OrderBy(t => t.Name, StringComparer.Ordinal)
             .ToList();
 
@@ -87,14 +91,12 @@ public sealed class StreamingCustomInputTests : GlobalTestData
 
         foreach (var type in types)
         {
-            var selector = FindSelectorConstructor(type);
-            if (selector is null)
+            var build = FindDefaultConstruction(type);
+            if (build is null)
             {
                 cannotTakeInput.Add(type.Name);
                 continue;
             }
-
-            if (selector.Value.Args is null) { unpaired++; continue; }
 
             var batch = FindBatchMethod(type.Name);
             if (batch is null) { unpaired++; continue; }
@@ -105,8 +107,8 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             {
                 var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, custom: null));
                 var batchOnCustom = Flatten((StockData)InvokeBatch(batch, bars, series));
-                var streamOnClose = Run(Build(selector.Value.Ctor, selector.Value.Args, (Func<OhlcvBar, double>)Close), bars);
-                var streamOnCustom = Run(Build(selector.Value.Ctor, selector.Value.Args, Selector(series)), bars);
+                var streamOnClose = Run(new CustomInputState(Build(build.Value), Close), bars);
+                var streamOnCustom = Run(new CustomInputState(Build(build.Value), Selector(series)), bars);
 
                 // An indicator whose window never fills over this fixture - the catalogue has
                 // defaults as long as 550 against 251 bars - emits nothing but zeros, and "no
@@ -143,8 +145,9 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         using var scope = new AssertionScope();
 
         cannotTakeInput.Should().BeEmpty(
-            $"every indicator must take custom values; {cannotTakeInput.Count} states have no " +
-            $"Func<OhlcvBar, double> constructor: {string.Join(", ", cannotTakeInput)}");
+            $"every indicator must take custom values through CustomInputState, which needs a way to " +
+            $"build the state with its defaults; {cannotTakeInput.Count} cannot be built: " +
+            $"{string.Join(", ", cannotTakeInput)}");
 
         disagreements.Should().BeEmpty(
             $"streaming and batch must agree about what the {series} input series controls. " +
@@ -196,56 +199,34 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         return batch.Invoke(null, args)!;
     }
 
-    private static IStreamingIndicatorState Build(ConstructorInfo ctor, object?[] args, object last) =>
-        (IStreamingIndicatorState)ctor.Invoke(args.Append<object?>(last).ToArray())!;
+    private static IStreamingIndicatorState Build((ConstructorInfo Ctor, object?[] Args) build) =>
+        (IStreamingIndicatorState)build.Ctor.Invoke(build.Args)!;
 
     /// <summary>Whether a run produced nothing to compare.</summary>
     private static bool Silent(Dictionary<string, List<double>> series) =>
         series.Values.All(s => s.All(v => v == 0 || double.IsNaN(v)));
 
     /// <summary>
-    /// The state's selector constructor, plus leading argument values to build it with.
+    /// How to build the state as a caller would with no arguments: a constructor whose parameters all
+    /// have defaults, preferring the one with the fewest parameters.
     /// </summary>
-    /// <returns>
-    /// Null when the state has no <c>Func&lt;OhlcvBar, double&gt;</c> constructor at all - it cannot
-    /// take custom values. <c>Args</c> is null when it has one but no overload declares defaults to
-    /// build it from, which is a harness limit rather than a verdict.
-    /// </returns>
+    /// <returns>Null when no constructor can be called without arguments.</returns>
     /// <remarks>
-    /// The leading values come from the selector constructor's own defaults when it has them, else
-    /// from a sibling overload with the same leading parameter types whose parameters all have
-    /// defaults (ignoring a trailing InputName, while that parameter still exists).
+    /// Custom input no longer comes from a per-state selector overload - <see cref="CustomInputState"/>
+    /// wraps any state - so what matters is only that the state can be built. Both runs build it the
+    /// same way and differ only in the selector, which rules out the old trap of two overloads being
+    /// filled with different argument values.
     /// </remarks>
-    private static (ConstructorInfo Ctor, object?[]? Args)? FindSelectorConstructor(Type type)
+    private static (ConstructorInfo Ctor, object?[] Args)? FindDefaultConstruction(Type type)
     {
-        var ctors = type.GetConstructors();
+        var ctor = type.GetConstructors()
+            .Where(c => c.GetParameters().All(p => p.HasDefaultValue))
+            .OrderBy(c => c.GetParameters().Length)
+            .FirstOrDefault();
 
-        var bySelector = ctors.FirstOrDefault(c =>
-        {
-            var ps = c.GetParameters();
-            return ps.Length > 0 && ps[^1].ParameterType == typeof(Func<OhlcvBar, double>);
-        });
-        if (bySelector is null) { return null; }
-
-        var lead = bySelector.GetParameters()[..^1];
-        if (lead.All(p => p.HasDefaultValue))
-        {
-            return (bySelector, lead.Select(p => p.DefaultValue).ToArray());
-        }
-
-        foreach (var sibling in ctors)
-        {
-            var ps = sibling.GetParameters();
-            var leading = ps.Length > 0 && ps[^1].ParameterType == typeof(InputName) ? ps[..^1] : ps;
-            if (leading.Length == lead.Length
-                && leading.Select(p => p.ParameterType).SequenceEqual(lead.Select(p => p.ParameterType))
-                && leading.All(p => p.HasDefaultValue))
-            {
-                return (bySelector, leading.Select(p => p.DefaultValue).ToArray());
-            }
-        }
-
-        return (bySelector, null);
+        return ctor is null
+            ? null
+            : (ctor, ctor.GetParameters().Select(p => p.DefaultValue).ToArray());
     }
 
     /// <summary>The batch twin, by the catalogue's naming convention: XyzState -&gt; CalculateXyz.</summary>

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using OoplesFinance.StockIndicators.Enums;
+using OoplesFinance.StockIndicators.Models;
+using OoplesFinance.StockIndicators.Streaming;
+using Xunit;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
+
+/// <summary>
+/// Streaming responds to a caller-supplied input series if, and only if, the batch does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both engines let a caller compute an indicator on something other than the close. In batch that
+/// is chaining - <c>data.CalculateMedianPrice().CalculateRsi()</c>. In streaming it is the
+/// <c>Func&lt;OhlcvBar, double&gt;</c> constructor overload. A state can build a
+/// <c>StreamingInputResolver</c> and never read it, in which case the selector is accepted and
+/// discarded: no exception, no warning, and results that silently disagree with the batch the moment
+/// a caller supplies custom values.
+/// </para>
+/// <para>
+/// <b>Why the rule is an equivalence rather than "streaming must respond".</b> Some indicators are
+/// defined on specific bar fields - Ichimoku on highs and lows, Fibonacci retracements on the range -
+/// and for those there is no series to substitute, so neither engine should move. An
+/// "always respond" rule would need a list of exceptions, and a list of exceptions is a trapdoor:
+/// any genuine defect can be silenced by adding a name and a plausible sentence. Comparing the two
+/// engines instead needs no list. The input-independent indicators pass because their batch does not
+/// move either, which is the same evidence a human would have used to justify exempting them.
+/// </para>
+/// <para>
+/// <b>Two traps in the harness itself.</b> The selector constructor usually declares no defaults, so
+/// filling its leading parameters with <c>default</c> builds a state with <c>length: 0</c> - the two
+/// states then differ because of the length rather than the input, which reads as a pass. Both are
+/// therefore constructed from the SAME argument values, taken from the InputName overload's
+/// defaults. And <c>Result.Value</c> is only one member of a state's output set, the rest arriving
+/// through <c>Outputs</c>; comparing <c>Value</c> alone misses a state whose selected series moves
+/// only a secondary series, which is exactly how DrunkardWalk escaped an earlier sweep. Every key is
+/// compared, on both sides.
+/// </para>
+/// </remarks>
+public sealed class StreamingCustomInputTests : GlobalTestData
+{
+    private const int Bars = 70;
+
+    [Fact]
+    public void StreamingRespondsToACustomInputExactlyWhenTheBatchDoes()
+    {
+        var bars = StockTestData.Take(Bars).ToList();
+        bars.Should().NotBeEmpty();
+
+        var stateType = typeof(IStreamingIndicatorState);
+        var types = stateType.Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && stateType.IsAssignableFrom(t))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var disagreements = new List<string>();
+        var compared = 0;
+        var unpaired = 0;
+
+        foreach (var type in types)
+        {
+            var pair = FindComparablePair(type);
+            if (pair is null) { unpaired++; continue; }
+
+            var batch = FindBatchMethod(type.Name);
+            if (batch is null) { unpaired++; continue; }
+
+            bool batchMoved;
+            bool streamMoved;
+            try
+            {
+                batchMoved = BatchRespondsToInput(batch, bars);
+                streamMoved = StreamingRespondsToSelector(pair.Value, bars);
+            }
+            catch
+            {
+                unpaired++;
+                continue;
+            }
+
+            compared++;
+
+            if (batchMoved != streamMoved)
+            {
+                disagreements.Add(
+                    $"{type.Name}: batch {(batchMoved ? "responds" : "ignores")}, " +
+                    $"streaming {(streamMoved ? "responds" : "ignores")}");
+            }
+        }
+
+        compared.Should().BeGreaterThan(150, "the harness must exercise a broad set of indicators");
+
+        disagreements.Should().BeEmpty(
+            $"streaming and batch must agree about what the input series controls. " +
+            $"{compared} indicators compared, {unpaired} without a comparable pair. " +
+            $"Disagreements: {string.Join(" | ", disagreements)}");
+    }
+
+    private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
+
+    /// <summary>
+    /// An (InputName, selector) constructor pair differing only in the final parameter, plus the
+    /// shared argument values, so the only difference between the two states is the input.
+    /// </summary>
+    private static (ConstructorInfo ByName, ConstructorInfo BySelector, object?[] Args)? FindComparablePair(Type type)
+    {
+        var ctors = type.GetConstructors();
+
+        var byName = ctors.FirstOrDefault(c =>
+        {
+            var ps = c.GetParameters();
+            return ps.Length > 0
+                && ps[^1].ParameterType == typeof(InputName)
+                && ps.Take(ps.Length - 1).All(p => p.HasDefaultValue);
+        });
+        if (byName is null) { return null; }
+
+        var lead = byName.GetParameters()[..^1];
+
+        var bySelector = ctors.FirstOrDefault(c =>
+        {
+            var ps = c.GetParameters();
+            return ps.Length == lead.Length + 1
+                && ps[^1].ParameterType == typeof(Func<OhlcvBar, double>)
+                && ps[..^1].Select(p => p.ParameterType).SequenceEqual(lead.Select(p => p.ParameterType));
+        });
+        if (bySelector is null) { return null; }
+
+        return (byName, bySelector, lead.Select(p => p.DefaultValue).ToArray());
+    }
+
+    /// <summary>The batch twin, by the catalogue's naming convention: XyzState -&gt; CalculateXyz.</summary>
+    private static MethodInfo? FindBatchMethod(string stateTypeName)
+    {
+        var name = "Calculate" + stateTypeName[..^"State".Length];
+
+        return typeof(StockData).Assembly.GetTypes()
+            .Where(t => t.IsSealed && t.IsAbstract)                       // static classes
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .FirstOrDefault(m =>
+                m.Name == name
+                && m.ReturnType == typeof(StockData)
+                && m.GetParameters().Length > 0
+                && m.GetParameters()[0].ParameterType == typeof(StockData)
+                && m.GetParameters().Skip(1).All(p => p.HasDefaultValue));
+    }
+
+    private static bool BatchRespondsToInput(MethodInfo batch, List<TickerData> bars)
+    {
+        var args = new object?[batch.GetParameters().Length];
+        for (var i = 1; i < args.Length; i++) { args[i] = batch.GetParameters()[i].DefaultValue; }
+
+        args[0] = new StockData(bars);
+        var onClose = Flatten((StockData)batch.Invoke(null, args)!);
+
+        // Chaining is how a batch caller supplies a different series.
+        args[0] = new StockData(bars).CalculateMedianPrice();
+        var onMedian = Flatten((StockData)batch.Invoke(null, args)!);
+
+        return Differs(onClose, onMedian);
+    }
+
+    private static bool StreamingRespondsToSelector(
+        (ConstructorInfo ByName, ConstructorInfo BySelector, object?[] Args) pair, List<TickerData> bars)
+    {
+        var onClose = Run(
+            (IStreamingIndicatorState)pair.ByName.Invoke(pair.Args.Append<object?>(InputName.Close).ToArray())!, bars);
+        var onMedian = Run(
+            (IStreamingIndicatorState)pair.BySelector.Invoke(pair.Args.Append<object?>((Func<OhlcvBar, double>)Median).ToArray())!, bars);
+
+        return Differs(onClose, onMedian);
+    }
+
+    /// <summary>Every published series of a batch result, keyed by output name.</summary>
+    private static Dictionary<string, List<double>> Flatten(StockData result)
+    {
+        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal)
+        {
+            ["<primary>"] = result.CustomValuesList,
+        };
+
+        foreach (var kv in result.OutputValues) { all[kv.Key] = kv.Value; }
+
+        return all;
+    }
+
+    /// <summary>Every published series of a streaming run, keyed the same way.</summary>
+    private static Dictionary<string, List<double>> Run(IStreamingIndicatorState state, List<TickerData> bars)
+    {
+        var all = new Dictionary<string, List<double>>(StringComparer.Ordinal) { ["<primary>"] = new() };
+
+        foreach (var t in bars)
+        {
+            var bar = new OhlcvBar("TEST", BarTimeframe.Tick, t.Date, t.Date,
+                t.Open, t.High, t.Low, t.Close, t.Volume, isFinal: true);
+            var r = state.Update(bar, isFinal: true, includeOutputs: true);
+
+            all["<primary>"].Add(r.Value);
+            if (r.Outputs is null) { continue; }
+
+            foreach (var kv in r.Outputs)
+            {
+                if (!all.TryGetValue(kv.Key, out var series)) { all[kv.Key] = series = new List<double>(); }
+                series.Add(kv.Value);
+            }
+        }
+
+        return all;
+    }
+
+    private static bool Differs(Dictionary<string, List<double>> a, Dictionary<string, List<double>> b)
+    {
+        foreach (var key in a.Keys)
+        {
+            if (!b.TryGetValue(key, out var other)) { return true; }
+
+            var mine = a[key];
+            for (var i = 0; i < Math.Min(mine.Count, other.Count) && i < Bars; i++)
+            {
+                if (double.IsNaN(mine[i]) && double.IsNaN(other[i])) { continue; }
+                if (Math.Abs(mine[i] - other[i]) > 1e-12) { return true; }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -156,6 +156,9 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             $"build the state with its defaults; {cannotTakeInput.Count} cannot be built: " +
             $"{string.Join(", ", cannotTakeInput)}");
 
+        couldNotRun.Should().BeEmpty(
+            $"every indicator must complete both the batch and the streaming run: {string.Join(", ", couldNotRun)}");
+
         disagreements.Should().BeEmpty(
             $"streaming and batch must agree about what the {series} input series controls. " +
             $"{compared} indicators compared, {unpaired} without a comparable run " +
@@ -203,11 +206,12 @@ public sealed class StreamingCustomInputTests : GlobalTestData
 
         args[0] = data;
 
-        return batch.Invoke(null, args)!;
+        return batch.Invoke(null, args)
+            ?? throw new InvalidOperationException($"{batch.Name} returned null instead of its StockData");
     }
 
     private static IStreamingIndicatorState Build((ConstructorInfo Ctor, object?[] Args) build) =>
-        (IStreamingIndicatorState)build.Ctor.Invoke(build.Args)!;
+        (IStreamingIndicatorState)build.Ctor.Invoke(build.Args);
 
     /// <summary>Whether a run produced nothing to compare.</summary>
     private static bool Silent(Dictionary<string, List<double>> series) =>
@@ -239,6 +243,8 @@ public sealed class StreamingCustomInputTests : GlobalTestData
     /// <summary>The batch twin, by the catalogue's naming convention: XyzState -&gt; CalculateXyz.</summary>
     private static MethodInfo? FindBatchMethod(string stateTypeName)
     {
+        if (!stateTypeName.EndsWith("State", StringComparison.Ordinal)) { return null; }
+
         var name = "Calculate" + stateTypeName[..^"State".Length];
 
         return typeof(StockData).Assembly.GetTypes()
@@ -293,12 +299,15 @@ public sealed class StreamingCustomInputTests : GlobalTestData
 
     private static bool Differs(Dictionary<string, List<double>> a, Dictionary<string, List<double>> b)
     {
-        foreach (var key in a.Keys)
+        // The union of both runs' keys, and unequal lengths count as a difference: absent data is not
+        // agreement. Iterating one side's keys, bounded by the shorter series, read "only the second run
+        // published this" or "one run stopped early" as "no change".
+        foreach (var key in a.Keys.Union(b.Keys, StringComparer.Ordinal))
         {
-            if (!b.TryGetValue(key, out var other)) { return true; }
+            if (!a.TryGetValue(key, out var mine) || !b.TryGetValue(key, out var other)) { return true; }
+            if (mine.Count != other.Count) { return true; }
 
-            var mine = a[key];
-            for (var i = 0; i < Math.Min(mine.Count, other.Count) && i < Bars; i++)
+            for (var i = 0; i < mine.Count; i++)
             {
                 if (double.IsNaN(mine[i]) && double.IsNaN(other[i])) { continue; }
                 // Relative, not absolute. A series in the millions - volume, an accumulation line - carries

--- a/tests/StreamingTests/StreamingCustomInputTests.cs
+++ b/tests/StreamingTests/StreamingCustomInputTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using OoplesFinance.StockIndicators.Enums;
 using OoplesFinance.StockIndicators.Models;
 using OoplesFinance.StockIndicators.Streaming;
@@ -11,35 +12,34 @@ using Xunit;
 namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
 
 /// <summary>
-/// Streaming responds to a caller-supplied input series if, and only if, the batch does.
+/// Every indicator takes a caller-supplied input series, and streaming responds to one exactly when
+/// the batch does.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Both engines let a caller compute an indicator on something other than the close. In batch that
-/// is chaining - <c>data.CalculateMedianPrice().CalculateRsi()</c>. In streaming it is the
-/// <c>Func&lt;OhlcvBar, double&gt;</c> constructor overload. A state can build a
-/// <c>StreamingInputResolver</c> and never read it, in which case the selector is accepted and
-/// discarded: no exception, no warning, and results that silently disagree with the batch the moment
-/// a caller supplies custom values.
+/// is chaining - <c>data.CalculateMedianPrice().CalculateRsi()</c> - and a chained series always wins.
+/// In streaming it is the <c>Func&lt;OhlcvBar, double&gt;</c> constructor overload. Callers pass
+/// values, not a name for them, so nothing here goes through InputName.
 /// </para>
 /// <para>
-/// <b>Why the rule is an equivalence rather than "streaming must respond".</b> Some indicators are
-/// defined on specific bar fields - Ichimoku on highs and lows, Fibonacci retracements on the range -
-/// and for those there is no series to substitute, so neither engine should move. An
-/// "always respond" rule would need a list of exceptions, and a list of exceptions is a trapdoor:
-/// any genuine defect can be silenced by adding a name and a plausible sentence. Comparing the two
-/// engines instead needs no list. The input-independent indicators pass because their batch does not
-/// move either, which is the same evidence a human would have used to justify exempting them.
+/// <b>Two rules.</b> First, every state must HAVE a selector constructor: one without it cannot take
+/// custom values at all, and it is a named failure here rather than a skip. Skipping it is how 87
+/// states went unexamined by the first version of this test, which only compared states that had
+/// both an InputName and a selector overload. Second, a state must respond to a custom series if,
+/// and only if, its batch twin does. That rule is an equivalence rather than "must respond" because
+/// some indicators legitimately read specific bar fields - a median-price series lies inside the
+/// bar's range, so an Ichimoku line built on true highs and lows does not move - and an equivalence
+/// needs no list of exceptions. A list of exceptions is a trapdoor: any genuine defect can be
+/// silenced with a name and a plausible sentence.
 /// </para>
 /// <para>
 /// <b>Two traps in the harness itself.</b> The selector constructor usually declares no defaults, so
-/// filling its leading parameters with <c>default</c> builds a state with <c>length: 0</c> - the two
-/// states then differ because of the length rather than the input, which reads as a pass. Both are
-/// therefore constructed from the SAME argument values, taken from the InputName overload's
-/// defaults. And <c>Result.Value</c> is only one member of a state's output set, the rest arriving
-/// through <c>Outputs</c>; comparing <c>Value</c> alone misses a state whose selected series moves
-/// only a secondary series, which is exactly how DrunkardWalk escaped an earlier sweep. Every key is
-/// compared, on both sides.
+/// filling its leading parameters with <c>default</c> builds a state with <c>length: 0</c>. Both runs
+/// therefore use the SAME constructor and the SAME leading arguments, taken from a sibling overload's
+/// defaults, and differ only in the selector. And <c>Result.Value</c> is only one member of a state's
+/// output set; comparing it alone misses a state whose input moves only a secondary series, which is
+/// how DrunkardWalk escaped an earlier sweep. Every key is compared, on both sides.
 /// </para>
 /// </remarks>
 public sealed class StreamingCustomInputTests : GlobalTestData
@@ -59,14 +59,22 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             .OrderBy(t => t.Name, StringComparer.Ordinal)
             .ToList();
 
+        var cannotTakeInput = new List<string>();
         var disagreements = new List<string>();
+        var couldNotRun = new List<string>();
         var compared = 0;
         var unpaired = 0;
 
         foreach (var type in types)
         {
-            var pair = FindComparablePair(type);
-            if (pair is null) { unpaired++; continue; }
+            var selector = FindSelectorConstructor(type);
+            if (selector is null)
+            {
+                cannotTakeInput.Add(type.Name);
+                continue;
+            }
+
+            if (selector.Value.Args is null) { unpaired++; continue; }
 
             var batch = FindBatchMethod(type.Name);
             if (batch is null) { unpaired++; continue; }
@@ -75,10 +83,10 @@ public sealed class StreamingCustomInputTests : GlobalTestData
             bool streamMoved;
             try
             {
-                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, InputName.Close));
-                var batchOnMedian = Flatten((StockData)InvokeBatch(batch, bars, InputName.MedianPrice));
-                var streamOnClose = Run(Build(pair.Value.ByName, pair.Value.Args, InputName.Close), bars);
-                var streamOnMedian = Run(Build(pair.Value.BySelector, pair.Value.Args, (Func<OhlcvBar, double>)Median), bars);
+                var batchOnClose = Flatten((StockData)InvokeBatch(batch, bars, chainMedian: false));
+                var batchOnMedian = Flatten((StockData)InvokeBatch(batch, bars, chainMedian: true));
+                var streamOnClose = Run(Build(selector.Value.Ctor, selector.Value.Args, (Func<OhlcvBar, double>)Close), bars);
+                var streamOnMedian = Run(Build(selector.Value.Ctor, selector.Value.Args, (Func<OhlcvBar, double>)Median), bars);
 
                 // An indicator whose window never fills over this fixture - the catalogue has
                 // defaults as long as 550 against 251 bars - emits nothing but zeros, and "no
@@ -90,8 +98,10 @@ public sealed class StreamingCustomInputTests : GlobalTestData
                 batchMoved = Differs(batchOnClose, batchOnMedian);
                 streamMoved = Differs(streamOnClose, streamOnMedian);
             }
-            catch
+            catch (Exception ex)
             {
+                // Named, not swallowed: a state that throws on a plain run is worth knowing about.
+                couldNotRun.Add($"{type.Name} ({(ex.InnerException ?? ex).GetType().Name})");
                 unpaired++;
                 continue;
             }
@@ -108,46 +118,42 @@ public sealed class StreamingCustomInputTests : GlobalTestData
 
         compared.Should().BeGreaterThan(150, "the harness must exercise a broad set of indicators");
 
+        // Both lists in one run: they are independent defects, and a first assertion that throws
+        // would hide the second list behind it.
+        using var scope = new AssertionScope();
+
+        cannotTakeInput.Should().BeEmpty(
+            $"every indicator must take custom values; {cannotTakeInput.Count} states have no " +
+            $"Func<OhlcvBar, double> constructor: {string.Join(", ", cannotTakeInput)}");
+
         disagreements.Should().BeEmpty(
             $"streaming and batch must agree about what the input series controls. " +
-            $"{compared} indicators compared, {unpaired} without a comparable pair. " +
-            $"Disagreements: {string.Join(" | ", disagreements)}");
+            $"{compared} indicators compared, {unpaired} without a comparable run " +
+            $"(could not run: {string.Join(", ", couldNotRun)}). " +
+            $"Disagreements ({disagreements.Count}): {string.Join(" | ", disagreements)}");
     }
+
+    private static double Close(OhlcvBar bar) => bar.Close;
 
     private static double Median(OhlcvBar bar) => (bar.High + bar.Low) / 2;
 
     /// <summary>
-    /// Runs a batch indicator on a given input series, using whichever lever that indicator exposes.
+    /// Runs a batch indicator on the close, or on a median-price series chained in front of it.
     /// </summary>
     /// <remarks>
-    /// The catalogue has two ways of accepting an input series and they are not interchangeable.
-    /// Most indicators read it from the StockData - CustomValuesList if chained, else InputValues -
-    /// so chaining is how a caller changes it. A minority declare an <c>InputName</c> parameter and
-    /// resolve through the two-argument <c>GetInputValuesList(inputName, stockData)</c>, which never
-    /// looks at the chained series at all; AwesomeOscillator is one, and it defaults to
-    /// <c>MedianPrice</c> rather than close.
-    ///
-    /// Testing only the chaining lever reported those as ignoring their input, which they do not -
-    /// they ignore that particular lever. Each is driven the way it actually accepts input.
+    /// Chaining is the one lever: a chained series always wins. Some methods still take their own
+    /// <c>inputName</c> parameter and resolve it through the two-argument
+    /// <c>GetInputValuesList(inputName, stockData)</c>, which never looks at the chained series -
+    /// AwesomeOscillator defaults it to MedianPrice. An earlier version of this test drove those
+    /// through the parameter instead, which hid exactly that defect: they ignore the chain.
     /// </remarks>
-    private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, InputName input)
+    private static object InvokeBatch(MethodInfo batch, List<TickerData> bars, bool chainMedian)
     {
         var ps = batch.GetParameters();
         var args = new object?[ps.Length];
         for (var i = 1; i < ps.Length; i++) { args[i] = ps[i].DefaultValue; }
 
-        var byParameter = Array.FindIndex(ps, p => p.ParameterType == typeof(InputName));
-        if (byParameter > 0)
-        {
-            args[0] = new StockData(bars);
-            args[byParameter] = input;
-        }
-        else
-        {
-            args[0] = input == InputName.MedianPrice
-                ? new StockData(bars).CalculateMedianPrice()
-                : new StockData(bars);
-        }
+        args[0] = chainMedian ? new StockData(bars).CalculateMedianPrice() : new StockData(bars);
 
         return batch.Invoke(null, args)!;
     }
@@ -160,34 +166,48 @@ public sealed class StreamingCustomInputTests : GlobalTestData
         series.Values.All(s => s.All(v => v == 0 || double.IsNaN(v)));
 
     /// <summary>
-    /// An (InputName, selector) constructor pair differing only in the final parameter, plus the
-    /// shared argument values, so the only difference between the two states is the input.
+    /// The state's selector constructor, plus leading argument values to build it with.
     /// </summary>
-    private static (ConstructorInfo ByName, ConstructorInfo BySelector, object?[] Args)? FindComparablePair(Type type)
+    /// <returns>
+    /// Null when the state has no <c>Func&lt;OhlcvBar, double&gt;</c> constructor at all - it cannot
+    /// take custom values. <c>Args</c> is null when it has one but no overload declares defaults to
+    /// build it from, which is a harness limit rather than a verdict.
+    /// </returns>
+    /// <remarks>
+    /// The leading values come from the selector constructor's own defaults when it has them, else
+    /// from a sibling overload with the same leading parameter types whose parameters all have
+    /// defaults (ignoring a trailing InputName, while that parameter still exists).
+    /// </remarks>
+    private static (ConstructorInfo Ctor, object?[]? Args)? FindSelectorConstructor(Type type)
     {
         var ctors = type.GetConstructors();
-
-        var byName = ctors.FirstOrDefault(c =>
-        {
-            var ps = c.GetParameters();
-            return ps.Length > 0
-                && ps[^1].ParameterType == typeof(InputName)
-                && ps.Take(ps.Length - 1).All(p => p.HasDefaultValue);
-        });
-        if (byName is null) { return null; }
-
-        var lead = byName.GetParameters()[..^1];
 
         var bySelector = ctors.FirstOrDefault(c =>
         {
             var ps = c.GetParameters();
-            return ps.Length == lead.Length + 1
-                && ps[^1].ParameterType == typeof(Func<OhlcvBar, double>)
-                && ps[..^1].Select(p => p.ParameterType).SequenceEqual(lead.Select(p => p.ParameterType));
+            return ps.Length > 0 && ps[^1].ParameterType == typeof(Func<OhlcvBar, double>);
         });
         if (bySelector is null) { return null; }
 
-        return (byName, bySelector, lead.Select(p => p.DefaultValue).ToArray());
+        var lead = bySelector.GetParameters()[..^1];
+        if (lead.All(p => p.HasDefaultValue))
+        {
+            return (bySelector, lead.Select(p => p.DefaultValue).ToArray());
+        }
+
+        foreach (var sibling in ctors)
+        {
+            var ps = sibling.GetParameters();
+            var leading = ps.Length > 0 && ps[^1].ParameterType == typeof(InputName) ? ps[..^1] : ps;
+            if (leading.Length == lead.Length
+                && leading.Select(p => p.ParameterType).SequenceEqual(lead.Select(p => p.ParameterType))
+                && leading.All(p => p.HasDefaultValue))
+            {
+                return (bySelector, leading.Select(p => p.DefaultValue).ToArray());
+            }
+        }
+
+        return (bySelector, null);
     }
 
     /// <summary>The batch twin, by the catalogue's naming convention: XyzState -&gt; CalculateXyz.</summary>

--- a/tests/StreamingTests/StreamingPreviewTests.cs
+++ b/tests/StreamingTests/StreamingPreviewTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using OoplesFinance.StockIndicators.Enums;
+using OoplesFinance.StockIndicators.Models;
+using OoplesFinance.StockIndicators.Streaming;
+using Xunit;
+using static OoplesFinance.StockIndicators.Tests.Unit.StreamingTests.IndicatorRunner;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
+
+/// <summary>
+/// A preview of a bar is what the bar will publish once it is final, and previewing changes nothing.
+/// </summary>
+/// <remarks>
+/// A forming bar is sent with <c>isFinal: false</c>, and every state promises to answer it without
+/// committing it. Two ways to break that promise: answering from a mix of this bar and the last - the
+/// Ehlers periodogram once divided the previous bar's powers by this bar's maximum - or letting the
+/// preview leak into state, so later bars differ from a run that never previewed. Each bar here is
+/// previewed with its final values and then committed, so the preview must equal the commit exactly as
+/// published, and the committed series must equal a run with no previews at all.
+/// </remarks>
+public sealed class StreamingPreviewTests : GlobalTestData
+{
+    private const int Bars = 251;
+
+    [Fact]
+    public void APreviewEqualsTheFinalBarAndLeavesNoTrace()
+    {
+        var bars = StockTestData.Take(Bars)
+            .Select(t => new OhlcvBar("TEST", BarTimeframe.Tick, t.Date, t.Date, t.Open, t.High, t.Low, t.Close,
+                t.Volume, isFinal: true))
+            .ToList();
+
+        var stateType = typeof(IStreamingIndicatorState);
+        var types = stateType.Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && t.IsPublic && stateType.IsAssignableFrom(t))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var previewDiffers = new List<string>();
+        var previewLeaks = new List<string>();
+        var compared = 0;
+
+        foreach (var type in types)
+        {
+            var build = StreamingCustomInputTests.FindDefaultConstruction(type);
+            if (build is null)
+            {
+                // Named and failed by the custom-input sweep; nothing to preview without a construction.
+                continue;
+            }
+
+            var clean = StreamingCustomInputTests.Build(build.Value);
+            var previewed = StreamingCustomInputTests.Build(build.Value);
+            compared++;
+
+            string? differs = null;
+            string? leaks = null;
+            for (var i = 0; i < bars.Count && (differs is null || leaks is null); i++)
+            {
+                var expected = clean.Update(bars[i], isFinal: true, includeOutputs: true);
+                var preview = previewed.Update(bars[i], isFinal: false, includeOutputs: true);
+                var final = previewed.Update(bars[i], isFinal: true, includeOutputs: true);
+
+                differs ??= FirstDifference(preview, final, i);
+                leaks ??= FirstDifference(final, expected, i);
+            }
+
+            if (differs is not null) { previewDiffers.Add($"{type.Name} {differs}"); }
+            if (leaks is not null) { previewLeaks.Add($"{type.Name} {leaks}"); }
+        }
+
+        compared.Should().BeGreaterThan(700, "every public streaming state is previewed");
+
+        using var scope = new AssertionScope();
+        previewDiffers.Should().BeEmpty(
+            $"a preview of a bar publishes what the bar publishes once final ({previewDiffers.Count}): " +
+            string.Join(" | ", previewDiffers));
+        previewLeaks.Should().BeEmpty(
+            $"a preview leaves the state as it found it ({previewLeaks.Count}): " + string.Join(" | ", previewLeaks));
+    }
+
+    private static string? FirstDifference(StreamingIndicatorStateResult actual, StreamingIndicatorStateResult expected,
+        int bar)
+    {
+        if (!IsClose(expected.Value, actual.Value))
+        {
+            return $"{Primary} at bar {bar}: {actual.Value} vs {expected.Value}";
+        }
+
+        if (expected.Outputs is null || actual.Outputs is null)
+        {
+            return expected.Outputs is null == actual.Outputs is null ? null : $"outputs missing at bar {bar}";
+        }
+
+        foreach (var kv in expected.Outputs)
+        {
+            if (!actual.Outputs.TryGetValue(kv.Key, out var value))
+            {
+                return $"{kv.Key} missing at bar {bar}";
+            }
+
+            if (!IsClose(kv.Value, value))
+            {
+                return $"{kv.Key} at bar {bar}: {value} vs {kv.Value}";
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/StreamingTests/StreamingPreviewTests.cs
+++ b/tests/StreamingTests/StreamingPreviewTests.cs
@@ -96,6 +96,11 @@ public sealed class StreamingPreviewTests : GlobalTestData
             return expected.Outputs is null == actual.Outputs is null ? null : $"outputs missing at bar {bar}";
         }
 
+        if (!new HashSet<string>(expected.Outputs.Keys, StringComparer.Ordinal).SetEquals(actual.Outputs.Keys))
+        {
+            return $"output keys differ at bar {bar}: [{string.Join(",", actual.Outputs.Keys)}] vs [{string.Join(",", expected.Outputs.Keys)}]";
+        }
+
         foreach (var kv in expected.Outputs)
         {
             if (!actual.Outputs.TryGetValue(kv.Key, out var value))

--- a/tests/StreamingTests/StreamingStatefulParityTests.cs
+++ b/tests/StreamingTests/StreamingStatefulParityTests.cs
@@ -157,8 +157,8 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
             yield return new object[]
             {
                 new StatefulIndicatorSpec("ChartmillValueIndicator.Cmvc",
-                    () => new ChartmillValueIndicatorState(MovingAvgType.SimpleMovingAverage, InputName.MedianPrice, 5),
-                    data => data.CalculateChartmillValueIndicator(MovingAvgType.SimpleMovingAverage, InputName.MedianPrice, 5)
+                    () => new ChartmillValueIndicatorState(MovingAvgType.SimpleMovingAverage, 5),
+                    data => data.CalculateChartmillValueIndicator(MovingAvgType.SimpleMovingAverage, 5)
                         .OutputValues["Cmvc"])
             };
             yield return new object[]
@@ -211,8 +211,8 @@ public sealed class StreamingStatefulParityTests : GlobalTestData
             yield return new object[]
             {
                 new StatefulIndicatorSpec("ChopZone",
-                    () => new ChopZoneState(MovingAvgType.ExponentialMovingAverage, InputName.TypicalPrice, 30, 34),
-                    data => data.CalculateChopZone(MovingAvgType.ExponentialMovingAverage, InputName.TypicalPrice, 30, 34)
+                    () => new ChopZoneState(MovingAvgType.ExponentialMovingAverage, 30, 34),
+                    data => data.CalculateChopZone(MovingAvgType.ExponentialMovingAverage, 30, 34)
                         .CustomValuesList)
             };
             yield return new object[]

--- a/tests/StreamingTests/UseInputTests.cs
+++ b/tests/StreamingTests/UseInputTests.cs
@@ -95,6 +95,27 @@ public sealed class UseInputTests : GlobalTestData
             "the control: if the input were dropped this is what the indicator would compute");
     }
 
+    /// <summary>
+    /// A chain computes the same with its series unpublished. Each calculation returns the same StockData, so the
+    /// next one reads what the last left behind; with IncludeCustomValues off that used to be an emptied list,
+    /// and the RSI ran on the close instead of the average.
+    /// </summary>
+    [Fact]
+    public void AChainComputesTheSameWhenCustomValuesAreNotPublished()
+    {
+        var tickers = Tickers();
+
+        var published = new StockData(tickers).CalculateSimpleMovingAverage(20).CalculateRelativeStrengthIndex();
+        var unpublished = new StockData(tickers) { Options = new IndicatorOptions { IncludeCustomValues = false } }
+            .CalculateSimpleMovingAverage(20).CalculateRelativeStrengthIndex();
+        var onClose = new StockData(tickers).CalculateRelativeStrengthIndex();
+
+        unpublished.OutputValues.Should().BeEquivalentTo(published.OutputValues);
+        unpublished.OutputValues.Should().NotBeEquivalentTo(onClose.OutputValues,
+            "the control: if the average were dropped this is what the RSI would compute");
+        unpublished.CustomValuesList.Should().BeEmpty("the option still hides the series from the caller");
+    }
+
     /// <summary>RoundingDigits rounds what an indicator publishes, never what it computes on.</summary>
     [Fact]
     public void TheInputIsNotRoundedByTheOutputRounding()

--- a/tests/StreamingTests/UseInputTests.cs
+++ b/tests/StreamingTests/UseInputTests.cs
@@ -1,0 +1,78 @@
+using OoplesFinance.StockIndicators.Streaming;
+
+namespace OoplesFinance.StockIndicators.Tests.Unit.StreamingTests;
+
+/// <summary>
+/// <c>StockData.UseInput</c>: the batch replacement for passing an input name, sharing its presets with
+/// streaming.
+/// </summary>
+public sealed class UseInputTests : GlobalTestData
+{
+    private const int Bars = 200;
+    private const double Tolerance = 1e-9;
+
+    private List<TickerData> Tickers() => StockTestData.Take(Bars).ToList();
+
+    [Fact]
+    public void APresetGivesExactlyWhatChainingTheIndicatorItNamesGives()
+    {
+        var tickers = Tickers();
+
+        var viaPreset = new StockData(tickers).UseInput(InputSeries.MedianPrice)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+        var viaChain = new StockData(tickers).CalculateMedianPrice()
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        viaPreset.Should().Equal(viaChain);
+    }
+
+    [Fact]
+    public void AWindowedPresetMatchesChainingItsIndicator()
+    {
+        var tickers = Tickers();
+
+        var viaPreset = new StockData(tickers).UseInput(InputSeries.Midpoint(14))
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+        var viaChain = new StockData(tickers).CalculateMidpoint(14)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        viaPreset.Should().HaveCount(viaChain.Count);
+        for (var i = 0; i < viaChain.Count; i++)
+        {
+            viaPreset[i].Should().BeApproximately(viaChain[i], Tolerance, $"bar {i}");
+        }
+    }
+
+    /// <summary>The point of sharing presets: one object, the same numbers in either engine.</summary>
+    [Fact]
+    public void BothEnginesAgreeOnTheSamePreset()
+    {
+        var tickers = Tickers();
+
+        var batch = new StockData(tickers).UseInput(InputSeries.TypicalPrice)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        var state = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.TypicalPrice);
+        var streamed = tickers.Select(t => state.Update(
+            new OhlcvBar("TEST", BarTimeframe.Tick, t.Date, t.Date, t.Open, t.High, t.Low, t.Close, t.Volume, isFinal: true),
+            isFinal: true, includeOutputs: false).Value).ToList();
+
+        streamed.Should().HaveCount(batch.Count);
+        for (var i = 0; i < batch.Count; i++)
+        {
+            streamed[i].Should().BeApproximately(batch[i], Tolerance, $"bar {i}");
+        }
+    }
+
+    [Fact]
+    public void AStatefulSeriesStartsFreshEachTimeItIsUsed()
+    {
+        var tickers = Tickers();
+        var midpoint = InputSeries.Midpoint(14);
+
+        var first = new StockData(tickers).UseInput(midpoint).CustomValuesList;
+        var second = new StockData(tickers).UseInput(midpoint).CustomValuesList;
+
+        second.Should().Equal(first, "UseInput resets the series, so reusing it does not continue the old window");
+    }
+}

--- a/tests/StreamingTests/UseInputTests.cs
+++ b/tests/StreamingTests/UseInputTests.cs
@@ -75,4 +75,36 @@ public sealed class UseInputTests : GlobalTestData
 
         second.Should().Equal(first, "UseInput resets the series, so reusing it does not continue the old window");
     }
+
+    /// <summary>
+    /// IncludeCustomValues decides whether an indicator's OUTPUT is published; it must not decide whether the
+    /// caller's input reaches the indicator. It used to: the series was cleared and the SMA ran on the close.
+    /// </summary>
+    [Fact]
+    public void TheInputIsUsedWhenCustomValuesAreNotPublished()
+    {
+        var tickers = Tickers();
+
+        var published = new StockData(tickers).UseInput(InputSeries.MedianPrice).CalculateSimpleMovingAverage(20);
+        var unpublished = new StockData(tickers) { Options = new IndicatorOptions { IncludeCustomValues = false } }
+            .UseInput(InputSeries.MedianPrice).CalculateSimpleMovingAverage(20);
+        var onClose = new StockData(tickers).CalculateSimpleMovingAverage(20);
+
+        unpublished.OutputValues.Should().BeEquivalentTo(published.OutputValues);
+        unpublished.OutputValues.Should().NotBeEquivalentTo(onClose.OutputValues,
+            "the control: if the input were dropped this is what the indicator would compute");
+    }
+
+    /// <summary>RoundingDigits rounds what an indicator publishes, never what it computes on.</summary>
+    [Fact]
+    public void TheInputIsNotRoundedByTheOutputRounding()
+    {
+        var tickers = Tickers();
+
+        var input = new StockData(tickers) { Options = new IndicatorOptions { RoundingDigits = 2 } }
+            .UseInput(InputSeries.Of(bar => bar.Close / 3)).CustomValuesList;
+
+        input.Should().Equal(tickers.Select(t => t.Close / 3));
+        input.Should().Contain(v => v != Math.Round(v, 2), "the control: a third of a price is not a whole cent");
+    }
 }


### PR DESCRIPTION
Every indicator now takes custom values, in both engines, and the two compute the same values bar by bar on a
custom series. Callers pass **values**, not a name for them (#182): `InputName` and the per-state selector
constructors are gone, replaced by one mechanism per engine and presets named after the input names they
replace.

```csharp
// batch - chaining; a chained series always wins
var rsi = stockData.UseInput(InputSeries.MedianPrice).CalculateRelativeStrengthIndex(length: 14);

// streaming - wrap any state
var rsi = new CustomInputState(new RelativeStrengthIndexState(14), InputSeries.MedianPrice);

// streaming chaining - another indicator's output as the input
var sma = new CustomInputState(new SimpleMovingAverageState(20), InputSeries.Of(new RelativeStrengthIndexState(14)));
```

## What was wrong

- **82 streaming states could not take custom values at all**, and 148 that could still read the bar's true
  high and low whatever series they were given.
- **28 batch methods ignored a chained series** because they read their own `inputName`, and so did every
  indicator built on one of them. **All 8 pivot points** ignored it too, rebuilding each period from
  `TickerDataList`, and **PercentageVolumeOscillator** read raw volume whatever was chained.
- **`StockData`'s input name was ignored by ~650 indicators** (#182), and two streaming options fed it.
- **High and low under a custom series were decided for the whole series at once**, which a streaming state
  cannot compute, so the engines could not agree on any series outside the bars' range.
- **`IncludeCustomValues = false` broke 179 indicators.** `SetCustomValues` emptied the one list that both the
  caller and the next calculation read: a chain ran on the close, 176 indicators threw reading an empty list from
  their own components, and three computed other values. Master has the same code.
- **`IncludeOutputValues = false` broke 56 more, and `RoundingDigits` leaked into 187.** Composites read their
  components' named series from the dictionary the option emptied, and both options rounded the one copy the
  next calculation read, so those indicators published the rounding of a different computation.
- **Four indicators took a component of another component** instead of the price - CCT StochRSI, the Fast and
  Slow RSI Oscillator, the Sector Rotation Model and Connors RSI - and their streaming states copied the chain.

## What changed

**Streaming - `CustomInputState`.** Wraps any state. Each bar the inner state sees the caller's value as the
close, and a high and low from the per-bar rule below; open and volume are the bar's own. A forming bar is
measured against the last final value and never replaces it. States whose own default input is not the close
implement `ICustomInputConsumer` so the wrapper can tell them to read the close.

**Presets - `IInputSeries` / `InputSeries`.** One per input name, each pinned to give exactly the value the name
selected. `Midpoint(n)` and `Midprice(n)` are windowed; `InputSeries.Of(selector)` takes any function of the bar,
`InputSeries.Of(state)` another indicator's output. The same preset objects work in batch through
`StockData.UseInput`.

**The per-bar rule (both engines).** A value inside the bar's range keeps the bar's true high and low; a value
outside it takes the max and min of the previous and current value. The close itself is exempt, so unchained
results do not move. The derived-series helpers (true range, HL2 and the rest) apply the same rule to a chained
close, so an ATR on a log-close no longer measures the gap between it and the price.

**Batch.** A chained series wins over a method's named input. Pivot points build each period from the adjusted
bars. PercentageVolumeOscillator lets a chained series replace volume.

**Composites hand every component the caller's series.** Each captures it on entry and restores it before each
later component, instead of clearing it mid-method - a clear dropped a caller's chain for every component after
the first. 18 methods moved from clearing to restoring (the Ehlers adaptive family, the decycler oscillators, KST,
Keltner Channels and others).

**`IncludeCustomValues` hides a result without changing any.** `StockData` keeps an internal chained series
beside the published list. The public setter keeps them one list, `SetCustomValues` hides only the published one,
and every read of an input or of a component's result goes through the chained series. With the option on
nothing changes, because the two are the same list.

**Every publication option changes only what is published.** The named series get the same treatment:
StockData keeps them unrounded in `ChainedOutputs`, and `CustomValuesList` and `OutputValues` are the published
copies, rounded or empty as `RoundingDigits`, `IncludeCustomValues` and `IncludeOutputValues` say, and replaced
rather than cleared in place. All 104 internal reads of a component's named series go through the chained copy.

**Components of the price.** CCT StochRSI, the Fast and Slow RSI Oscillator and the Sector Rotation Model take
every component of the caller's series, in both engines where streaming had copied the chain. Connors RSI ranks
the one-bar rate of change of the price over 100 bars, as Connors defines it.

**One order in the order statistic.** A NaN preview left a node in the order-statistic tree; every path now
compares with `double.CompareTo`.

**Streaming corrections the value comparison found.** Grover Llorens and the Ultimate Trader Oscillator took the
first bar's true range as the whole high. Adaptive Ehlers windows turned a dominant cycle that is an integer in
exact arithmetic into a window a bar longer when rounding put it an ulp above; `MathHelper.CeilingCycle` takes a
cycle within a relative 1e-9 of an integer as that integer, in both engines.

**Previews.** Nine states published a preview that differed from the same bar once final (ALMA, IQR bands,
Trimean, Alligator, Gator, FRAMA, and Connors RSI with the two indicators built on it), and the periodogram
behind the adaptive Ehlers family normalised the previous bar's powers by the forming bar's maximum.

**Generator.** The factory generator read any member access in a state's `Name` as its `IndicatorName`; it now
accepts only `IndicatorName.X`.

## Breaking changes

- **684 public per-state selector constructors removed.** Five stay, internal, because the library composes those
  states on a derived series itself.
- **`InputName` removed** from 682 streaming constructors, 28 `Calculate*` methods, `StockData` and `IStockData`,
  `StreamingOptions`, `IndicatorSubscriptionOptions` and `VolumeFlowIndicatorSpecOptions`.
- **The `InputName` enum, `StreamingInputSelector` and `GetInputValuesList(InputName, StockData)` are internal.**
- **`Clear()` replaces the series** instead of emptying the list in place, and a null `CustomValuesList` reads
  back as empty.
- **Results change in the direction of correctness** wherever an input name used to be silently ignored, and
  in the corrections above.

`MIGRATION.md` has before/after for each, the preset for each input name, and every corrected value.

## The tests

- `StreamingCustomInputTests` pairs every public streaming state with its batch twin and compares **every output
  series on every bar** - on the close and on two custom series, median price (inside every bar's range) and the
  log of the close (outside it, and non-linear). A state that cannot be built for the wrapper or has no batch twin
  is a named failure, not a skip. An earlier version only checked that both engines moved when the input changed,
  which a pair computing different numbers passed. **0 disagreements on either series.**
- `StreamingPreviewTests` previews every bar of every state and then commits it: the preview must equal the
  commit, and the committed series must equal a run that never previewed. **0 failures.**
- `IncludeCustomValuesTests` runs every batch indicator with the option on and off: nothing throws and every
  output series is the same. **0 failures** (6 multi-series indicators cannot run on their defaults at all and
  are named, not compared).
- `IncludeOutputValuesTests` and `RoundingDigitsTests` hold the other two publication options the same way.
  Rounding needs no tolerance: rounding once, after the same computation, is exact. **0 failures** each.
- `RollingOrderStatisticTests` previews NaN, both infinities and a plain value on the tree path and compares every
  later percentile with a twin that never previewed.
- `CeilingCycleTests` pins the cycle ceiling at and around an integer.

Full suite **6080 passed, 0 failed, 24 skipped**. The library builds on every target framework.

BREAKING CHANGE: the per-state Func<OhlcvBar, double> constructors and every InputName parameter, property and option
are removed from the public API; the InputName enum, StreamingInputSelector and GetInputValuesList(InputName, StockData)
are internal. Use CustomInputState (streaming) or StockData.UseInput (batch) with an InputSeries preset. Clear() now
replaces the custom series instead of emptying it in place. See MIGRATION.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5
