### PR TITLE
fix: make stockdata honour the input name it is built with

### DIFF
--- a/src/Models/StockData.cs
+++ b/src/Models/StockData.cs
@@ -14,6 +14,8 @@ namespace OoplesFinance.StockIndicators.Models;
 public class StockData : IStockData
 {
     private List<double>? _inputValues;
+    private bool _inputValuesAssigned;
+    private InputName _inputName;
     private List<double>? _openPrices;
     private List<double>? _highPrices;
     private List<double>? _lowPrices;
@@ -24,7 +26,37 @@ public class StockData : IStockData
     private bool _columnsInitialized;
     private bool _rowsInitialized;
 
-    public InputName InputName { get; set; }
+    /// <summary>
+    /// The price series calculations read when nothing has been chained in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Honoured through <see cref="InputValues"/>, which is what the single-argument
+    /// <c>GetInputValuesList(stockData)</c> reads - the path about 650 indicators take. It used to be
+    /// stored and never consulted there: <c>new StockData(tickers, InputName.MedianPrice)</c> gave
+    /// close-based results from every one of them, silently (#182).
+    /// </para>
+    /// <para>
+    /// A chained series still wins. <c>CustomValuesList</c> is checked before <c>InputValues</c>, so
+    /// this only decides what an indicator reads when it is the first in a chain.
+    /// </para>
+    /// </remarks>
+    public InputName InputName
+    {
+        get => _inputName;
+        set
+        {
+            if (_inputName != value && !_inputValuesAssigned)
+            {
+                // The cached series was built from the previous name. An explicitly assigned
+                // InputValues is the caller's own series and is left alone.
+                _inputValues = null;
+            }
+
+            _inputName = value;
+        }
+    }
+
     public IndicatorName IndicatorName { get; set; }
 
     public List<double> InputValues
@@ -33,12 +65,37 @@ public class StockData : IStockData
         {
             if (_inputValues == null)
             {
-                _inputValues = new List<double>(ClosePrices);
+                _inputValues = InputName == InputName.Close
+                    ? new List<double>(ClosePrices)
+                    : BuildInputValues(InputName);
             }
 
             return _inputValues;
         }
-        set => _inputValues = value ?? new List<double>();
+        set
+        {
+            _inputValues = value ?? new List<double>();
+            _inputValuesAssigned = true;
+        }
+    }
+
+    /// <summary>
+    /// Builds the series an <see cref="Enums.InputName"/> names, with the same mapping the indicators
+    /// that take their own <c>inputName</c> parameter already use.
+    /// </summary>
+    /// <remarks>
+    /// Built over a separate <see cref="StockData"/> on the same prices. Two of the names -
+    /// <see cref="InputName.Midpoint"/> and <see cref="InputName.Midprice"/> - are indicators
+    /// themselves, and running one here would publish its results onto this object from inside a
+    /// property getter. The copy starts on Close, so building it cannot come back here.
+    /// </remarks>
+    private List<double> BuildInputValues(InputName inputName)
+    {
+        var source = new StockData(OpenPrices, HighPrices, LowPrices, ClosePrices, Volumes, Dates);
+        var (inputList, _, _, _, _, _) =
+            OoplesFinance.StockIndicators.Helpers.CalculationsHelper.GetInputValuesList(inputName, source);
+
+        return new List<double>(inputList);
     }
 
     public List<double> OpenPrices

--- a/tests/ModelsTests/StockDataInputNameTests.cs
+++ b/tests/ModelsTests/StockDataInputNameTests.cs
@@ -1,0 +1,114 @@
+namespace OoplesFinance.StockIndicators.Tests.Unit.ModelsTests;
+
+/// <summary>
+/// The <see cref="InputName"/> a <see cref="StockData"/> is built with is the series its indicators
+/// read (#182).
+/// </summary>
+/// <remarks>
+/// Each test compares against the path that has always worked - handing the same series in through
+/// <see cref="StockData.InputValues"/>, which the single-argument <c>GetInputValuesList</c> reads -
+/// rather than against a hand-rolled calculation, so they pin where the series comes from and nothing
+/// about how any one indicator computes.
+/// </remarks>
+public sealed class StockDataInputNameTests : GlobalTestData
+{
+    private const int Bars = 200;
+
+    private List<TickerData> Tickers() => StockTestData.Take(Bars).ToList();
+
+    private static List<double> Median(IEnumerable<TickerData> tickers) =>
+        tickers.Select(t => (t.High + t.Low) / 2).ToList();
+
+    private static List<double> Typical(IEnumerable<TickerData> tickers) =>
+        tickers.Select(t => (t.High + t.Low + t.Close) / 3).ToList();
+
+    [Fact]
+    public void TheInputNameGivenToTheConstructorIsTheSeriesIndicatorsRead()
+    {
+        var tickers = Tickers();
+
+        var viaInputName = new StockData(tickers, InputName.MedianPrice)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+        var reference = new StockData(tickers) { InputValues = Median(tickers) }
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+        var onClose = new StockData(tickers).CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        viaInputName.Should().Equal(reference);
+        viaInputName.Should().NotEqual(onClose,
+            "median price and close are different series, so the result must not be the close-based one");
+    }
+
+    [Fact]
+    public void TheColumnConstructorHonoursItToo()
+    {
+        var tickers = Tickers();
+        var data = new StockData(
+            tickers.Select(t => t.Open), tickers.Select(t => t.High), tickers.Select(t => t.Low),
+            tickers.Select(t => t.Close), tickers.Select(t => t.Volume), tickers.Select(t => t.Date),
+            InputName.TypicalPrice);
+
+        var viaInputName = data.CalculateSimpleMovingAverage(20).CustomValuesList;
+        var reference = new StockData(tickers) { InputValues = Typical(tickers) }
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        viaInputName.Should().Equal(reference);
+    }
+
+    [Fact]
+    public void AChainedSeriesStillWinsAfterTheFirstLink()
+    {
+        var tickers = Tickers();
+
+        var chained = new StockData(tickers, InputName.MedianPrice)
+            .CalculateExponentialMovingAverage(10)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+        var reference = new StockData(tickers) { InputValues = Median(tickers) }
+            .CalculateExponentialMovingAverage(10)
+            .CalculateSimpleMovingAverage(20).CustomValuesList;
+
+        chained.Should().Equal(reference,
+            "InputName decides what the first indicator reads; the second reads the first one's output");
+    }
+
+    [Fact]
+    public void ChangingTheInputNameAfterConstructionRebuildsTheSeries()
+    {
+        var tickers = Tickers();
+        var data = new StockData(tickers);
+
+        data.InputValues.Should().Equal(data.ClosePrices);
+
+        data.InputName = InputName.MedianPrice;
+
+        data.InputValues.Should().Equal(Median(tickers),
+            "the cached close series was built from the previous name and must not outlive it");
+    }
+
+    [Fact]
+    public void AnExplicitlyAssignedSeriesSurvivesAnInputNameChange()
+    {
+        var tickers = Tickers();
+        var mine = Enumerable.Range(0, tickers.Count).Select(i => (double)i).ToList();
+        var data = new StockData(tickers) { InputValues = mine };
+
+        data.InputName = InputName.High;
+
+        data.InputValues.Should().Equal(mine, "the caller's own series is not the InputName's to replace");
+    }
+
+    [Theory]
+    [InlineData(InputName.Midpoint)]
+    [InlineData(InputName.Midprice)]
+    public void BuildingAnIndicatorBackedSeriesDoesNotWriteOntoTheObject(InputName inputName)
+    {
+        var tickers = Tickers();
+        var data = new StockData(tickers, inputName);
+        var indicatorBefore = data.IndicatorName;
+
+        data.InputValues.Should().HaveCount(tickers.Count);
+
+        data.CustomValuesList.Should().BeEmpty("reading a property must not chain an indicator onto the data");
+        data.OutputValues.Should().BeEmpty();
+        data.IndicatorName.Should().Be(indicatorBefore);
+    }
+}


### PR DESCRIPTION
Closes #182 (batch side). You chose option 1 there: fix `StockData`, keep streaming as it is.

## The defect

```csharp
var data = new StockData(tickers, InputName.MedianPrice);
var sma  = data.CalculateSimpleMovingAverage(20);   // was: an SMA of the CLOSE, silently
```

`StockData` stored the `InputName` and ~650 indicators never read it. They call the single-argument
`GetInputValuesList(stockData)`, which reads `InputValues`, and `InputValues` was always a copy of the
close.

## The fix

`InputValues` is built from `InputName` on first read, reusing the mapping the 24 indicators that take
their own `inputName` parameter already use, so there is one mapping, not two. The 650 sites pick it
up through the path they already read; none of them changes.

- **A chained series still wins.** `CustomValuesList` is checked before `InputValues`, so `InputName`
  only decides what the *first* indicator in a chain reads.
- **Changing `InputName` later rebuilds the series**, unless the caller assigned `InputValues`
  themselves, which is left alone.
- **No side effects from a getter.** `Midpoint` and `Midprice` are indicators, and running one would
  publish its results onto this object. The series is built over a separate `StockData` on the same
  prices instead.
- **`Close` costs nothing extra.** That's the default, and it keeps the old path: a copy of the close.

## Behaviour change

Anyone constructing `StockData` with a non-Close `InputName` now gets results on that series instead of
the close. No code in `src/` and no existing test does that, which is itself how the defect survived.

## Tests

`StockDataInputNameTests` compares each case against the path that has always worked, handing the
same series in through `InputValues`, so it pins where the series comes from, not how any indicator
computes.

Control arm, with the fix reverted: the 4 behaviour tests **fail** (constructor, column constructor,
chaining, rebuild-on-change) and the 3 guard tests pass (explicit assignment survives, Midpoint/Midprice
don't write onto the object), which is what guards are for. Full suite: **2161 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vmi2eqPuCXgNVYa9NBcM5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock-based indicators now use the selected input series instead of always using closing prices.
  * Changing the selected input series refreshes calculated values correctly.
  * Explicitly assigned input values are preserved when the selected series changes.
  * Reading stock data properties no longer unintentionally applies additional indicator calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->